### PR TITLE
Use Puppeteer as browser for web tests to allow them to run on TeamCity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@web/dev-server-esbuild": "^0.2.14",
         "@web/dev-server-import-maps": "^0.0.6",
         "@web/test-runner-chrome": "^0.10.2",
+        "@web/test-runner-puppeteer": "^0.10.5",
         "concurrently": "^6.2.1",
         "esbuild": "^0.13.12",
         "eslint": "^7.32.0",
@@ -3702,6 +3703,20 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
+    },
+    "node_modules/@web/test-runner-puppeteer": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-puppeteer/-/test-runner-puppeteer-0.10.5.tgz",
+      "integrity": "sha512-B+dn5wWMUwHZEm68o3f4WJEoqeApDxfKtNbLNbsVp7Mg2JUnoQkKpbOTi5uyU4YjWVIpP+CHkD5jJ9JWikGiNQ==",
+      "dev": true,
+      "dependencies": {
+        "@web/test-runner-chrome": "^0.10.6",
+        "@web/test-runner-core": "^0.10.20",
+        "puppeteer": "^13.1.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/@web/test-runner/node_modules/@web/test-runner-commands": {
       "version": "0.6.1",
@@ -12979,6 +12994,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.7.0.tgz",
+      "integrity": "sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.981744",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=10.18.1"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "13.5.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.5.1.tgz",
@@ -13020,6 +13059,46 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.981744",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+      "integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
+      "dev": true
+    },
+    "node_modules/puppeteer/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/puppeteer/node_modules/ws": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
@@ -19324,6 +19403,17 @@
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
         }
+      }
+    },
+    "@web/test-runner-puppeteer": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-puppeteer/-/test-runner-puppeteer-0.10.5.tgz",
+      "integrity": "sha512-B+dn5wWMUwHZEm68o3f4WJEoqeApDxfKtNbLNbsVp7Mg2JUnoQkKpbOTi5uyU4YjWVIpP+CHkD5jJ9JWikGiNQ==",
+      "dev": true,
+      "requires": {
+        "@web/test-runner-chrome": "^0.10.6",
+        "@web/test-runner-core": "^0.10.20",
+        "puppeteer": "^13.1.2"
       }
     },
     "abbrev": {
@@ -26349,6 +26439,51 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-13.7.0.tgz",
+      "integrity": "sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.981744",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.5.0"
+      },
+      "dependencies": {
+        "devtools-protocol": {
+          "version": "0.0.981744",
+          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+          "integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
+          "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "dev": true,
+          "requires": {}
+        }
+      }
     },
     "puppeteer-core": {
       "version": "13.5.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@web/dev-server-esbuild": "^0.2.14",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/test-runner-chrome": "^0.10.2",
+    "@web/test-runner-puppeteer": "^0.10.5",
     "concurrently": "^6.2.1",
     "esbuild": "^0.13.12",
     "eslint": "^7.32.0",

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
 import { esbuildPlugin } from '@web/dev-server-esbuild';
-import { chromeLauncher } from '@web/test-runner-chrome';
 import { readdir } from 'fs/promises';
 import { URL } from 'url';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { puppeteerLauncher } from '@web/test-runner-puppeteer';
 
 // One of the packages in the `packages` dir
 const cwd = process.cwd();
@@ -39,15 +39,14 @@ export default {
       inject: {
         importMap: {
           imports: {
-            'socket.io-client': '/mocks/socket.io-client.ts'
+            'socket.io-client': '/mocks/socket.io-client.ts',
           },
         },
       },
     }),
-
   ],
   browsers: [
-    chromeLauncher({
+    puppeteerLauncher({
       launchOptions: {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       },


### PR DESCRIPTION
## Description

As currently web tests cannot be run on TeamCity as Chrome is needed. By switching to Puppeteer, they work there too. That seems to have no consequences running them elsewhere as before, but that's still quite a change as far as tests are concerned.

Fixes #436

## Type of change

- [x] Bugfix
- [ ] Feature
