### PR TITLE
fix(engine): add support for custom connect client

### DIFF
--- a/packages/ts/generator-typescript-cli/src/index.ts
+++ b/packages/ts/generator-typescript-cli/src/index.ts
@@ -46,7 +46,7 @@ const logger = new LoggerFactory({ verbose });
 const io = new GeneratorIO(outputDir, logger);
 
 const resolvedPlugins = await Promise.all(Array.from(new Set(plugins), (pluginPath) => io.loadPlugin(pluginPath)));
-const generator = new Generator(resolvedPlugins, logger, outputDir);
+const generator = new Generator(resolvedPlugins, { logger, outputDir });
 
 const files = await generator.process(await processInput(input, io));
 await io.cleanOutputDir();

--- a/packages/ts/generator-typescript-cli/src/index.ts
+++ b/packages/ts/generator-typescript-cli/src/index.ts
@@ -46,7 +46,7 @@ const logger = new LoggerFactory({ verbose });
 const io = new GeneratorIO(outputDir, logger);
 
 const resolvedPlugins = await Promise.all(Array.from(new Set(plugins), (pluginPath) => io.loadPlugin(pluginPath)));
-const generator = new Generator(resolvedPlugins, logger);
+const generator = new Generator(resolvedPlugins, logger, outputDir);
 
 const files = await generator.process(await processInput(input, io));
 await io.cleanOutputDir();

