### PR TITLE
feat: allow developers to cancel endpoint requests

### DIFF
--- a/packages/ts/hilla-frontend/src/Connect.ts
+++ b/packages/ts/hilla-frontend/src/Connect.ts
@@ -249,6 +249,16 @@ function isFlowLoaded(): boolean {
 }
 
 /**
+ * A list of parameters supported by {@link ConnectClient.call | the call() method in ConnectClient}.
+ */
+export interface EndpointRequestInit {
+  /**
+   * An AbortSignal to set request's signal.
+   */
+  signal?: AbortSignal | null;
+}
+
+/**
  * A low-level network calling utility. It stores
  * a prefix and facilitates remote calls to endpoint class methods
  * on the Hilla backend.
@@ -320,10 +330,15 @@ export class ConnectClient {
    * @param endpoint Endpoint name.
    * @param method Method name to call in the endpoint class.
    * @param params Optional parameters to pass to the method.
-   * @param fetchOptions Optional object to pass options to the fetch request
+   * @param endpointRequestInit Optional parameters for the request
    * @returns {} Decoded JSON response data.
    */
-  public async call(endpoint: string, method: string, params?: any, fetchOptions?: RequestInit): Promise<any> {
+  public async call(
+    endpoint: string,
+    method: string,
+    params?: any,
+    endpointRequestInit?: EndpointRequestInit,
+  ): Promise<any> {
     if (arguments.length < 2) {
       throw new TypeError(`2 arguments required, but got only ${arguments.length}`);
     }
@@ -379,7 +394,7 @@ export class ConnectClient {
     // this way makes the folding down below more concise.
     const fetchNext: MiddlewareNext = async (context: MiddlewareContext): Promise<Response> => {
       $wnd.Vaadin.connectionState.loadingStarted();
-      return fetch(context.request, fetchOptions)
+      return fetch(context.request, { signal: endpointRequestInit?.signal })
         .then((response) => {
           $wnd.Vaadin.connectionState.loadingFinished();
           return response;

--- a/packages/ts/hilla-frontend/test/Connect.test.ts
+++ b/packages/ts/hilla-frontend/test/Connect.test.ts
@@ -210,6 +210,22 @@ describe('ConnectClient', () => {
       }
     });
 
+    it('should be able to abort a call', async () => {
+      const getDelayedOk = () => new Promise((res) => setTimeout(() => res(200), 500));
+      fetchMock.post(`${base}/connect/FooEndpoint/abort`, getDelayedOk());
+
+      const controller = new AbortController();
+      const called = client.call('FooEndpoint', 'fooMethod', {}, { signal: controller.signal });
+      controller.abort();
+
+      try {
+        await called;
+        expect(false).to.be.true; // should not reach here
+      } catch (err: any) {
+        expect(err.name).to.equal('AbortError');
+      }
+    });
+
     it('should  set connection state to CONNECTED upon server error', async () => {
       const $wnd = window as any;
       const body = 'Unexpected error';

--- a/packages/ts/hilla-frontend/test/Connect.test.ts
+++ b/packages/ts/hilla-frontend/test/Connect.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-new */
 /* tslint:disable: no-unused-expression */
-import { expect } from '@open-wc/testing';
+import { assert, expect } from '@open-wc/testing';
 import { ConnectionState, ConnectionStateStore } from '@vaadin/common-frontend';
 import fetchMock from 'fetch-mock/esm/client.js';
 import sinon from 'sinon';
@@ -220,9 +220,12 @@ describe('ConnectClient', () => {
 
       try {
         await called;
-        expect(false).to.be.true; // should not reach here
+        assert.fail("Request didn't abort as expected");
       } catch (err: any) {
-        expect(err.name).to.equal('AbortError');
+        // Should throw AbortError. If not, rethrow
+        if (err.name !== 'AbortError') {
+          throw err;
+        }
       }
     });
 


### PR DESCRIPTION
## Description

As a developer, I want to be able to cancel endpoint requests by using `AbortController`. This feature adds support for an optional call parameter, which allows to specify an `AbortSignal`. The endpoint generator is modified in the Flow repository to allow developers to add the signal to their calls if needed.

Fixes #169

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
