### PR TITLE
feat: Allow binding a subscription to a context

### DIFF
--- a/packages/ts/hilla-frontend/src/Connect.ts
+++ b/packages/ts/hilla-frontend/src/Connect.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import { ConnectionIndicator, ConnectionState } from '@vaadin/common-frontend';
+import type { ReactiveElement } from 'lit';
 import { getCsrfTokenHeadersForEndpointRequest } from './CsrfUtils.js';
 import { FluxConnection } from './FluxConnection.js';
 
@@ -99,6 +100,10 @@ export interface Subscription<T> {
   onError: (callback: () => void) => Subscription<T>;
   /** Called when the subscription has completed. No values are made available after calling this. */
   onComplete: (callback: () => void) => Subscription<T>;
+  /*
+   * Binds to the given context (element) so that when the context is deactivated (element detached), the subscription is closed.
+   */
+  context: (context: ReactiveElement) => Subscription<T>;
 }
 
 interface ConnectExceptionData {

--- a/packages/ts/hilla-frontend/src/FluxConnection.ts
+++ b/packages/ts/hilla-frontend/src/FluxConnection.ts
@@ -1,4 +1,5 @@
 import type { DefaultEventsMap } from '@socket.io/component-emitter';
+import type { ReactiveElement } from 'lit';
 import { io, Socket } from 'socket.io-client';
 import type { Subscription } from './Connect';
 import { getCsrfTokenHeadersForEndpointRequest } from './CsrfUtils';
@@ -95,9 +96,22 @@ export class FluxConnection {
         return hillaSubscription;
       },
       cancel: () => {
+        if (!this.endpointInfos.has(id)) {
+          // Subscription already closed or canceled
+          return;
+        }
+
         const closeMessage: ServerCloseMessage = { '@type': 'unsubscribe', id };
         this.send(closeMessage);
         this.removeSubscription(id);
+      },
+      context: (context: ReactiveElement): Subscription<any> => {
+        context.addController({
+          hostDisconnected: () => {
+            hillaSubscription.cancel();
+          },
+        });
+        return hillaSubscription;
       },
     };
     return hillaSubscription;

--- a/packages/ts/hilla-frontend/test/FluxConnection.test.ts
+++ b/packages/ts/hilla-frontend/test/FluxConnection.test.ts
@@ -87,7 +87,7 @@ describe('FluxConnection', () => {
     fluxConnectionAny.handleMessage(msg);
     expect(errorCalled).to.eq(1);
   });
-  it('should call not deliver messages after completing', () => {
+  it('should not deliver messages after completing', () => {
     const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
     let onNextCalled = 0;
     sub.onNext((_value) => {
@@ -116,7 +116,7 @@ describe('FluxConnection', () => {
       id: '0',
     });
   });
-  it('should call not deliver messages after canceling', () => {
+  it('should not deliver messages after canceling', () => {
     const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
     let onNextCalled = 0;
     sub.onNext((_value) => {
@@ -165,7 +165,6 @@ describe('FluxConnection', () => {
     sub.onNext((_value) => {
       // Just need a callback
     });
-    sub.cancel();
 
     const completeMsg: ClientCompleteMessage = { '@type': 'complete', id: '0' };
     fluxConnectionAny.handleMessage(completeMsg);
@@ -174,7 +173,6 @@ describe('FluxConnection', () => {
     expect(fluxConnectionAny.onNextCallbacks.size).to.equal(0);
     expect(fluxConnectionAny.onCompleteCallbacks.size).to.equal(0);
     expect(fluxConnectionAny.onErrorCallbacks.size).to.equal(0);
-    expect(fluxConnectionAny.closed.size).to.equal(0);
   });
   it('clean internal data on error', () => {
     const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
@@ -187,7 +185,6 @@ describe('FluxConnection', () => {
     sub.onNext((_value) => {
       // Just need a callback
     });
-    sub.cancel();
 
     const completeMsg: ClientErrorMessage = { '@type': 'error', id: '0', message: 'foo' };
     fluxConnectionAny.handleMessage(completeMsg);
@@ -196,6 +193,23 @@ describe('FluxConnection', () => {
     expect(fluxConnectionAny.onNextCallbacks.size).to.equal(0);
     expect(fluxConnectionAny.onCompleteCallbacks.size).to.equal(0);
     expect(fluxConnectionAny.onErrorCallbacks.size).to.equal(0);
-    expect(fluxConnectionAny.closed.size).to.equal(0);
+  });
+  it('clean internal data on cancel', () => {
+    const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
+    sub.onComplete(() => {
+      // Just need a callback
+    });
+    sub.onError(() => {
+      // Just need a callback
+    });
+    sub.onNext((_value) => {
+      // Just need a callback
+    });
+    sub.cancel();
+
+    expect(fluxConnectionAny.endpointInfos.size).to.equal(0);
+    expect(fluxConnectionAny.onNextCallbacks.size).to.equal(0);
+    expect(fluxConnectionAny.onCompleteCallbacks.size).to.equal(0);
+    expect(fluxConnectionAny.onErrorCallbacks.size).to.equal(0);
   });
 });

--- a/packages/ts/hilla-frontend/test/FluxConnection.test.ts
+++ b/packages/ts/hilla-frontend/test/FluxConnection.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@open-wc/testing';
+import type { ReactiveController } from 'lit';
 import { FluxConnection } from '../src/FluxConnection';
 import type { ClientCompleteMessage, ClientErrorMessage, ClientUpdateMessage } from '../src/FluxMessages';
 
@@ -207,6 +208,54 @@ describe('FluxConnection', () => {
     });
     sub.cancel();
 
+    expect(fluxConnectionAny.endpointInfos.size).to.equal(0);
+    expect(fluxConnectionAny.onNextCallbacks.size).to.equal(0);
+    expect(fluxConnectionAny.onCompleteCallbacks.size).to.equal(0);
+    expect(fluxConnectionAny.onErrorCallbacks.size).to.equal(0);
+  });
+  it('should ignore a second cancel call', () => {
+    const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
+    sub.onComplete(() => {
+      // Just need a callback
+    });
+    sub.onError(() => {
+      // Just need a callback
+    });
+    sub.onNext((_value) => {
+      // Just need a callback
+    });
+    expect(fluxConnectionAny.socket.sentMessages.length).to.equal(1);
+
+    sub.cancel();
+    expect(fluxConnectionAny.socket.sentMessages.length).to.equal(2);
+    sub.cancel();
+    expect(fluxConnectionAny.socket.sentMessages.length).to.equal(2);
+  });
+  it('calls cancel when context is deactivated', () => {
+    const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
+    sub.onComplete(() => {
+      // Just need a callback
+    });
+    sub.onError(() => {
+      // Just need a callback
+    });
+    sub.onNext((_value) => {
+      // Just need a callback
+    });
+    class FakeElement {
+      private controllers: ReactiveController[] = [];
+
+      addController(controller: ReactiveController) {
+        this.controllers.push(controller);
+      }
+      disconnectedCallback() {
+        this.controllers.forEach((controller) => controller.hostDisconnected && controller.hostDisconnected());
+      }
+    }
+
+    const fakeElement: any = new FakeElement();
+    sub.context(fakeElement);
+    fakeElement.disconnectedCallback();
     expect(fluxConnectionAny.endpointInfos.size).to.equal(0);
     expect(fluxConnectionAny.onNextCallbacks.size).to.equal(0);
     expect(fluxConnectionAny.onCompleteCallbacks.size).to.equal(0);


### PR DESCRIPTION
When the context becomes inactive, the subscription is cancelled

Fixes #400