### PR TITLE
fix: add plugin comparator to the treeset

### DIFF
--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/ParserProcessor.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/ParserProcessor.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -20,6 +21,7 @@ import dev.hilla.parser.utils.OpenAPIPrinter;
 
 import dev.hilla.parser.core.Parser;
 import dev.hilla.parser.core.ParserConfig;
+import dev.hilla.parser.core.Plugin;
 import dev.hilla.parser.core.PluginManager;
 
 final class ParserProcessor {
@@ -131,7 +133,8 @@ final class ParserProcessor {
         var loadedPlugins = pluginsProcessor.process().stream()
                 .map((plugin) -> PluginManager.load(plugin.getName(),
                         plugin.getOrder(), plugin.getConfiguration()))
-                .collect(Collectors.toCollection(TreeSet::new));
+                .collect(Collectors.toCollection(() -> new TreeSet<>(
+                        Comparator.comparingInt(Plugin::getOrder))));
 
         builder.plugins(loadedPlugins);
     }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Plugin.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Plugin.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 
 import javax.annotation.Nonnull;
 
-public interface Plugin {
+public interface Plugin extends Comparable<Plugin> {
     void execute(@Nonnull Collection<RelativeClassInfo> endpoints,
             @Nonnull Collection<RelativeClassInfo> entities,
             @Nonnull SharedStorage storage);
@@ -19,5 +19,10 @@ public interface Plugin {
                     "The '%s' plugin does not expect configuration set",
                     getClass().getName()));
         }
+    }
+
+    @Override
+    default int compareTo(Plugin another) {
+        return Integer.compare(getOrder(), another.getOrder());
     }
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Plugin.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Plugin.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 
 import javax.annotation.Nonnull;
 
-public interface Plugin extends Comparable<Plugin> {
+public interface Plugin {
     void execute(@Nonnull Collection<RelativeClassInfo> endpoints,
             @Nonnull Collection<RelativeClassInfo> entities,
             @Nonnull SharedStorage storage);
@@ -19,10 +19,5 @@ public interface Plugin extends Comparable<Plugin> {
                     "The '%s' plugin does not expect configuration set",
                     getClass().getName()));
         }
-    }
-
-    @Override
-    default int compareTo(Plugin another) {
-        return Integer.compare(getOrder(), another.getOrder());
     }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Fixes the error below when running the generator plugin

```
[ERROR] Failed to execute goal dev.hilla:generator-maven-plugin:1.0-SNAPSHOT:generate (default-cli) on project pure-hilla: A type incompatibility occurred while executing dev.hilla:generator-maven-plugin:1.0-SNAPSHOT:generate: class dev.hilla.parser.plugins.nonnull.NonnullPlugin cannot be cast to class java.lang.Comparable (dev.hilla.parser.plugins.nonnull.NonnullPlugin is in unnamed module of loader org.codehaus.plexus.classworlds.realm.ClassRealm @4e73b552; java.lang.Comparable is in module java.base of loader 'bootstrap')
```
Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
