### PR TITLE
refactor: rename hilla-maven-plugin to generator-maven-plugin

### DIFF
--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>generagtor-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Maevn Plugin for Code Generation</name>
+  <name>Maven Plugin for Code Generation</name>
 
   <properties>
     <maven.version>3.8.1</maven.version>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -10,7 +10,7 @@
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>generagtor-maven-plugin</artifactId>
+  <artifactId>generator-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>Maven Plugin for Code Generation</name>
 

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -10,9 +10,9 @@
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>hilla-maven-plugin</artifactId>
+  <artifactId>endpoint-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Maevn Plugin for Hilla</name>
+  <name>Maevn Plugin for Hilla Endpoint</name>
 
   <properties>
     <maven.version>3.8.1</maven.version>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -10,9 +10,9 @@
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>endpoint-maven-plugin</artifactId>
+  <artifactId>generagtor-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Maevn Plugin for Hilla Endpoint</name>
+  <name>Maevn Plugin for Code Generation</name>
 
   <properties>
     <maven.version>3.8.1</maven.version>


### PR DESCRIPTION
renaming so that it doesn't conflict with the [hilla-maven-plugin](https://github.com/vaadin/platform/tree/master/hilla-maven-plugin) in the platform repo