--- a/packages/ts/generator-typescript-core/src/Generator.ts
+++ b/packages/ts/generator-typescript-core/src/Generator.ts
@@ -15,11 +15,11 @@ export default class Generator {
   readonly #parser: SwaggerParser;
   readonly #outputDir: string | undefined;
 
-  public constructor(plugins: readonly PluginConstructor[], logger: LoggerFactory, outputDir?: string) {
+  public constructor(plugins: readonly PluginConstructor[], context: { logger: LoggerFactory; outputDir?: string }) {
     this.#parser = new SwaggerParser();
-    this.#manager = new PluginManager(plugins, new ReferenceResolver(this.#parser), logger);
-    this.#logger = logger;
-    this.#outputDir = outputDir;
+    this.#manager = new PluginManager(plugins, new ReferenceResolver(this.#parser), context.logger);
+    this.#logger = context.logger;
+    this.#outputDir = context.outputDir;
   }
 
   public async process(input: string): Promise<readonly File[]> {

--- a/packages/ts/generator-typescript-core/src/Generator.ts
+++ b/packages/ts/generator-typescript-core/src/Generator.ts
@@ -13,11 +13,13 @@ export default class Generator {
   readonly #logger: LoggerFactory;
   readonly #manager: PluginManager;
   readonly #parser: SwaggerParser;
+  readonly #outputDir: string;
 
-  public constructor(plugins: readonly PluginConstructor[], logger: LoggerFactory) {
+  public constructor(plugins: readonly PluginConstructor[], logger: LoggerFactory, outputDir: string) {
     this.#parser = new SwaggerParser();
     this.#manager = new PluginManager(plugins, new ReferenceResolver(this.#parser), logger);
     this.#logger = logger;
+    this.#outputDir = outputDir;
   }
 
   public async process(input: string): Promise<readonly File[]> {
@@ -29,6 +31,7 @@ export default class Generator {
       apiRefs: this.#parser.$refs,
       pluginStorage: new Map(),
       sources: [],
+      outputDir: this.#outputDir,
     };
 
     this.#logger.global.debug('Executing plugins');

--- a/packages/ts/generator-typescript-core/src/Generator.ts
+++ b/packages/ts/generator-typescript-core/src/Generator.ts
@@ -9,13 +9,18 @@ import PluginManager from './PluginManager.js';
 import ReferenceResolver from './ReferenceResolver.js';
 import type SharedStorage from './SharedStorage.js';
 
+export type GeneratorContext = Readonly<{
+  logger: LoggerFactory;
+  outputDir?: string;
+}>;
+
 export default class Generator {
   readonly #logger: LoggerFactory;
   readonly #manager: PluginManager;
   readonly #parser: SwaggerParser;
   readonly #outputDir: string | undefined;
 
-  public constructor(plugins: readonly PluginConstructor[], context: { logger: LoggerFactory; outputDir?: string }) {
+  public constructor(plugins: readonly PluginConstructor[], context: GeneratorContext) {
     this.#parser = new SwaggerParser();
     this.#manager = new PluginManager(plugins, new ReferenceResolver(this.#parser), context.logger);
     this.#logger = context.logger;

--- a/packages/ts/generator-typescript-core/src/Generator.ts
+++ b/packages/ts/generator-typescript-core/src/Generator.ts
@@ -13,9 +13,9 @@ export default class Generator {
   readonly #logger: LoggerFactory;
   readonly #manager: PluginManager;
   readonly #parser: SwaggerParser;
-  readonly #outputDir: string;
+  readonly #outputDir: string | undefined;
 
-  public constructor(plugins: readonly PluginConstructor[], logger: LoggerFactory, outputDir: string) {
+  public constructor(plugins: readonly PluginConstructor[], logger: LoggerFactory, outputDir?: string) {
     this.#parser = new SwaggerParser();
     this.#manager = new PluginManager(plugins, new ReferenceResolver(this.#parser), logger);
     this.#logger = logger;

--- a/packages/ts/generator-typescript-core/src/SharedStorage.d.ts
+++ b/packages/ts/generator-typescript-core/src/SharedStorage.d.ts
@@ -8,7 +8,7 @@ type SharedStorage = Readonly<{
   apiRefs: $Refs;
   sources: SourceFile[];
   pluginStorage: Map<string, unknown>;
-  outputDir: string;
+  outputDir?: string;
 }>;
 
 export default SharedStorage;

--- a/packages/ts/generator-typescript-core/src/SharedStorage.d.ts
+++ b/packages/ts/generator-typescript-core/src/SharedStorage.d.ts
@@ -8,6 +8,7 @@ type SharedStorage = Readonly<{
   apiRefs: $Refs;
   sources: SourceFile[];
   pluginStorage: Map<string, unknown>;
+  outputDir: string;
 }>;
 
 export default SharedStorage;

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
@@ -81,7 +81,7 @@ class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProces
 
     const methodIdentifier = exports.named.add(this.#endpointMethodName);
     const clientLibIdentifier = imports.default.getIdentifier(
-      paths.createRelativePath(await ClientPlugin.clientFileName(outputDir)),
+      paths.createRelativePath(await ClientPlugin.getClientFileName(outputDir)),
     )!;
 
     const callExpression = ts.factory.createCallExpression(

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
@@ -39,7 +39,7 @@ export default abstract class EndpointMethodOperationProcessor {
     }
   }
 
-  public abstract process(outputDir?: string): Statement | undefined;
+  public abstract process(outputDir?: string): Promise<Statement | undefined>;
 }
 
 class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProcessor {
@@ -64,7 +64,7 @@ class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProces
     this.#operation = operation;
   }
 
-  public process(outputDir?: string): Statement | undefined {
+  public async process(outputDir?: string): Promise<Statement | undefined> {
     const { exports, imports, paths } = this.#dependencies;
     this.#owner.logger.debug(`${this.#endpointName}.${this.#endpointMethodName} - processing POST method`);
     const initTypeIdentifier = imports.named.getIdentifier(
@@ -81,7 +81,7 @@ class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProces
 
     const methodIdentifier = exports.named.add(this.#endpointMethodName);
     const clientLibIdentifier = imports.default.getIdentifier(
-      paths.createRelativePath(ClientPlugin.clientFile(outputDir).name),
+      paths.createRelativePath(await ClientPlugin.clientFileName(outputDir)),
     )!;
 
     const callExpression = ts.factory.createCallExpression(

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
@@ -39,7 +39,7 @@ export default abstract class EndpointMethodOperationProcessor {
     }
   }
 
-  public abstract process(): Statement | undefined;
+  public abstract process(outputDir: string): Statement | undefined;
 }
 
 class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProcessor {
@@ -64,7 +64,7 @@ class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProces
     this.#operation = operation;
   }
 
-  public process(): Statement | undefined {
+  public process(outputDir: string): Statement | undefined {
     const { exports, imports, paths } = this.#dependencies;
     this.#owner.logger.debug(`${this.#endpointName}.${this.#endpointMethodName} - processing POST method`);
     const initTypeIdentifier = imports.named.getIdentifier(
@@ -80,7 +80,9 @@ class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProces
     ).process();
 
     const methodIdentifier = exports.named.add(this.#endpointMethodName);
-    const clientLibIdentifier = imports.default.getIdentifier(paths.createRelativePath(ClientPlugin.CLIENT_FILE_NAME))!;
+    const clientLibIdentifier = imports.default.getIdentifier(
+      paths.createRelativePath(ClientPlugin.clientFile(outputDir).name),
+    )!;
 
     const callExpression = ts.factory.createCallExpression(
       ts.factory.createPropertyAccessExpression(clientLibIdentifier, ts.factory.createIdentifier('call')),

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointMethodOperationProcessor.ts
@@ -39,7 +39,7 @@ export default abstract class EndpointMethodOperationProcessor {
     }
   }
 
-  public abstract process(outputDir: string): Statement | undefined;
+  public abstract process(outputDir?: string): Statement | undefined;
 }
 
 class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProcessor {
@@ -64,7 +64,7 @@ class EndpointMethodOperationPOSTProcessor extends EndpointMethodOperationProces
     this.#operation = operation;
   }
 
-  public process(outputDir: string): Statement | undefined {
+  public process(outputDir?: string): Statement | undefined {
     const { exports, imports, paths } = this.#dependencies;
     this.#owner.logger.debug(`${this.#endpointName}.${this.#endpointMethodName} - processing POST method`);
     const initTypeIdentifier = imports.named.getIdentifier(

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
@@ -18,9 +18,9 @@ export default class EndpointProcessor {
   readonly #name: string;
   readonly #owner: Plugin;
   readonly #sourcePaths = new PathManager({ extension: 'ts' });
-  readonly #outputDir: string;
+  readonly #outputDir: string | undefined;
 
-  public constructor(name: string, owner: Plugin, outputDir: string) {
+  public constructor(name: string, owner: Plugin, outputDir?: string) {
     this.#owner = owner;
     this.#name = name;
     this.#outputDir = outputDir;

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
@@ -40,7 +40,7 @@ export default class EndpointProcessor {
   ): Promise<EndpointProcessor> {
     const endpoint = new EndpointProcessor(name, owner, methods, outputDir);
     endpoint.#dependencies.imports.default.add(
-      endpoint.#dependencies.paths.createRelativePath(await ClientPlugin.clientFileName(outputDir)),
+      endpoint.#dependencies.paths.createRelativePath(await ClientPlugin.getClientFileName(outputDir)),
       'client',
     );
     endpoint.#dependencies.imports.named.add(

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
@@ -18,12 +18,14 @@ export default class EndpointProcessor {
   readonly #name: string;
   readonly #owner: Plugin;
   readonly #sourcePaths = new PathManager({ extension: 'ts' });
+  readonly #outputDir: string;
 
-  public constructor(name: string, owner: Plugin) {
+  public constructor(name: string, owner: Plugin, outputDir: string) {
     this.#owner = owner;
     this.#name = name;
+    this.#outputDir = outputDir;
     this.#dependencies.imports.default.add(
-      this.#dependencies.paths.createRelativePath(ClientPlugin.CLIENT_FILE_NAME),
+      this.#dependencies.paths.createRelativePath(ClientPlugin.clientFile(outputDir).name),
       'client',
     );
     this.#dependencies.imports.named.add(
@@ -64,7 +66,7 @@ export default class EndpointProcessor {
           pathItem[httpMethod] as EndpointMethodOperation,
           this.#dependencies,
           this.#owner,
-        )?.process(),
+        )?.process(this.#outputDir),
       )
       .filter(Boolean) as readonly Statement[];
   }

--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
@@ -14,36 +14,48 @@ import EndpointMethodOperationProcessor, {
 
 export default class EndpointProcessor {
   readonly #dependencies = new DependencyManager(new PathManager());
-  readonly #methods = new Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>();
+  readonly #methods: Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>;
   readonly #name: string;
   readonly #owner: Plugin;
   readonly #sourcePaths = new PathManager({ extension: 'ts' });
   readonly #outputDir: string | undefined;
 
-  public constructor(name: string, owner: Plugin, outputDir?: string) {
-    this.#owner = owner;
+  private constructor(
+    name: string,
+    owner: Plugin,
+    methods: Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>,
+    outputDir?: string,
+  ) {
     this.#name = name;
+    this.#owner = owner;
+    this.#methods = methods;
     this.#outputDir = outputDir;
-    this.#dependencies.imports.default.add(
-      this.#dependencies.paths.createRelativePath(ClientPlugin.clientFile(outputDir).name),
+  }
+
+  public static async create(
+    name: string,
+    owner: Plugin,
+    methods: Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>,
+    outputDir?: string,
+  ): Promise<EndpointProcessor> {
+    const endpoint = new EndpointProcessor(name, owner, methods, outputDir);
+    endpoint.#dependencies.imports.default.add(
+      endpoint.#dependencies.paths.createRelativePath(await ClientPlugin.clientFileName(outputDir)),
       'client',
     );
-    this.#dependencies.imports.named.add(
-      this.#dependencies.paths.createBareModulePath(HILLA_FRONTEND_NAME),
+    endpoint.#dependencies.imports.named.add(
+      endpoint.#dependencies.paths.createBareModulePath(HILLA_FRONTEND_NAME),
       INIT_TYPE_NAME,
     );
+    return endpoint;
   }
 
-  public add(method: string, pathItem: ReadonlyDeep<OpenAPIV3.PathItemObject>): void {
-    this.#methods.set(method, pathItem);
-  }
-
-  public process(): SourceFile {
+  public async process(): Promise<SourceFile> {
     this.#owner.logger.debug(`Processing endpoint: ${this.#name}`);
 
-    const statements = Array.from(this.#methods, ([method, pathItem]) => this.#processMethod(method, pathItem)).flatMap(
-      (item) => item,
-    );
+    const statements = (
+      await Promise.all(Array.from(this.#methods, async ([method, pathItem]) => this.#processMethod(method, pathItem)))
+    ).flatMap((item) => item);
 
     const { imports, exports } = this.#dependencies;
 
@@ -53,21 +65,27 @@ export default class EndpointProcessor {
     );
   }
 
-  #processMethod(method: string, pathItem: ReadonlyDeep<OpenAPIV3.PathItemObject>): readonly Statement[] {
+  async #processMethod(
+    method: string,
+    pathItem: ReadonlyDeep<OpenAPIV3.PathItemObject>,
+  ): Promise<readonly Statement[]> {
     this.#owner.logger.debug(`Processing endpoint method: ${this.#name}.${method}`);
 
-    return Object.values(OpenAPIV3.HttpMethods)
-      .filter((httpMethod) => pathItem[httpMethod])
-      .map((httpMethod) =>
-        EndpointMethodOperationProcessor.createProcessor(
-          httpMethod,
-          this.#name,
-          method,
-          pathItem[httpMethod] as EndpointMethodOperation,
-          this.#dependencies,
-          this.#owner,
-        )?.process(this.#outputDir),
+    return (
+      await Promise.all(
+        Object.values(OpenAPIV3.HttpMethods)
+          .filter((httpMethod) => pathItem[httpMethod])
+          .map((httpMethod) =>
+            EndpointMethodOperationProcessor.createProcessor(
+              httpMethod,
+              this.#name,
+              method,
+              pathItem[httpMethod] as EndpointMethodOperation,
+              this.#dependencies,
+              this.#owner,
+            )?.process(this.#outputDir),
+          ),
       )
-      .filter(Boolean) as readonly Statement[];
+    ).filter(Boolean) as readonly Statement[];
   }
 }

--- a/packages/ts/generator-typescript-plugin-backbone/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/index.ts
@@ -36,7 +36,7 @@ export default class BackbonePlugin extends Plugin {
     const endpoints = new Map<string, Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>>();
 
     Object.entries(storage.api.paths)
-      .filter(([, pathItem]) => Boolean(pathItem))
+      .filter(([, pathItem]) => !!pathItem)
       .forEach(([path, pathItem]) => {
         const [, endpointName, endpointMethodName] = path.split('/');
 

--- a/packages/ts/generator-typescript-plugin-backbone/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/index.ts
@@ -46,7 +46,7 @@ export default class BackbonePlugin extends Plugin {
       if (endpoints.has(endpointName)) {
         endpointProcessor = endpoints.get(endpointName)!;
       } else {
-        endpointProcessor = new EndpointProcessor(endpointName, this);
+        endpointProcessor = new EndpointProcessor(endpointName, this, storage.outputDir);
         endpoints.set(endpointName, endpointProcessor);
       }
 

--- a/packages/ts/generator-typescript-plugin-backbone/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/index.ts
@@ -1,5 +1,7 @@
 import Plugin from '@hilla/generator-typescript-core/Plugin.js';
 import type SharedStorage from '@hilla/generator-typescript-core/SharedStorage';
+import type { OpenAPIV3 } from 'openapi-types';
+import type { ReadonlyDeep } from 'type-fest';
 import type { SourceFile } from 'typescript';
 import EndpointProcessor from './EndpointProcessor.js';
 import { EntityProcessor } from './EntityProcessor.js';
@@ -18,8 +20,8 @@ export default class BackbonePlugin extends Plugin {
     return import.meta.url;
   }
 
-  public async execute(storage: SharedStorage): Promise<void> {
-    const endpointSourceFiles = this.#processEndpoints(storage);
+  public override async execute(storage: SharedStorage): Promise<void> {
+    const endpointSourceFiles = await this.#processEndpoints(storage);
     const entitySourceFiles = this.#processEntities(storage);
 
     endpointSourceFiles.forEach((file) => this.#tags.set(file, BackbonePluginSourceType.Endpoint));
@@ -29,31 +31,34 @@ export default class BackbonePlugin extends Plugin {
     storage.pluginStorage.set(this.constructor.BACKBONE_PLUGIN_FILE_TAGS, this.#tags);
   }
 
-  #processEndpoints(storage: SharedStorage): readonly SourceFile[] {
+  async #processEndpoints(storage: SharedStorage): Promise<readonly SourceFile[]> {
     this.logger.debug('Processing endpoints');
-    const endpoints = new Map<string, EndpointProcessor>();
+    const endpoints = new Map<string, Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>>();
 
-    for (const [path, pathItem] of Object.entries(storage.api.paths)) {
-      if (!pathItem) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
+    Object.entries(storage.api.paths)
+      .filter(([, pathItem]) => Boolean(pathItem))
+      .forEach(([path, pathItem]) => {
+        const [, endpointName, endpointMethodName] = path.split('/');
 
-      const [, endpointName, endpointMethodName] = path.split('/');
+        let methods: Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>;
 
-      let endpointProcessor: EndpointProcessor;
+        if (endpoints.has(endpointName)) {
+          methods = endpoints.get(endpointName)!;
+        } else {
+          methods = new Map();
+          endpoints.set(endpointName, methods);
+        }
 
-      if (endpoints.has(endpointName)) {
-        endpointProcessor = endpoints.get(endpointName)!;
-      } else {
-        endpointProcessor = new EndpointProcessor(endpointName, this, storage.outputDir);
-        endpoints.set(endpointName, endpointProcessor);
-      }
+        methods.set(endpointMethodName, pathItem!);
+      });
 
-      endpointProcessor.add(endpointMethodName, pathItem);
-    }
+    const processors = await Promise.all(
+      [...endpoints.entries()].map(([endpointName, methods]) =>
+        EndpointProcessor.create(endpointName, this, methods, storage.outputDir),
+      ),
+    );
 
-    return Array.from(endpoints.values(), (processor) => processor.process());
+    return Promise.all(processors.map((processor) => processor.process()));
   }
 
   #processEntities(storage: SharedStorage): readonly SourceFile[] {

--- a/packages/ts/generator-typescript-plugin-backbone/test/custom-client/CustomClient.json
+++ b/packages/ts/generator-typescript-plugin-backbone/test/custom-client/CustomClient.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Vaadin Application",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/CustomClientEndpoint/getString": {
+      "post": {
+        "tags": ["CustomClientEndpoint"],
+        "operationId": "CustomClientEndpoint_getString_POST",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/ts/generator-typescript-plugin-backbone/test/custom-client/CustomClient.spec.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/custom-client/CustomClient.spec.ts
@@ -2,6 +2,7 @@
 import ClientPlugin from '@hilla/generator-typescript-plugin-client';
 import snapshotMatcher from '@hilla/generator-typescript-utils/testing/snapshotMatcher.js';
 import { expect, use } from 'chai';
+import path from 'path';
 import sinonChai from 'sinon-chai';
 import BackbonePlugin from '../../src/index.js';
 import { createGenerator, loadInput } from '../utils/common.js';
@@ -14,7 +15,7 @@ describe('BackbonePlugin', () => {
     const sectionName = 'CustomClient';
 
     it('correctly generates code', async () => {
-      const generator = createGenerator([BackbonePlugin, ClientPlugin], import.meta.url.replace(/[\w.]+$/, 'fixtures'));
+      const generator = createGenerator([BackbonePlugin, ClientPlugin], path.join(import.meta.url, '../fixtures'));
       const input = await loadInput(sectionName, import.meta.url);
       const files = await generator.process(input);
       expect(files.length).to.equal(1);

--- a/packages/ts/generator-typescript-plugin-backbone/test/custom-client/CustomClient.spec.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/custom-client/CustomClient.spec.ts
@@ -1,0 +1,27 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import ClientPlugin from '@hilla/generator-typescript-plugin-client';
+import snapshotMatcher from '@hilla/generator-typescript-utils/testing/snapshotMatcher.js';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import BackbonePlugin from '../../src/index.js';
+import { createGenerator, loadInput } from '../utils/common.js';
+
+use(sinonChai);
+use(snapshotMatcher);
+
+describe('BackbonePlugin', () => {
+  context('when a custom client file is available', () => {
+    const sectionName = 'CustomClient';
+
+    it('correctly generates code', async () => {
+      const generator = createGenerator([BackbonePlugin, ClientPlugin], import.meta.url.replace(/[\w.]+$/, 'fixtures'));
+      const input = await loadInput(sectionName, import.meta.url);
+      const files = await generator.process(input);
+      expect(files.length).to.equal(1);
+
+      const [endpointFile] = files;
+      await expect(await endpointFile.text()).toMatchSnapshot(`${sectionName}Endpoint`, import.meta.url);
+      expect(endpointFile.name).to.equal(`${sectionName}Endpoint.ts`);
+    });
+  });
+});

--- a/packages/ts/generator-typescript-plugin-backbone/test/custom-client/connect-client.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/custom-client/connect-client.ts
@@ -1,0 +1,1 @@
+// custom connect client

--- a/packages/ts/generator-typescript-plugin-backbone/test/custom-client/fixtures/CustomClientEndpoint.snap.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/custom-client/fixtures/CustomClientEndpoint.snap.ts
@@ -1,0 +1,4 @@
+import { EndpointRequestInit as EndpointRequestInit_1 } from "@hilla/frontend";
+import client_1 from "../connect-client";
+async function getString_1(init?: EndpointRequestInit_1): Promise<string | undefined> { return client_1.call("CustomClientEndpoint", "getString", {}, init); }
+export { getString_1 as getString };

--- a/packages/ts/generator-typescript-plugin-backbone/test/utils/common.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/utils/common.ts
@@ -6,8 +6,8 @@ import { URL } from 'url';
 
 export const pathBase = 'dev/hilla/parser/plugins/backbone';
 
-export function createGenerator(plugins: readonly PluginConstructor[]): Generator {
-  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test', verbose: true }));
+export function createGenerator(plugins: readonly PluginConstructor[], outputDir: string): Generator {
+  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test', verbose: true }), outputDir);
 }
 
 export async function loadInput(name: string, importMeta: string): Promise<string> {

--- a/packages/ts/generator-typescript-plugin-backbone/test/utils/common.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/utils/common.ts
@@ -6,7 +6,7 @@ import { URL } from 'url';
 
 export const pathBase = 'dev/hilla/parser/plugins/backbone';
 
-export function createGenerator(plugins: readonly PluginConstructor[], outputDir: string): Generator {
+export function createGenerator(plugins: readonly PluginConstructor[], outputDir?: string): Generator {
   return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test', verbose: true }), outputDir);
 }
 

--- a/packages/ts/generator-typescript-plugin-backbone/test/utils/common.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/utils/common.ts
@@ -7,7 +7,7 @@ import { URL } from 'url';
 export const pathBase = 'dev/hilla/parser/plugins/backbone';
 
 export function createGenerator(plugins: readonly PluginConstructor[], outputDir?: string): Generator {
-  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test', verbose: true }), outputDir);
+  return new Generator(plugins, { logger: new LoggerFactory({ name: 'tsgen-test', verbose: true }), outputDir });
 }
 
 export async function loadInput(name: string, importMeta: string): Promise<string> {

--- a/packages/ts/generator-typescript-plugin-barrel/test/basic/BasicBarrel.spec.ts
+++ b/packages/ts/generator-typescript-plugin-barrel/test/basic/BasicBarrel.spec.ts
@@ -16,10 +16,9 @@ describe('BarrelPlugin', () => {
   const sectionName = 'BasicBarrel';
 
   it('correctly generates code', async () => {
-    const generator = new Generator(
-      [BackbonePlugin, BarrelPlugin],
-      new LoggerFactory({ name: 'barrel-plugin-test', verbose: true }),
-    );
+    const generator = new Generator([BackbonePlugin, BarrelPlugin], {
+      logger: new LoggerFactory({ name: 'barrel-plugin-test', verbose: true }),
+    });
     const input = await readFile(new URL(`./${sectionName}.json`, import.meta.url), 'utf8');
     const files = await generator.process(input);
 

--- a/packages/ts/generator-typescript-plugin-client/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-client/src/index.ts
@@ -24,7 +24,7 @@ export default class ClientPlugin extends Plugin {
 
   private static async checkForCustomClientFile(path?: string): Promise<boolean> {
     const dir = path && path.startsWith('file:') ? fileURLToPath(path) : path;
-    return Boolean(dir && (await open(`${dir}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`, 'r')));
+    return !!(dir && (await open(`${dir}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`, 'r')));
   }
 
   public static async getClientFileName(path?: string): Promise<string> {

--- a/packages/ts/generator-typescript-plugin-client/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-client/src/index.ts
@@ -27,7 +27,7 @@ export default class ClientPlugin extends Plugin {
     return Boolean(dir && (await open(`${dir}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`, 'r')));
   }
 
-  public static async clientFileName(path?: string): Promise<string> {
+  public static async getClientFileName(path?: string): Promise<string> {
     return (await ClientPlugin.checkForCustomClientFile(path))
       ? ClientPlugin.CUSTOM_CLIENT_FILE_NAME
       : ClientPlugin.CLIENT_FILE_NAME;

--- a/packages/ts/generator-typescript-plugin-client/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-client/src/index.ts
@@ -22,7 +22,11 @@ export default class ClientPlugin extends Plugin {
   }
 
   public static clientFile(path: string): { name: string; custom: boolean } {
-    return path && existsSync(fileURLToPath(`${path}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`))
+    if (path && path.startsWith('file:')) {
+      path = fileURLToPath(path);
+    }
+
+    return path && existsSync(`${path}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`)
       ? { name: ClientPlugin.CUSTOM_CLIENT_FILE_NAME, custom: true }
       : { name: ClientPlugin.CLIENT_FILE_NAME, custom: false };
   }

--- a/packages/ts/generator-typescript-plugin-client/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-client/src/index.ts
@@ -1,9 +1,12 @@
 import Plugin from '@hilla/generator-typescript-core/Plugin.js';
 import type SharedStorage from '@hilla/generator-typescript-core/SharedStorage.js';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
 import ClientProcessor from './ClientProcessor.js';
 
 export default class ClientPlugin extends Plugin {
   public static readonly CLIENT_FILE_NAME = 'connect-client.default';
+  public static readonly CUSTOM_CLIENT_FILE_NAME = '../connect-client';
 
   public declare ['constructor']: typeof ClientPlugin;
 
@@ -11,8 +14,16 @@ export default class ClientPlugin extends Plugin {
     return import.meta.url;
   }
 
-  public override async execute({ sources }: SharedStorage): Promise<void> {
-    const clientFile = new ClientProcessor(this.constructor.CLIENT_FILE_NAME, this).process();
-    sources.push(clientFile);
+  public override async execute({ sources, outputDir }: SharedStorage): Promise<void> {
+    if (!ClientPlugin.clientFile(outputDir).custom) {
+      const clientFile = new ClientProcessor(this.constructor.CLIENT_FILE_NAME, this).process();
+      sources.push(clientFile);
+    }
+  }
+
+  public static clientFile(path: string): { name: string; custom: boolean } {
+    return path && existsSync(fileURLToPath(`${path}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`))
+      ? { name: ClientPlugin.CUSTOM_CLIENT_FILE_NAME, custom: true }
+      : { name: ClientPlugin.CLIENT_FILE_NAME, custom: false };
   }
 }

--- a/packages/ts/generator-typescript-plugin-client/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-client/src/index.ts
@@ -15,18 +15,17 @@ export default class ClientPlugin extends Plugin {
   }
 
   public override async execute({ sources, outputDir }: SharedStorage): Promise<void> {
-    if (!ClientPlugin.clientFile(outputDir).custom) {
+    // the client file is created only if a custom client file is not found
+    if (!(outputDir && ClientPlugin.clientFile(outputDir).custom)) {
       const clientFile = new ClientProcessor(this.constructor.CLIENT_FILE_NAME, this).process();
       sources.push(clientFile);
     }
   }
 
-  public static clientFile(path: string): { name: string; custom: boolean } {
-    if (path && path.startsWith('file:')) {
-      path = fileURLToPath(path);
-    }
+  public static clientFile(path?: string): { name: string; custom: boolean } {
+    const dir = path && path.startsWith('file:') ? fileURLToPath(path) : path;
 
-    return path && existsSync(`${path}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`)
+    return dir && existsSync(`${dir}/${ClientPlugin.CUSTOM_CLIENT_FILE_NAME}.ts`)
       ? { name: ClientPlugin.CUSTOM_CLIENT_FILE_NAME, custom: true }
       : { name: ClientPlugin.CLIENT_FILE_NAME, custom: false };
   }

--- a/packages/ts/generator-typescript-plugin-client/test/basic/BasicClient.spec.ts
+++ b/packages/ts/generator-typescript-plugin-client/test/basic/BasicClient.spec.ts
@@ -14,7 +14,9 @@ describe('ClientPlugin', () => {
   const sectionName = 'BasicClient';
 
   it('correctly generates code', async () => {
-    const generator = new Generator([ClientPlugin], new LoggerFactory({ name: 'client-plugin-test', verbose: true }));
+    const generator = new Generator([ClientPlugin], {
+      logger: new LoggerFactory({ name: 'client-plugin-test', verbose: true }),
+    });
     const input = await readFile(new URL(`./${sectionName}.json`, import.meta.url), 'utf8');
     const files = await generator.process(input);
 

--- a/packages/ts/generator-typescript-plugin-client/test/basic/BasicClient.spec.ts
+++ b/packages/ts/generator-typescript-plugin-client/test/basic/BasicClient.spec.ts
@@ -14,7 +14,11 @@ describe('ClientPlugin', () => {
   const sectionName = 'BasicClient';
 
   it('correctly generates code', async () => {
-    const generator = new Generator([ClientPlugin], new LoggerFactory({ name: 'client-plugin-test', verbose: true }));
+    const generator = new Generator(
+      [ClientPlugin],
+      new LoggerFactory({ name: 'client-plugin-test', verbose: true }),
+      '',
+    );
     const input = await readFile(new URL(`./${sectionName}.json`, import.meta.url), 'utf8');
     const files = await generator.process(input);
 

--- a/packages/ts/generator-typescript-plugin-client/test/basic/BasicClient.spec.ts
+++ b/packages/ts/generator-typescript-plugin-client/test/basic/BasicClient.spec.ts
@@ -14,11 +14,7 @@ describe('ClientPlugin', () => {
   const sectionName = 'BasicClient';
 
   it('correctly generates code', async () => {
-    const generator = new Generator(
-      [ClientPlugin],
-      new LoggerFactory({ name: 'client-plugin-test', verbose: true }),
-      '',
-    );
+    const generator = new Generator([ClientPlugin], new LoggerFactory({ name: 'client-plugin-test', verbose: true }));
     const input = await readFile(new URL(`./${sectionName}.json`, import.meta.url), 'utf8');
     const files = await generator.process(input);
 

--- a/packages/ts/generator-typescript-plugin-model/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/index.ts
@@ -18,7 +18,7 @@ export default class ModelPlugin extends Plugin {
     return import.meta.url;
   }
 
-  public async execute(storage: SharedStorage): Promise<void> {
+  public override async execute(storage: SharedStorage): Promise<void> {
     const files = this.#processEntities(storage.api.components?.schemas);
     files.forEach((file) => this.#tags.set(file, ModelPluginSourceType.Model));
     storage.sources.push(...files);

--- a/packages/ts/generator-typescript-plugin-model/test/model/Model.spec.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/Model.spec.ts
@@ -27,7 +27,9 @@ describe('FormPlugin', () => {
         'FormNonnullTypesModel',
       ];
 
-      const generator = new Generator([ModelPlugin], new LoggerFactory({ name: 'model-plugin-test', verbose: true }));
+      const generator = new Generator([ModelPlugin], {
+        logger: new LoggerFactory({ name: 'model-plugin-test', verbose: true }),
+      });
       const input = await readFile(new URL('./Model.json', import.meta.url), 'utf8');
       const files = await generator.process(input);
       expect(files.length).to.equal(modelNames.length);

--- a/packages/ts/generator-typescript-plugin-model/test/model/Model.spec.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/Model.spec.ts
@@ -27,11 +27,7 @@ describe('FormPlugin', () => {
         'FormNonnullTypesModel',
       ];
 
-      const generator = new Generator(
-        [ModelPlugin],
-        new LoggerFactory({ name: 'model-plugin-test', verbose: true }),
-        '',
-      );
+      const generator = new Generator([ModelPlugin], new LoggerFactory({ name: 'model-plugin-test', verbose: true }));
       const input = await readFile(new URL('./Model.json', import.meta.url), 'utf8');
       const files = await generator.process(input);
       expect(files.length).to.equal(modelNames.length);

--- a/packages/ts/generator-typescript-plugin-model/test/model/Model.spec.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/Model.spec.ts
@@ -27,7 +27,11 @@ describe('FormPlugin', () => {
         'FormNonnullTypesModel',
       ];
 
-      const generator = new Generator([ModelPlugin], new LoggerFactory({ name: 'model-plugin-test', verbose: true }));
+      const generator = new Generator(
+        [ModelPlugin],
+        new LoggerFactory({ name: 'model-plugin-test', verbose: true }),
+        '',
+      );
       const input = await readFile(new URL('./Model.json', import.meta.url), 'utf8');
       const files = await generator.process(input);
       expect(files.length).to.equal(modelNames.length);

--- a/packages/ts/generator-typescript-plugin-push/src/index.ts
+++ b/packages/ts/generator-typescript-plugin-push/src/index.ts
@@ -39,7 +39,7 @@ export default class PushPlugin extends Plugin {
     return import.meta.url;
   }
 
-  async execute(storage: SharedStorage): Promise<void> {
+  public override async execute(storage: SharedStorage): Promise<void> {
     const { api, sources } = storage;
     const endpointMethodMap = this.constructor.#collectPatchableMethods(api.paths);
 

--- a/packages/ts/generator-typescript-plugin-push/test/utils/common.ts
+++ b/packages/ts/generator-typescript-plugin-push/test/utils/common.ts
@@ -7,7 +7,7 @@ import { URL } from 'url';
 export const pathBase = 'dev/hilla/parser/plugins/push';
 
 export function createGenerator(plugins: readonly PluginConstructor[]): Generator {
-  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test-push', verbose: true }));
+  return new Generator(plugins, { logger: new LoggerFactory({ name: 'tsgen-test-push', verbose: true }) });
 }
 
 export async function loadInput(name: string, importMeta: string): Promise<string> {

--- a/packages/ts/generator-typescript-plugin-push/test/utils/common.ts
+++ b/packages/ts/generator-typescript-plugin-push/test/utils/common.ts
@@ -7,7 +7,7 @@ import { URL } from 'url';
 export const pathBase = 'dev/hilla/parser/plugins/push';
 
 export function createGenerator(plugins: readonly PluginConstructor[]): Generator {
-  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test-push', verbose: true }), '');
+  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test-push', verbose: true }));
 }
 
 export async function loadInput(name: string, importMeta: string): Promise<string> {

--- a/packages/ts/generator-typescript-plugin-push/test/utils/common.ts
+++ b/packages/ts/generator-typescript-plugin-push/test/utils/common.ts
@@ -7,7 +7,7 @@ import { URL } from 'url';
 export const pathBase = 'dev/hilla/parser/plugins/push';
 
 export function createGenerator(plugins: readonly PluginConstructor[]): Generator {
-  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test-push', verbose: true }));
+  return new Generator(plugins, new LoggerFactory({ name: 'tsgen-test-push', verbose: true }), '');
 }
 
 export async function loadInput(name: string, importMeta: string): Promise<string> {


### PR DESCRIPTION
Adds a check to verify if a file named `frontend/connect-client.ts` exists, just like in the single-module generator.

Fixes #485