### PR TITLE
fix(parser-jvm-plugin-nonnull): add default constructor to make AnnotationMatcher usable in Maven config

### DIFF
--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/AnnotationMatcher.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/AnnotationMatcher.java
@@ -12,11 +12,19 @@ public final class AnnotationMatcher {
     /**
      * A default annotation, which corresponds to not having any annotation
      */
-    public static final AnnotationMatcher DEFAULT = new AnnotationMatcher(
-            "(default)", true, 0);
+    public static final AnnotationMatcher DEFAULT = new AnnotationMatcher();
     private final boolean makesNullable;
     private final String name;
     private final int score;
+
+    /**
+     * A default annotation, which corresponds to not having any annotation
+     */
+    public AnnotationMatcher() {
+        this.name = "(default)";
+        this.makesNullable = true;
+        this.score = 0;
+    }
 
     public AnnotationMatcher(@Nonnull String name, boolean makesNullable,
             int score) {


### PR DESCRIPTION
For now, you cannot specify annotation for `NonnullPlugin` using the `pom.xml`:
```xml
<plugin>
    <groupId>dev.hilla</groupId>
    <artifactId>hilla-maven-plugin</artifactId>
    <version>${hilla.version}</version>
    <configuration>
        <parser>
            <plugins>
                <use>
                    <plugin>
                        <name>dev.hilla.parser.plugins.nonnull.NonnullPlugin</name>
                        <configuration
                                implementation="dev.hilla.parser.plugins.nonnull.NonnullPluginConfig">
                            <use>
                                <annotation>
                                    <name>com.example.application.Nonnull</name>
                                    <makesNullable>false</makesNullable>
                                    <score>30</score>
                                </annotation>
                            </use>
                        </configuration>
                    </plugin>
                </use>
            </plugins>
        </parser>
    </configuration>
    ...
</plugin>
```
It will fail because `AnnotationMatcher` does not have a default constructor.

This PR fixes the issue.