### PR TITLE
fix: handle spring csrf as string undefined in meta tags

### DIFF
--- a/packages/ts/fusion-frontend/src/CsrfUtils.ts
+++ b/packages/ts/fusion-frontend/src/CsrfUtils.ts
@@ -7,10 +7,10 @@ export const VAADIN_CSRF_COOKIE_NAME = 'csrfToken';
 /** @internal */
 export const SPRING_CSRF_COOKIE_NAME = 'XSRF-TOKEN';
 
-function extractContentFromMetaTag(element: Element | null): string | undefined {
+function extractContentFromMetaTag(element: HTMLMetaElement | null): string | undefined {
   if (element) {
-    const value = (element as HTMLMetaElement).content;
-    if (value && value.toLocaleLowerCase() !== 'undefined') {
+    const value = element.content;
+    if (value && value.toLowerCase() !== 'undefined') {
       return value;
     }
   }
@@ -19,7 +19,7 @@ function extractContentFromMetaTag(element: Element | null): string | undefined 
 
 /** @internal */
 function getSpringCsrfHeaderFromMetaTag(doc: Document): string | undefined {
-  const csrfHeader = doc.head.querySelector('meta[name="_csrf_header"]');
+  const csrfHeader = doc.head.querySelector<HTMLMetaElement>('meta[name="_csrf_header"]');
   return extractContentFromMetaTag(csrfHeader);
 }
 

--- a/packages/ts/fusion-frontend/src/CsrfUtils.ts
+++ b/packages/ts/fusion-frontend/src/CsrfUtils.ts
@@ -25,7 +25,7 @@ function getSpringCsrfHeaderFromMetaTag(doc: Document): string | undefined {
 
 /** @internal */
 function getSpringCsrfTokenFromMetaTag(doc: Document): string | undefined {
-  const csrfToken = doc.head.querySelector('meta[name="_csrf"]');
+  const csrfToken = doc.head.querySelector<HTMLMetaElement>('meta[name="_csrf"]');
   return extractContentFromMetaTag(csrfToken);
 }
 

--- a/packages/ts/fusion-frontend/src/CsrfUtils.ts
+++ b/packages/ts/fusion-frontend/src/CsrfUtils.ts
@@ -7,27 +7,37 @@ export const VAADIN_CSRF_COOKIE_NAME = 'csrfToken';
 /** @internal */
 export const SPRING_CSRF_COOKIE_NAME = 'XSRF-TOKEN';
 
-/** @internal */
-function getSpringCsrfHeaderFromMetaTag(doc: Document): string {
-  const csrfHeader = doc.head.querySelector('meta[name="_csrf_header"]');
-  return (csrfHeader && (csrfHeader as HTMLMetaElement).content) || '';
+function extractContentFromMetaTag(element: Element | null): string | undefined {
+  if (element) {
+    const value = (element as HTMLMetaElement).content;
+    if (value && value.toLocaleLowerCase() !== 'undefined') {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 /** @internal */
-function getSpringCsrfTokenFromMetaTag(doc: Document): string {
+function getSpringCsrfHeaderFromMetaTag(doc: Document): string | undefined {
+  const csrfHeader = doc.head.querySelector('meta[name="_csrf_header"]');
+  return extractContentFromMetaTag(csrfHeader);
+}
+
+/** @internal */
+function getSpringCsrfTokenFromMetaTag(doc: Document): string | undefined {
   const csrfToken = doc.head.querySelector('meta[name="_csrf"]');
-  return (csrfToken && (csrfToken as HTMLMetaElement).content) || '';
+  return extractContentFromMetaTag(csrfToken);
 }
 
 /** @internal */
 export function getSpringCsrfInfo(doc: Document): Record<string, string> {
   const csrfHeader = getSpringCsrfHeaderFromMetaTag(doc);
-  let csrf = getCookie(SPRING_CSRF_COOKIE_NAME) || '';
-  if (csrf.length === 0) {
+  let csrf = getCookie(SPRING_CSRF_COOKIE_NAME);
+  if (!csrf || csrf.length === 0) {
     csrf = getSpringCsrfTokenFromMetaTag(doc);
   }
   const headers: Record<string, string> = {};
-  if (csrf.length > 0 && csrfHeader.length > 0) {
+  if (csrf && csrfHeader) {
     headers._csrf = csrf;
     headers._csrf_header = csrfHeader;
   }

--- a/packages/ts/fusion-frontend/test/Connect.test.ts
+++ b/packages/ts/fusion-frontend/test/Connect.test.ts
@@ -284,6 +284,25 @@ describe('ConnectClient', () => {
       }
     });
 
+    it('should set header for preventing CSRF using Fusion csrf when having Spring csrf meta tags with string undefined', async () => {
+      try {
+        // happens when spring csrf is disabled
+        // https://github.com/vaadin/hilla/issues/185
+        setupSpringCsrfMetaTags('undefined', 'undefined');
+
+        const csrfToken = 'foo';
+        setCookie('csrfToken', csrfToken);
+
+        await client.call('FooEndpoint', 'fooMethod');
+
+        expect(fetchMock.lastOptions()?.headers).to.deep.include({
+          [VAADIN_CSRF_HEADER.toLowerCase()]: csrfToken,
+        });
+      } finally {
+        clearSpringCsrfMetaTags();
+      }
+    });
+
     it('should resolve to response JSON data', async () => {
       const data = await client.call('FooEndpoint', 'fooMethod');
       expect(data).to.deep.equal({ fooData: 'foo' });

--- a/packages/ts/fusion-frontend/test/SpringCsrfTestUtils.test.ts
+++ b/packages/ts/fusion-frontend/test/SpringCsrfTestUtils.test.ts
@@ -4,13 +4,18 @@ export const TEST_SPRING_CSRF_HEADER_NAME = 'x-xsrf-token';
 export const TEST_SPRING_CSRF_TOKEN_VALUE = 'spring-csrf-token';
 export const TEST_VAADIN_CSRF_TOKEN_VALUE = 'vaadin-csrf-token';
 
-export function setupSpringCsrfMetaTags(csrfToken = TEST_SPRING_CSRF_TOKEN_VALUE) {
+const TEST_SPRING_CSRF_META_TAG_NAME = '_csrf';
+
+export function setupSpringCsrfMetaTags(
+  csrfToken = TEST_SPRING_CSRF_TOKEN_VALUE,
+  csrfMetaTagName = TEST_SPRING_CSRF_META_TAG_NAME,
+) {
   let csrfMetaTag = document.head.querySelector('meta[name="_csrf"]') as HTMLMetaElement | null;
   let csrfHeaderNameMetaTag = document.head.querySelector('meta[name="_csrf_header"]') as HTMLMetaElement | null;
 
   if (!csrfMetaTag) {
     csrfMetaTag = document.createElement('meta');
-    csrfMetaTag.name = '_csrf';
+    csrfMetaTag.name = csrfMetaTagName;
     document.head.appendChild(csrfMetaTag);
   }
   csrfMetaTag.content = csrfToken;


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

When Spring CSRF is disabled, it brings meta tags with string undefined (`'undefined'`) to the index.html page which results in CSRF check malfuction

Fixes #185

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
