### PR TITLE
fix: remove the `undefined` return type for Flux endpoint methods

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/generator/typescript/CodeGenerator.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/generator/typescript/CodeGenerator.java
@@ -318,8 +318,8 @@ public class CodeGenerator extends AbstractTypeScriptClientCodegen {
             Schema inner = arraySchema.getItems();
             if (schema.getExtensions() != null
                     && schema.getExtensions().containsKey("x-flux")) {
-                return String.format("Subscription<%s>%s",
-                        this.getTypeDeclaration(inner), optionalSuffix);
+                return String.format("Subscription<%s>",
+                        this.getTypeDeclaration(inner));
             } else {
                 return String.format("Array<%s>%s",
                         this.getTypeDeclaration(inner), optionalSuffix);

--- a/packages/java/endpoint/src/test/resources/dev/hilla/generator/endpoints/flux/expected-FluxTestEndpoint.ts
+++ b/packages/java/endpoint/src/test/resources/dev/hilla/generator/endpoints/flux/expected-FluxTestEndpoint.ts
@@ -23,7 +23,7 @@ Subscription<User> {
 * Return a list of users
 */
 function _getAllUsers():
-Subscription<User | undefined> | undefined {
+Subscription<User | undefined> {
   return client.subscribe (
     'FluxTestEndpoint', 'getAllUsers',{}
   );


### PR DESCRIPTION
Change the source-based generator code to never return `undefined` for endpoint methods that call `client.subscribe`.

Note: this fix is an API change.

Fixes #484