### PR TITLE
Implement creation of a file index for proper cleanup

### DIFF
--- a/packages/ts/generator-typescript-cli/test/GeneratorIO.spec.ts
+++ b/packages/ts/generator-typescript-cli/test/GeneratorIO.spec.ts
@@ -1,8 +1,83 @@
 import { expect } from 'chai';
+import LoggerFactory from '@hilla/generator-typescript-utils/LoggerFactory.js';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import GeneratorIO from '../src/GeneratorIO.js';
 
-// TODO: This is a stub. We need to add real tests
-describe('STUB', () => {
-  it('TEST STUB', () => {
-    expect(true).to.be.true;
+describe('Testing GeneratorIO', () => {
+  const logger = new LoggerFactory({ verbose: true });
+  const generatedFilenames = [1, 2, 3].map((i) => `file${i}.ts`);
+  let tmpDir: string;
+  let genIO: GeneratorIO;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp('genIOtest-');
+    genIO = new GeneratorIO(tmpDir, logger);
+    await Promise.all(
+      generatedFilenames.map(async (name) => {
+        await writeFile(join(tmpDir, name), 'dummy content');
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('Testing GeneratorIO.exists', () => {
+    it('should detect that a file exists', async () => {
+      const path = join(tmpDir, generatedFilenames[0]);
+      expect(await genIO.exists(path)).to.be.true;
+    });
+
+    it("should detect that a file doesn't exist", async () => {
+      const path = join(tmpDir, 'nobody-created-me');
+      expect(await genIO.exists(path)).to.be.false;
+    });
+  });
+
+  describe('Testing GeneratorIO.createIndex', () => {
+    it('should create file index with right content', async () => {
+      await genIO.createFileIndex(generatedFilenames);
+      const indexPath = join(tmpDir, GeneratorIO.INDEX_FILENAME);
+      expect(await genIO.exists(indexPath)).to.be.true;
+      const content = await genIO.read(indexPath);
+      generatedFilenames.forEach((name) => expect(content).to.contain(name));
+    });
+  });
+
+  describe('Testing GeneratorIO.cleanOutputDir', () => {
+    it("should do nothing when there's no file index", async () => {
+      const deletedFiles = await genIO.cleanOutputDir();
+      expect(deletedFiles).to.be.empty;
+
+      await Promise.all(
+        generatedFilenames.map(async (name) => {
+          const path = join(tmpDir, name);
+          expect(await genIO.exists(path)).to.be.true;
+        }),
+      );
+    });
+
+    it('should delete all generated files and report them', async () => {
+      await genIO.createFileIndex(generatedFilenames);
+      const deletedFiles = await genIO.cleanOutputDir();
+      expect(deletedFiles.size).to.be.equal(generatedFilenames.length);
+
+      await Promise.all(
+        generatedFilenames.map(async (name) => {
+          expect(await genIO.exists(join(tmpDir, name))).to.be.false;
+        }),
+      );
+    });
+
+    it('should not touch other files', async () => {
+      await genIO.createFileIndex(generatedFilenames);
+      const name = 'other-file.ts';
+      await writeFile(join(tmpDir, name), 'dummy content');
+      const deletedFiles = await genIO.cleanOutputDir();
+      expect(deletedFiles.size).to.be.equal(generatedFilenames.length);
+      expect(await genIO.exists(join(tmpDir, name))).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
## Description

A file is created in the `generated` directory containing a list of all files that have been created by the generator. At the next run, files listed there will be deleted before another generation. This allows to avoid to delete the whole `generated` dir, thus preserving files generated by Flow.

Fixes #425

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
