### PR TITLE
chore: use `hilla` instead of `engine` as Maven prefix

### DIFF
--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateHillaImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateHillaImpl.java
@@ -72,7 +72,7 @@ public class TaskGenerateHillaImpl implements TaskGenerateHilla {
     }
 
     List<String> prepareMavenCommand() {
-        return List.of("mvn", "engine:generate");
+        return List.of("mvn", "hilla:generate");
     }
 
     List<String> prepareGradleCommand() {

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -89,6 +89,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>3.6.1</version>
+          <configuration>
+            <goalPrefix>hilla</goalPrefix>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The `engine-maven-plugin` is configured to use `hilla` as prefix for goal invocation. The `TaskGenerateHillaImpl` is modified to use that prefix too.

Closes #493