### PR TITLE
fix: update Lit version in root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
-      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.0.tgz",
+      "integrity": "sha512-blrtlLKvtVyjTJ3gUHWNSHOU6tD8be9mRafqtnO7GVMcB+5z4RjNcO0DpMGmccK6N8yur1vVVYnS0gPdQ/WgEQ=="
     },
     "node_modules/@mdn/browser-compat-data": {
       "version": "4.2.1",
@@ -10561,13 +10561,13 @@
       "dev": true
     },
     "node_modules/lit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.5.tgz",
-      "integrity": "sha512-Ln463c0xJZfzVxBcHddNvFQQ8Z22NK7KgNmrzwFF1iESHUud412RRExzepj18wpTbusgwoTnOYuoTpo9uyNBaQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
       "dependencies": {
-        "@lit/reactive-element": "^1.3.0",
+        "@lit/reactive-element": "^1.4.0",
         "lit-element": "^3.2.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.3.0"
       }
     },
     "node_modules/lit-element": {
@@ -10595,9 +10595,9 @@
       }
     },
     "node_modules/lit/node_modules/lit-html": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.5.tgz",
-      "integrity": "sha512-e56Y9V+RNA+SGYsWP2DGb/wad5Ccd3xUZYjmcmbeZcnc0wP4zFQRXeXn7W3bbfBekmHDK2dOnuYNYkg0bQjh/w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.3.0.tgz",
+      "integrity": "sha512-bnJneRqizoeSTxUeyDJLBDr+DI+7bn6P3WWqsj/4AwPWJjYgjSO5W64BVl1CrEo/8DtgU6DAYADX6yeI5/eDsg==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -17829,9 +17829,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
-      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.0.tgz",
+      "integrity": "sha512-blrtlLKvtVyjTJ3gUHWNSHOU6tD8be9mRafqtnO7GVMcB+5z4RjNcO0DpMGmccK6N8yur1vVVYnS0gPdQ/WgEQ=="
     },
     "@mdn/browser-compat-data": {
       "version": "4.2.1",
@@ -24515,13 +24515,13 @@
       }
     },
     "lit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.5.tgz",
-      "integrity": "sha512-Ln463c0xJZfzVxBcHddNvFQQ8Z22NK7KgNmrzwFF1iESHUud412RRExzepj18wpTbusgwoTnOYuoTpo9uyNBaQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
       "requires": {
-        "@lit/reactive-element": "^1.3.0",
+        "@lit/reactive-element": "^1.4.0",
         "lit-element": "^3.2.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.3.0"
       },
       "dependencies": {
         "lit-element": {
@@ -24534,9 +24534,9 @@
           }
         },
         "lit-html": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.5.tgz",
-          "integrity": "sha512-e56Y9V+RNA+SGYsWP2DGb/wad5Ccd3xUZYjmcmbeZcnc0wP4zFQRXeXn7W3bbfBekmHDK2dOnuYNYkg0bQjh/w==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.3.0.tgz",
+          "integrity": "sha512-bnJneRqizoeSTxUeyDJLBDr+DI+7bn6P3WWqsj/4AwPWJjYgjSO5W64BVl1CrEo/8DtgU6DAYADX6yeI5/eDsg==",
           "requires": {
             "@types/trusted-types": "^2.0.2"
           }


### PR DESCRIPTION
As Flow tries to upgrade Lit to 2.3.0, some tests fail due to version mismatch with peer dependencies in the root. Allowing those versions to update fixes those errors.