### PR TITLE
fix!: Use /HILLA/push instead of /VAADIN/... for the push endpoint

### DIFF
--- a/packages/ts/hilla-frontend/src/FluxConnection.ts
+++ b/packages/ts/hilla-frontend/src/FluxConnection.ts
@@ -26,7 +26,7 @@ export class FluxConnection {
 
   private connectWebsocket() {
     const extraHeaders = getCsrfTokenHeadersForEndpointRequest(document);
-    this.socket = io('/hilla', { path: '/VAADIN/hillapush/', extraHeaders });
+    this.socket = io('/hilla', { path: '/HILLA/push', extraHeaders });
     this.socket.on('message', (message) => {
       this.handleMessage(JSON.parse(message));
     });


### PR DESCRIPTION
This avoids conflict with the VaadinServlet when it is bound to /VAADIN/*
