### PR TITLE
Fix non-null check

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/generator/GeneratorType.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/generator/GeneratorType.java
@@ -148,20 +148,19 @@ class GeneratorType {
         if (isPrimitive()) {
             return true;
         }
-        if (!hasType()) {
-            return false;
-        }
         List<AnnotationExpr> allAnnotations = new ArrayList<>();
-        List<AnnotationExpr> typeAnnotations = type.getAnnotations();
-        if (typeAnnotations != null) {
-            allAnnotations.addAll(typeAnnotations);
+        if (type != null) {
+            List<AnnotationExpr> typeAnnotations = type.getAnnotations();
+            if (typeAnnotations != null) {
+                allAnnotations.addAll(typeAnnotations);
+            }
         }
         if (additionalAnnotations != null) {
             allAnnotations.addAll(additionalAnnotations);
         }
 
-        return hasType() && ExplicitNullableTypeChecker
-                .isRequired(requiredByContext, allAnnotations);
+        return ExplicitNullableTypeChecker.isRequired(requiredByContext,
+                allAnnotations);
     }
 
     boolean isString() {

--- a/packages/java/endpoint/src/main/java/dev/hilla/generator/OpenAPIObjectGenerator.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/generator/OpenAPIObjectGenerator.java
@@ -852,16 +852,10 @@ public class OpenAPIObjectGenerator {
             boolean requiredByContext) {
         ResolvedType mappedType = toMappedType(type);
 
-        if (mappedType != null) {
-            resolvedType = mappedType;
-            return new GeneratorType(
-                    resolvedTypeParametersMap.replaceAll(resolvedType),
-                    requiredByContext);
-        } else {
-            return new GeneratorType(type,
-                    resolvedTypeParametersMap.replaceAll(resolvedType),
-                    requiredByContext);
-        }
+        return new GeneratorType(type,
+                resolvedTypeParametersMap.replaceAll(
+                        mappedType == null ? resolvedType : mappedType),
+                requiredByContext);
     }
 
     @SuppressWarnings("squid:S1872")

--- a/packages/java/endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullable/NonNullableEndpoint.java
+++ b/packages/java/endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullable/NonNullableEndpoint.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 import dev.hilla.Endpoint;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
 
 @Endpoint
 public class NonNullableEndpoint {
@@ -68,6 +70,11 @@ public class NonNullableEndpoint {
 
     public String stringNullable() {
         return "";
+    }
+
+    @dev.hilla.Nonnull
+    public Page<@dev.hilla.Nonnull String> returnNonnullMappedType() {
+        return Mockito.mock(Page.class);
     }
 
     public static class NonNullableModel {

--- a/packages/java/endpoint/src/test/resources/dev/hilla/generator/endpoints/nonnullable/expected-NonNullableEndpoint.ts
+++ b/packages/java/endpoint/src/test/resources/dev/hilla/generator/endpoints/nonnullable/expected-NonNullableEndpoint.ts
@@ -56,7 +56,7 @@ function _getNotNullReturnType(__init?: EndpointRequestInit): Promise<ReturnType
   return client.call('NonNullableEndpoint', 'getNotNullReturnType', {}, __init);
 }
 
-function _returnNonnullMappedType(__init?: EndpointRequestInit): Promise<Array<string | undefined>> {
+function _returnNonnullMappedType(__init?: EndpointRequestInit): Promise<Array<string>> {
   return client.call('NonNullableEndpoint', 'returnNonnullMappedType', {}, __init);
 }
 

--- a/packages/java/endpoint/src/test/resources/dev/hilla/generator/endpoints/nonnullable/expected-NonNullableEndpoint.ts
+++ b/packages/java/endpoint/src/test/resources/dev/hilla/generator/endpoints/nonnullable/expected-NonNullableEndpoint.ts
@@ -56,6 +56,10 @@ function _getNotNullReturnType(__init?: EndpointRequestInit): Promise<ReturnType
   return client.call('NonNullableEndpoint', 'getNotNullReturnType', {}, __init);
 }
 
+function _returnNonnullMappedType(__init?: EndpointRequestInit): Promise<Array<string | undefined>> {
+  return client.call('NonNullableEndpoint', 'returnNonnullMappedType', {}, __init);
+}
+
 function _sendParameterType(
   parameterType: ParameterType | undefined,
   __init?: EndpointRequestInit
@@ -75,6 +79,7 @@ export {
   _getNonNullableIndex as getNonNullableIndex,
   _getNonNullableString as getNonNullableString,
   _getNotNullReturnType as getNotNullReturnType,
+  _returnNonnullMappedType as returnNonnullMappedType,
   _sendParameterType as sendParameterType,
   _stringNullable as stringNullable,
 };


### PR DESCRIPTION
Fix how the check is performed to restore the old behavior and always honors `additionalAnnotations`.

Fixes #523