### PR TITLE
feat: Allow binding a subscription to a context (#420) (CP: 1.1)

### DIFF
--- a/packages/ts/hilla-frontend/src/Connect.ts
+++ b/packages/ts/hilla-frontend/src/Connect.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import { ConnectionIndicator, ConnectionState } from '@vaadin/common-frontend';
+import type { ReactiveElement } from 'lit';
 import { getCsrfTokenHeadersForEndpointRequest } from './CsrfUtils.js';
 import { FluxConnection } from './FluxConnection.js';
 
@@ -99,6 +100,10 @@ export interface Subscription<T> {
   onError: (callback: () => void) => Subscription<T>;
   /** Called when the subscription has completed. No values are made available after calling this. */
   onComplete: (callback: () => void) => Subscription<T>;
+  /*
+   * Binds to the given context (element) so that when the context is deactivated (element detached), the subscription is closed.
+   */
+  context: (context: ReactiveElement) => Subscription<T>;
 }
 
 interface ConnectExceptionData {

--- a/packages/ts/hilla-frontend/src/FluxConnection.ts
+++ b/packages/ts/hilla-frontend/src/FluxConnection.ts
@@ -1,4 +1,5 @@
 import type { DefaultEventsMap } from '@socket.io/component-emitter';
+import type { ReactiveElement } from 'lit';
 import { io, Socket } from 'socket.io-client';
 import type { Subscription } from './Connect';
 import { getCsrfTokenHeadersForEndpointRequest } from './CsrfUtils';
@@ -10,7 +11,6 @@ export class FluxConnection {
   private onNextCallbacks = new Map<string, (value: any) => void>();
   private onCompleteCallbacks = new Map<string, () => void>();
   private onErrorCallbacks = new Map<string, () => void>();
-  private closed = new Set<string>();
 
   private socket!: Socket<DefaultEventsMap, DefaultEventsMap>;
 
@@ -38,11 +38,8 @@ export class FluxConnection {
 
     if (message['@type'] === 'update') {
       const callback = this.onNextCallbacks.get(id);
-      const closed = this.closed.has(id);
-      if (callback && !closed) {
+      if (callback) {
         callback(message.item);
-      } else if (!callback) {
-        throw new Error(`No callback for stream id ${id}`);
       }
     } else if (message['@type'] === 'complete') {
       const callback = this.onCompleteCallbacks.get(id);
@@ -70,7 +67,6 @@ export class FluxConnection {
     this.onCompleteCallbacks.delete(id);
     this.onErrorCallbacks.delete(id);
     this.endpointInfos.delete(id);
-    this.closed.delete(id);
   }
 
   private send(message: ServerMessage) {
@@ -100,9 +96,22 @@ export class FluxConnection {
         return hillaSubscription;
       },
       cancel: () => {
+        if (!this.endpointInfos.has(id)) {
+          // Subscription already closed or canceled
+          return;
+        }
+
         const closeMessage: ServerCloseMessage = { '@type': 'unsubscribe', id };
         this.send(closeMessage);
-        this.closed.add(id);
+        this.removeSubscription(id);
+      },
+      context: (context: ReactiveElement): Subscription<any> => {
+        context.addController({
+          hostDisconnected: () => {
+            hillaSubscription.cancel();
+          },
+        });
+        return hillaSubscription;
       },
     };
     return hillaSubscription;


### PR DESCRIPTION
* fix: properly clean up on subscription cancel()

* feat: Allow binding a subscription to a context

When the context becomes inactive, the subscription is cancelled

Fixes #400

(cherry picked from commit b37f89a4b52babc2ce7dd1999fa55ced9061c08f)