### PR TITLE
refactor(parser-jvm-core): add SignatureInfo to the AssociationMap

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/AssociationMap.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/AssociationMap.java
@@ -3,6 +3,9 @@ package dev.hilla.parser.core;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
 
 import dev.hilla.parser.models.ClassInfoModel;
 import dev.hilla.parser.models.FieldInfoModel;
@@ -18,35 +21,55 @@ public final class AssociationMap {
     private final Map<Schema<?>, MethodInfoModel> methods = new IdentityHashMap<>();
     private final Map<Schema<?>, MethodParameterInfoModel> parameters = new IdentityHashMap<>();
     private final Reversed reversed = new Reversed();
-    private final Map<Schema<?>, SignatureModel> types = new IdentityHashMap<>();
+    private final Map<Schema<?>, SignatureInfo> signatureInfo = new IdentityHashMap<>();
+    private final Map<Schema<?>, SignatureModel> signatures = new IdentityHashMap<>();
 
     AssociationMap() {
     }
 
-    public void addEntity(Schema<?> schema, ClassInfoModel entity) {
-        entities.put(schema, entity);
+    public void addEntity(@Nonnull Schema<?> schema,
+            @Nonnull ClassInfoModel entity) {
+        entities.put(Objects.requireNonNull(schema),
+                Objects.requireNonNull(entity));
         reversed.entities.put(entity, schema);
     }
 
-    public void addField(Schema<?> schema, FieldInfoModel field) {
-        fields.put(schema, field);
+    public void addField(@Nonnull Schema<?> schema,
+            @Nonnull FieldInfoModel field) {
+        fields.put(Objects.requireNonNull(schema),
+                Objects.requireNonNull(field));
         reversed.fields.put(field, schema);
     }
 
-    public void addMethod(Schema<?> schema, MethodInfoModel method) {
-        methods.put(schema, method);
+    public void addMethod(@Nonnull Schema<?> schema,
+            @Nonnull MethodInfoModel method) {
+        methods.put(Objects.requireNonNull(schema),
+                Objects.requireNonNull(method));
         reversed.methods.put(method, schema);
     }
 
-    public void addParameter(Schema<?> schema,
-            MethodParameterInfoModel parameter) {
-        parameters.put(schema, parameter);
+    public void addParameter(@Nonnull Schema<?> schema,
+            @Nonnull MethodParameterInfoModel parameter) {
+        parameters.put(Objects.requireNonNull(schema),
+                Objects.requireNonNull(parameter));
         reversed.parameters.put(parameter, schema);
     }
 
-    public void addType(Schema<?> schema, SignatureModel signature) {
-        types.put(schema, signature);
-        reversed.types.put(signature, schema);
+    public void addSignature(@Nonnull Schema<?> schema,
+            @Nonnull SignatureModel signature) {
+        addSignature(schema, signature, null);
+    }
+
+    public void addSignature(@Nonnull Schema<?> schema,
+            @Nonnull SignatureModel signature, SignatureInfo info) {
+        signatures.put(Objects.requireNonNull(schema),
+                Objects.requireNonNull(signature));
+        reversed.signatures.put(signature, schema);
+
+        if (info != null) {
+            signatureInfo.put(schema, info);
+            reversed.signatureInfo.put(signature, info);
+        }
     }
 
     public Map<Schema<?>, ClassInfoModel> getEntities() {
@@ -65,8 +88,12 @@ public final class AssociationMap {
         return Collections.unmodifiableMap(parameters);
     }
 
-    public Map<Schema<?>, SignatureModel> getTypes() {
-        return Collections.unmodifiableMap(types);
+    public Map<Schema<?>, SignatureInfo> getSignatureInfo() {
+        return Collections.unmodifiableMap(signatureInfo);
+    }
+
+    public Map<Schema<?>, SignatureModel> getSignatures() {
+        return Collections.unmodifiableMap(signatures);
     }
 
     public Reversed reversed() {
@@ -78,7 +105,8 @@ public final class AssociationMap {
         private final Map<FieldInfoModel, Schema<?>> fields = new IdentityHashMap<>();
         private final Map<MethodInfoModel, Schema<?>> methods = new IdentityHashMap<>();
         private final Map<MethodParameterInfoModel, Schema<?>> parameters = new IdentityHashMap<>();
-        private final Map<SignatureModel, Schema<?>> types = new IdentityHashMap<>();
+        private final Map<SignatureModel, SignatureInfo> signatureInfo = new IdentityHashMap<>();
+        private final Map<SignatureModel, Schema<?>> signatures = new IdentityHashMap<>();
 
         private Reversed() {
         }
@@ -99,8 +127,13 @@ public final class AssociationMap {
             return Collections.unmodifiableMap(parameters);
         }
 
-        public Map<SignatureModel, Schema<?>> getTypes() {
-            return Collections.unmodifiableMap(types);
+        public Map<SignatureModel, SignatureInfo> getSignatureInfo() {
+            return Collections.unmodifiableMap(signatureInfo);
+        }
+
+        public Map<SignatureModel, Schema<?>> getSignatures() {
+            return Collections.unmodifiableMap(signatures);
         }
     }
+
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/SignatureInfo.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/SignatureInfo.java
@@ -1,8 +1,8 @@
 package dev.hilla.parser.core;
 
-import javax.annotation.Nonnull;
-
 import java.util.Objects;
+
+import javax.annotation.Nonnull;
 
 import dev.hilla.parser.models.Model;
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/SignatureInfo.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/SignatureInfo.java
@@ -1,0 +1,19 @@
+package dev.hilla.parser.core;
+
+import javax.annotation.Nonnull;
+
+import java.util.Objects;
+
+import dev.hilla.parser.models.Model;
+
+public class SignatureInfo {
+    private final Model base;
+
+    public SignatureInfo(@Nonnull Model base) {
+        this.base = Objects.requireNonNull(base);
+    }
+
+    public Model getBase() {
+        return base;
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointProcessor.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointProcessor.java
@@ -99,8 +99,8 @@ final class EndpointProcessor {
             var requestMap = new ObjectSchema();
 
             for (var parameter : method.getParameters()) {
-                var schema = new SchemaProcessor(parameter.getType(), new SignatureInfo(parameter), storage)
-                        .process();
+                var schema = new SchemaProcessor(parameter.getType(),
+                        new SignatureInfo(parameter), storage).process();
                 requestMap.addProperties(parameter.getName(), schema);
                 storage.getAssociationMap().addParameter(schema, parameter);
             }
@@ -115,7 +115,8 @@ final class EndpointProcessor {
             var resultType = method.getResultType();
 
             if (!resultType.isVoid()) {
-                var schema = new SchemaProcessor(resultType, new SignatureInfo(method), storage).process();
+                var schema = new SchemaProcessor(resultType,
+                        new SignatureInfo(method), storage).process();
 
                 content.addMediaType("application/json",
                         new MediaType().schema(schema));

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointProcessor.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointProcessor.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import dev.hilla.parser.core.SharedStorage;
+import dev.hilla.parser.core.SignatureInfo;
 import dev.hilla.parser.models.ClassInfoModel;
 import dev.hilla.parser.models.MethodInfoModel;
 
@@ -98,7 +99,7 @@ final class EndpointProcessor {
             var requestMap = new ObjectSchema();
 
             for (var parameter : method.getParameters()) {
-                var schema = new SchemaProcessor(parameter.getType(), storage)
+                var schema = new SchemaProcessor(parameter.getType(), new SignatureInfo(parameter), storage)
                         .process();
                 requestMap.addProperties(parameter.getName(), schema);
                 storage.getAssociationMap().addParameter(schema, parameter);
@@ -114,7 +115,7 @@ final class EndpointProcessor {
             var resultType = method.getResultType();
 
             if (!resultType.isVoid()) {
-                var schema = new SchemaProcessor(resultType, storage).process();
+                var schema = new SchemaProcessor(resultType, new SignatureInfo(method), storage).process();
 
                 content.addMediaType("application/json",
                         new MediaType().schema(schema));

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EntityProcessor.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EntityProcessor.java
@@ -124,8 +124,8 @@ final class EntityProcessor {
 
         public ComponentSchemaPropertyProcessor(FieldInfoModel field) {
             this.key = field.getName();
-            this.value = new SchemaProcessor(field.getType(), new SignatureInfo(field), storage)
-                    .process();
+            this.value = new SchemaProcessor(field.getType(),
+                    new SignatureInfo(field), storage).process();
         }
 
         public String getKey() {

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EntityProcessor.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EntityProcessor.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import dev.hilla.parser.core.SharedStorage;
+import dev.hilla.parser.core.SignatureInfo;
 import dev.hilla.parser.models.ClassInfoModel;
 import dev.hilla.parser.models.FieldInfoModel;
 
@@ -123,7 +124,7 @@ final class EntityProcessor {
 
         public ComponentSchemaPropertyProcessor(FieldInfoModel field) {
             this.key = field.getName();
-            this.value = new SchemaProcessor(field.getType(), storage)
+            this.value = new SchemaProcessor(field.getType(), new SignatureInfo(field), storage)
                     .process();
         }
 

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ValidationConstraint.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ValidationConstraint.java
@@ -43,7 +43,7 @@ public final class ValidationConstraint {
         }
 
         public void process() {
-            map.getTypes().forEach(this::processSchema);
+            map.getSignatures().forEach(this::processSchema);
         }
 
         private ValidationConstraint convertAnnotation(

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullProcessor.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullProcessor.java
@@ -27,7 +27,7 @@ final class NonnullProcessor {
         map.getFields().forEach(this::processField);
         map.getMethods().forEach(this::processMethod);
         map.getParameters().forEach(this::processParameter);
-        map.getTypes().forEach(this::processSchema);
+        map.getSignatures().forEach(this::processSchema);
     }
 
     private boolean isNonNull(Stream<AnnotationInfoModel> annotationsStream) {


### PR DESCRIPTION
Add an `SignatureInfo` structure to `AssociationMap` that allows extracting the base of the signature: either a method, a field or a parameter. This addition allows getting the `PackageInfo` for the signature which was impossible before.