### PR TITLE
fix: boolean model converts "true" and "false" to their boolean equivalents

### DIFF
--- a/packages/ts/form/src/Models.ts
+++ b/packages/ts/form/src/Models.ts
@@ -94,7 +94,11 @@ export abstract class PrimitiveModel<T> extends AbstractModel<T> {}
 export class BooleanModel extends PrimitiveModel<boolean> implements HasFromString<boolean> {
   public static override createEmptyValue = Boolean;
 
-  public [_fromString] = Boolean;
+  public [_fromString](str: string): boolean {
+    // This implementation matches the values accepted by validator.js and converts all other values to false
+    // See https://github.com/validatorjs/validator.js/blob/master/src/lib/isBoolean.js
+    return ['true', '1', 'yes'].includes(str.toLowerCase());
+  }
 }
 
 export class NumberModel extends PrimitiveModel<number> implements HasFromString<number | undefined> {

--- a/packages/ts/form/test/Model.test.ts
+++ b/packages/ts/form/test/Model.test.ts
@@ -100,6 +100,35 @@ describe('form/Model', () => {
     });
   });
 
+  describe('boolean model', () => {
+    describe('_fromString', () => {
+      let fromString: (str: string) => boolean;
+
+      beforeEach(() => {
+        fromString = binder.model.fieldBoolean[_fromString];
+      });
+
+      it('should do semantic conversion from string to boolean model', async () => {
+        // The validator.js library is used as a reference of valid boolean values
+        // see https://github.com/validatorjs/validator.js/blob/master/src/lib/isBoolean.js
+        expect(fromString('true')).to.be.true;
+        expect(fromString('false')).to.be.false;
+        expect(fromString('1')).to.be.true;
+        expect(fromString('0')).to.be.false;
+        // loose values are also converted and case doesn't matter (again, see validator)
+        expect(fromString('yes')).to.be.true;
+        expect(fromString('no')).to.be.false;
+        expect(fromString('TRUE')).to.be.true;
+        expect(fromString('FALSE')).to.be.false;
+        expect(fromString('Yes')).to.be.true;
+        expect(fromString('No')).to.be.false;
+        // all other values are treated as false
+        expect(fromString('')).to.be.false;
+        expect(fromString('other')).to.be.false;
+      });
+    });
+  });
+
   describe('array model', () => {
     const strings = ['foo', 'bar'];
 

--- a/scripts/node/esbuild.js
+++ b/scripts/node/esbuild.js
@@ -20,7 +20,7 @@ export async function resolve(specifier, context, defaultResolve) {
       );
     }
 
-    const { url } = defaultResolve(`${specifier.substring(0, specifier.length - 3)}.ts`, context, defaultResolve);
+    const { url } = await defaultResolve(`${specifier.substring(0, specifier.length - 3)}.ts`, context, defaultResolve);
 
     return {
       format: 'module',


### PR DESCRIPTION
## Description

The default string to boolean conversion is not suitable, since all strings (including "false") are converted to true. This patch follows the convention used by [validator.js](https://github.com/validatorjs/validator.js/blob/master/src/lib/isBoolean.js) to avoid inconsistencies.

Fixes #177

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
