### PR TITLE
feat(form): support vaadin-combo-box string value / use model in field strategy (#421) (CP: 1.0)

### DIFF
--- a/packages/ts/form/src/Binder.ts
+++ b/packages/ts/form/src/Binder.ts
@@ -239,8 +239,8 @@ export class Binder<T, M extends AbstractModel<T>> extends BinderNode<T, M> {
    *
    * @param elm the bound element
    */
-  public getFieldStrategy(elm: any): FieldStrategy {
-    return getDefaultFieldStrategy(elm);
+  public getFieldStrategy<T>(elm: any, model?: AbstractModel<T>): FieldStrategy {
+    return getDefaultFieldStrategy(elm, model);
   }
 
   /**


### PR DESCRIPTION
* feat(form): support vaadin-combo-box string value / use model in field strategy

Fixes #151

Enables using models in the field strategy. The `<vaadin-combo-box>` strategy
uses `value` property when binding with models of primitive types
(boolean, string, number) and `selectedItem` for object and array types.

* test(form): add dynamic strategy selection test

(cherry picked from commit ae22e76a6e424bc0832f1138ebb2b97139547115)