### PR TITLE
Check if the number of digits is less or equal the value of the integer attribute

### DIFF
--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -307,7 +307,7 @@ export class Digits extends AbstractValidator<string> {
 
   public override validate(value: any) {
     return (
-      String(toFloat(`${value}`)).replace(/(.*)\.\d+/, '$1').length === this.integer &&
+      String(toFloat(`${value}`)).replace(/(.*)\.\d+/, '$1').length <= this.integer &&
       isDecimal(`${value}`, { decimal_digits: `0,${this.fraction}` })
     );
   }

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -241,7 +241,10 @@ describe('form/Validators', () => {
     const validator = new Digits({ integer: 2, fraction: 3 });
     assert.isNotTrue(validator.impliesRequired);
     assert.isTrue(validator.validate('11.111'));
-    assert.isFalse(validator.validate('1.1'));
+    assert.isTrue(validator.validate('1.1'));
+    assert.isTrue(validator.validate('1'));
+    assert.isFalse(validator.validate('1.1111'));
+    assert.isFalse(validator.validate('111.111'));
     assert.isFalse(validator.validate('111.1111'));
   });
 


### PR DESCRIPTION
According to https://jakarta.ee/specifications/platform/8/apidocs/javax/validation/constraints/digits the attribute integer defines the maximum number of integral digits accepted for this number.

Fixes #513 #514 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
