### PR TITLE
fix(form): Cross field validation returning the property field as a s…

### DIFF
--- a/packages/ts/form/test/TestModels.ts
+++ b/packages/ts/form/test/TestModels.ts
@@ -47,7 +47,7 @@ export class ProductModel<T extends Product = Product> extends IdEntityModel<T> 
   }
 }
 
-interface Customer extends IdEntity {
+export interface Customer extends IdEntity {
   fullName: string;
   nickName: string;
 }


### PR DESCRIPTION
...tring

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # https://github.com/vaadin/flow/issues/9460

## Type of change

- [X] Bugfix - I think
- [ ] Feature

## Checklist

Note that I have not done everything in the list yet. I'd like a quick discussion before on the idea of this PR.

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

All the examples and tests for cross field validation return a model in the `property` field.

For example see the existing test:

```ts
      const recordValidator = {
        validate(value: Order) {
          if (value.customer.fullName === value.customer.nickName) {
            // here we return a model   
            return { property: binder.model.customer.nickName };
          }

          return true;
        },
        message: 'cannot be the same',
      };
```

However to do this you need to capture the binder which is not always practical.

In my use case I have several entities in the form that need the same cross field validation. I have created a class for my validator:

```ts
export class MyValidator implements Validator<MyValue> {
  async validate(value: MyValue) {
    if (...) {
      this.message = `...`;
      // Where `account` is a property of MyValue      
      return { property: 'account' };
    }

    return true;
  }
}
```

I think returning `account` is the best thing to do as there is no way to know the parent name without the binder/model being captured.

I would like to know what you think about this.
If you agree with the idea could you please also take a quick look at the implementation ?

Tests missing from this PR (if we agree on the idea):
- returning a string property a top level,
- returning an array of `ValidationResult`.

Thanks !


