### PR TITLE
chore: add ts release script to fix the lerna peer dependencies issue

### DIFF
--- a/packages/ts/generator-typescript-cli/package.json
+++ b/packages/ts/generator-typescript-cli/package.json
@@ -42,7 +42,7 @@
     "tsgen": "bin/index.js"
   },
   "peerDependencies": {
-    "@hilla/generator-typescript-core": "^0.0.18"
+    "@hilla/generator-typescript-core": "^0.0.19"
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "^0.0.19",

--- a/packages/ts/generator-typescript-plugin-backbone/package.json
+++ b/packages/ts/generator-typescript-plugin-backbone/package.json
@@ -49,8 +49,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@hilla/generator-typescript-core": "^0.0.18",
-    "@hilla/generator-typescript-plugin-client": "^0.0.18"
+    "@hilla/generator-typescript-core": "^0.0.19",
+    "@hilla/generator-typescript-plugin-client": "^0.0.19"
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "^0.0.19",

--- a/packages/ts/generator-typescript-plugin-barrel/package.json
+++ b/packages/ts/generator-typescript-plugin-barrel/package.json
@@ -49,8 +49,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@hilla/generator-typescript-core": "^0.0.18",
-    "@hilla/generator-typescript-plugin-backbone": "^0.0.18"
+    "@hilla/generator-typescript-core": "^0.0.19",
+    "@hilla/generator-typescript-plugin-backbone": "^0.0.19"
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "^0.0.19",

--- a/packages/ts/generator-typescript-plugin-client/package.json
+++ b/packages/ts/generator-typescript-plugin-client/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@hilla/generator-typescript-core": "^0.0.18"
+    "@hilla/generator-typescript-core": "^0.0.19"
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "^0.0.19",

--- a/packages/ts/generator-typescript-plugin-model/package.json
+++ b/packages/ts/generator-typescript-plugin-model/package.json
@@ -49,9 +49,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@hilla/form": "^0.0.18",
-    "@hilla/generator-typescript-core": "^0.0.18",
-    "@hilla/generator-typescript-plugin-backbone": "^0.0.18"
+    "@hilla/form": "^0.0.19",
+    "@hilla/generator-typescript-core": "^0.0.19",
+    "@hilla/generator-typescript-plugin-backbone": "^0.0.19"
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "^0.0.19",

--- a/scripts/bump/exec.sh
+++ b/scripts/bump/exec.sh
@@ -18,6 +18,8 @@ find "$packages_dir"/*/src/index.ts -exec sed -i "s/version:.\+\$/version: \/* u
 
 npx lerna version "$VERSION_TAG" --no-git-tag-version --no-push --yes
 
+find "$packages_dir"/*/package.json -exec node "$bump_scripts_dir"/package-update.js -v "$VERSION_TAG" {} +
+
 git add --all
 
 git \

--- a/scripts/bump/package-update.js
+++ b/scripts/bump/package-update.js
@@ -1,0 +1,43 @@
+/* eslint-disable import/no-extraneous-dependencies,camelcase,no-console */
+import meow from 'meow';
+import { readFile, writeFile } from 'fs/promises';
+
+const {
+  input: packageFileNames,
+  flags: { version },
+} = meow({
+  importMeta: import.meta,
+  flags: {
+    version: {
+      type: 'string',
+      alias: 'v',
+    },
+  },
+});
+
+const errors = new Map();
+
+await Promise.all(
+  packageFileNames.map(async (packageFileName) => {
+    try {
+      const packageJson = JSON.parse(await readFile(packageFileName, 'utf8'));
+      const { peerDependencies } = packageJson;
+
+      if (peerDependencies) {
+        for (const dependency of Object.keys(peerDependencies)) {
+          if (dependency.startsWith('@hilla')) {
+            peerDependencies[dependency] = `^${version}`;
+          }
+        }
+
+        await writeFile(packageFileName, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8');
+      }
+    } catch (e) {
+      errors.set(packageFileName, e);
+    }
+  }),
+);
+
+for (const [file, error] of errors) {
+  console.error(`Error in ${file}:\n`, error);
+}


### PR DESCRIPTION
Fixes the issue of Lerna when it cannot update the version of the monorepo package mentioned in `peerDependencies` instead of `dependencies`: lerna/lerna#1575