### PR TITLE
chore: execute source and javadoc plugins in package phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
           <executions>
               <execution>
                   <id>attach-sources</id>
-                  <phase>verify</phase>
+                  <phase>package</phase>
                   <goals>
                       <goal>jar-no-fork</goal>
                   </goals>
@@ -354,7 +354,7 @@
           <executions>
               <execution>
                   <id>attach-javadocs</id>
-                  <phase>verify</phase>
+                  <phase>package</phase>
                   <goals>
                       <goal>jar</goal>
                   </goals>


### PR DESCRIPTION
This way the sources and javadoc jars are created before the `maven-gpg-plugin` is executed so that `.asc` files are also generated for those.
These `.asc` files are needed in order to deploy to maven central, otherwise signature validation fails and staging repository can't be closed
> Missing Signature: '/dev/hilla/parser-jvm-core/1.2.0/parser-jvm-core-1.2.0-sources.jar.asc' does not exist for 'parser-jvm-core-1.2.0-sources.jar'.
