### PR TITLE
feat(parser-jvm-core): add PackageInfoModel

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
@@ -31,6 +31,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     private List<ClassInfoModel> innerClasses;
     private List<ClassInfoModel> interfaces;
     private List<MethodInfoModel> methods;
+    private PackageInfoModel pkg;
     private Optional<ClassInfoModel> superClass;
 
     public static boolean is(Class<?> actor, String target) {
@@ -272,6 +273,14 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
         return getMethods().stream();
     }
 
+    public PackageInfoModel getPackage() {
+        if (pkg == null) {
+            pkg = preparePackage();
+        }
+
+        return pkg;
+    }
+
     public abstract String getSimpleName();
 
     public Optional<ClassInfoModel> getSuperClass() {
@@ -381,6 +390,8 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     protected abstract List<ClassInfoModel> prepareInterfaces();
 
     protected abstract List<MethodInfoModel> prepareMethods();
+
+    protected abstract PackageInfoModel preparePackage();
 
     protected abstract ClassInfoModel prepareSuperClass();
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -219,6 +219,11 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     }
 
     @Override
+    protected PackageInfoModel preparePackage() {
+        return PackageInfoModel.of(origin.getPackage());
+    }
+
+    @Override
     protected ClassInfoModel prepareSuperClass() {
         var superClass = origin.getSuperclass();
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
@@ -218,6 +218,11 @@ final class ClassInfoSourceModel extends ClassInfoModel implements SourceModel {
     }
 
     @Override
+    protected PackageInfoModel preparePackage() {
+        return PackageInfoModel.of(origin.getPackageInfo());
+    }
+
+    @Override
     protected ClassInfoModel prepareSuperClass() {
         var superClass = origin.getSuperclass();
         return superClass != null ? ClassInfoModel.of(superClass) : null;

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
@@ -1,0 +1,47 @@
+package dev.hilla.parser.models;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.github.classgraph.PackageInfo;
+
+public abstract class PackageInfoModel extends AnnotatedAbstractModel
+        implements Model, NamedModel {
+    public static PackageInfoModel of(Package origin) {
+        return new PackageInfoReflectionModel(origin);
+    }
+
+    public static PackageInfoModel of(PackageInfo origin) {
+        return new PackageInfoSourceModel(origin);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof PackageInfoModel)) {
+            return false;
+        }
+
+        var other = (PackageInfoModel) obj;
+
+        return getName().equals(other.getName());
+    }
+
+    @Override
+    public Set<ClassInfoModel> getDependencies() {
+        return Set.of();
+    }
+
+    @Override
+    public Stream<ClassInfoModel> getDependenciesStream() {
+        return Stream.empty();
+    }
+
+    @Override
+    public int hashCode() {
+        return getName().hashCode();
+    }
+}

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -1,0 +1,26 @@
+package dev.hilla.parser.models;
+
+import java.util.List;
+
+class PackageInfoReflectionModel extends PackageInfoModel {
+    private final Package origin;
+
+    PackageInfoReflectionModel(Package origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public Package get() {
+        return origin;
+    }
+
+    @Override
+    public String getName() {
+        return origin.getName();
+    }
+
+    @Override
+    protected List<AnnotationInfoModel> prepareAnnotations() {
+        return processAnnotations(origin.getDeclaredAnnotations());
+    }
+}

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
@@ -1,0 +1,28 @@
+package dev.hilla.parser.models;
+
+import java.util.List;
+
+import io.github.classgraph.PackageInfo;
+
+class PackageInfoSourceModel extends PackageInfoModel {
+    private final PackageInfo origin;
+
+    PackageInfoSourceModel(PackageInfo origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public PackageInfo get() {
+        return origin;
+    }
+
+    @Override
+    public String getName() {
+        return origin.getName();
+    }
+
+    @Override
+    protected List<AnnotationInfoModel> prepareAnnotations() {
+        return processAnnotations(origin.getAnnotationInfo());
+    }
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -1,6 +1,7 @@
 package dev.hilla.parser.models;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,6 +10,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -54,6 +56,31 @@ public class PackageInfoModelTests {
                 model.getAnnotationsStream()
                         .map(AnnotationInfoModel::getClassInfo)
                         .collect(Collectors.toList()));
+    }
+
+    @DisplayName("It should have the same hashCode for source and reflection models")
+    @Test
+    public void should_HaveSameHashCodeForSourceAndReflectionModels() {
+        var reflectionModel = PackageInfoModel.of(ctx.getReflectionOrigin());
+        var sourceModel = PackageInfoModel.of(ctx.getSourceOrigin());
+
+        assertEquals(reflectionModel.hashCode(), sourceModel.hashCode());
+    }
+
+    @DisplayName("It should have source and reflection models equal")
+    @Test
+    public void should_HaveSourceAndReflectionModelsEqual() {
+        var reflectionModel = PackageInfoModel.of(ctx.getReflectionOrigin());
+        var sourceModel = PackageInfoModel.of(ctx.getSourceOrigin());
+
+        assertEquals(reflectionModel, reflectionModel);
+        assertEquals(reflectionModel, sourceModel);
+
+        assertEquals(sourceModel, sourceModel);
+        assertEquals(sourceModel, reflectionModel);
+
+        assertNotEquals(sourceModel, new Object());
+        assertNotEquals(reflectionModel, new Object());
     }
 
     static class Context {

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -1,0 +1,105 @@
+package dev.hilla.parser.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import dev.hilla.parser.models.pack.Foo;
+import dev.hilla.parser.models.pack.PackageInfoModelSample;
+import dev.hilla.parser.test.helpers.ModelKind;
+import dev.hilla.parser.test.helpers.Source;
+import dev.hilla.parser.test.helpers.SourceExtension;
+
+import io.github.classgraph.PackageInfo;
+import io.github.classgraph.ScanResult;
+
+@ExtendWith(SourceExtension.class)
+public class PackageInfoModelTests {
+    private Context ctx;
+
+    @BeforeEach
+    public void setUp(@Source ScanResult source) {
+        this.ctx = new Context(source);
+    }
+
+    @DisplayName("It should contain an annotation")
+    @ParameterizedTest(name = ModelProvider.testNamePattern)
+    @ArgumentsSource(ModelProvider.class)
+    public void should_ContainAnnotation(PackageInfoModel model,
+            ModelKind kind) {
+        assertEquals(List.of(Foo.class.getName()),
+                model.getAnnotationsStream().map(AnnotationInfoModel::getName)
+                        .collect(Collectors.toList()));
+    }
+
+    @DisplayName("It should get annotations with ClassInfo")
+    @ParameterizedTest(name = ModelProvider.testNamePattern)
+    @ArgumentsSource(ModelProvider.class)
+    @Disabled("Probably, ClassGraph issue: ScanResult is null for package-level annotations for now")
+    public void should_GetAnnotationsWithClassInfo(PackageInfoModel model,
+            ModelKind kind) {
+        assertEquals(List.of(ClassInfoModel.of(Foo.class)),
+                model.getAnnotationsStream()
+                        .map(AnnotationInfoModel::getClassInfo)
+                        .collect(Collectors.toList()));
+    }
+
+    static class Context {
+        private static final Package reflectionOrigin = PackageInfoModelSample.class
+                .getPackage();
+
+        private final ScanResult source;
+        private final PackageInfo sourceOrigin;
+
+        Context(ExtensionContext context) {
+            this(SourceExtension.getSource(context));
+        }
+
+        Context(ScanResult source) {
+            this.source = source;
+            this.sourceOrigin = source
+                    .getClassInfo(PackageInfoModelSample.class.getName())
+                    .getPackageInfo();
+        }
+
+        public Package getReflectionOrigin() {
+            return reflectionOrigin;
+        }
+
+        public ScanResult getSource() {
+            return source;
+        }
+
+        public PackageInfo getSourceOrigin() {
+            return sourceOrigin;
+        }
+    }
+
+    static class ModelProvider implements ArgumentsProvider {
+        static final String testNamePattern = "{1}";
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(
+                ExtensionContext context) {
+            var ctx = new Context(context);
+
+            return Stream.of(
+                    Arguments.of(PackageInfoModel.of(ctx.getReflectionOrigin()),
+                            ModelKind.REFLECTION),
+                    Arguments.of(PackageInfoModel.of(ctx.getSourceOrigin()),
+                            ModelKind.SOURCE));
+        }
+    }
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -81,6 +82,30 @@ public class PackageInfoModelTests {
 
         assertNotEquals(sourceModel, new Object());
         assertNotEquals(reflectionModel, new Object());
+    }
+
+    @DisplayName("It should provide correct origin")
+    @ParameterizedTest(name = ModelProvider.testNamePattern)
+    @ArgumentsSource(ModelProvider.class)
+    public void should_ProvideCorrectOrigin(PackageInfoModel model,
+            ModelKind kind) {
+        switch (kind) {
+        case REFLECTION:
+            assertEquals(ctx.getReflectionOrigin(), model.get());
+            break;
+        case SOURCE:
+            assertEquals(ctx.getSourceOrigin(), model.get());
+            break;
+        }
+    }
+
+    @DisplayName("It should provide no dependencies")
+    @ParameterizedTest(name = ModelProvider.testNamePattern)
+    @ArgumentsSource(ModelProvider.class)
+    public void should_ProvideNoDependencies(PackageInfoModel model,
+            ModelKind kind) {
+        assertEquals(Set.of(), model.getDependencies());
+        assertEquals(0, model.getDependenciesStream().count());
     }
 
     static class Context {

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/Foo.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/Foo.java
@@ -1,0 +1,10 @@
+package dev.hilla.parser.models.pack;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PACKAGE)
+public @interface Foo {}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/Foo.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/Foo.java
@@ -7,4 +7,5 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PACKAGE)
-public @interface Foo {}
+public @interface Foo {
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/PackageInfoModelSample.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/PackageInfoModelSample.java
@@ -1,0 +1,4 @@
+package dev.hilla.parser.models.pack;
+
+public class PackageInfoModelSample {
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/package-info.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/pack/package-info.java
@@ -1,0 +1,2 @@
+@Foo
+package dev.hilla.parser.models.pack;


### PR DESCRIPTION
Adds `PackageInfoModel` to the list of core models.

### Known issues

Annotations provided by the ClassGraph `PackageInfo#getAnnotations` return `null` for `getClassInfo` call which should get information of their original class. For now it is better to use string names. 