### PR TITLE
fix(parser): ignore fields annotated with JsonIgnore

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/NodeDependencies.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/NodeDependencies.java
@@ -74,13 +74,13 @@ public final class NodeDependencies {
     }
 
     @Nonnull
-    public NodeDependencies withChildNodes(
+    private NodeDependencies withChildNodes(
             @Nonnull Stream<Node<?, ?>> childNodes) {
         return new NodeDependencies(getNode(), childNodes, getRelatedNodes());
     }
 
     @Nonnull
-    public NodeDependencies withRelatedNodes(
+    private NodeDependencies withRelatedNodes(
             @Nonnull Stream<Node<?, ?>> relatedNodes) {
         return new NodeDependencies(getNode(), getChildNodes(), relatedNodes);
     }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/NodeDependencies.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/NodeDependencies.java
@@ -74,13 +74,13 @@ public final class NodeDependencies {
     }
 
     @Nonnull
-    private NodeDependencies withChildNodes(
+    public NodeDependencies withChildNodes(
             @Nonnull Stream<Node<?, ?>> childNodes) {
         return new NodeDependencies(getNode(), childNodes, getRelatedNodes());
     }
 
     @Nonnull
-    private NodeDependencies withRelatedNodes(
+    public NodeDependencies withRelatedNodes(
             @Nonnull Stream<Node<?, ?>> relatedNodes) {
         return new NodeDependencies(getNode(), getChildNodes(), relatedNodes);
     }

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/BackbonePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/BackbonePlugin.java
@@ -9,6 +9,6 @@ public final class BackbonePlugin
     public BackbonePlugin() {
         super(new EndpointPlugin(), new MethodPlugin(),
                 new MethodParameterPlugin(), new EntityPlugin(),
-                new FieldPlugin(), new TypeSignaturePlugin());
+                new FieldPlugin(), new TypeSignaturePlugin(), new JSONPlugin());
     }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
@@ -19,6 +19,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class JSONPlugin extends AbstractPlugin<PluginConfiguration> {
+
+    public static final String JSON_IGNORE = JsonIgnore.class.getName();
+
+    public static final String JSON_IGNORE_PROPERTIES = JsonIgnoreProperties.class
+            .getName();
+
     @Override
     @Nonnull
     public NodeDependencies scan(@Nonnull NodeDependencies nodeDependencies) {
@@ -35,13 +41,12 @@ public class JSONPlugin extends AbstractPlugin<PluginConfiguration> {
         var ignoredByAnnotation = cls.getFieldsStream()
                 .filter(f -> f.getAnnotations().stream()
                         .map(AnnotationInfoModel::getName)
-                        .anyMatch(n -> n.equals(JsonIgnore.class.getName())))
+                        .anyMatch(n -> n.equals(JSON_IGNORE)))
                 .map(FieldInfoModel::getName);
 
         // Find the JsonIgnoreProperties and get list of ignored fields
         var ignoredByClassAnnotation = cls.getAnnotations().stream()
-                .filter(a -> a.getName()
-                        .equals(JsonIgnoreProperties.class.getName()))
+                .filter(a -> a.getName().equals(JSON_IGNORE_PROPERTIES))
                 .flatMap(AnnotationInfoModel::getParametersStream)
                 .flatMap(p -> Arrays.stream(((Object[]) p.getValue())))
                 .map(Objects::toString);

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
@@ -1,0 +1,78 @@
+package dev.hilla.parser.plugins.backbone;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import dev.hilla.parser.core.AbstractPlugin;
+import dev.hilla.parser.core.NodeDependencies;
+import dev.hilla.parser.core.NodePath;
+import dev.hilla.parser.core.PluginConfiguration;
+import dev.hilla.parser.models.AnnotationInfoModel;
+import dev.hilla.parser.models.ClassInfoModel;
+import dev.hilla.parser.models.FieldInfoModel;
+import dev.hilla.parser.plugins.backbone.nodes.EntityNode;
+import dev.hilla.parser.plugins.backbone.nodes.FieldNode;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JSONPlugin extends AbstractPlugin<PluginConfiguration> {
+    @Override
+    @Nonnull
+    public NodeDependencies scan(@Nonnull NodeDependencies nodeDependencies) {
+        if (!(nodeDependencies.getNode() instanceof EntityNode)) {
+            return nodeDependencies;
+        }
+
+        var cls = (ClassInfoModel) nodeDependencies.getNode().getSource();
+        if (cls.isEnum()) {
+            return nodeDependencies;
+        }
+
+        // Find fields annotated with JsonIgnore
+        var ignoredByAnnotation = cls.getFieldsStream()
+                .filter(f -> f.getAnnotations().stream()
+                        .map(AnnotationInfoModel::getName)
+                        .anyMatch(n -> n.equals(JsonIgnore.class.getName())))
+                .map(FieldInfoModel::getName);
+
+        // Find the JsonIgnoreProperties and get list of ignored fields
+        var ignoredByClassAnnotation = cls.getAnnotations().stream()
+                .filter(a -> a.getName()
+                        .equals(JsonIgnoreProperties.class.getName()))
+                .flatMap(AnnotationInfoModel::getParametersStream)
+                .flatMap(p -> Arrays.stream(((Object[]) p.getValue())))
+                .map(Objects::toString);
+
+        // Build the final list of field that must be ignored according to
+        // Jackson annotations
+        var ignored = Stream
+                .concat(ignoredByAnnotation, ignoredByClassAnnotation)
+                .collect(Collectors.toSet());
+
+        // Filter out ignored fields and rebuild dependencies stream for the
+        // node
+        return nodeDependencies
+                .withChildNodes(nodeDependencies.getChildNodes().filter(n -> {
+                    if (n instanceof FieldNode) {
+                        var fieldNode = (FieldNode) n;
+
+                        if (ignored.contains(fieldNode.getSource().getName())) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }));
+    }
+
+    @Override
+    public void enter(NodePath<?> nodePath) {
+    }
+
+    @Override
+    public void exit(NodePath<?> nodePath) {
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
@@ -24,12 +24,12 @@ import java.util.stream.Stream;
 
 public class JSONPlugin extends AbstractPlugin<PluginConfiguration> {
 
-    public static final String JSON_IGNORE = JsonIgnore.class.getName();
+    private static final String JSON_IGNORE = JsonIgnore.class.getName();
 
-    public static final String JSON_IGNORE_PROPERTIES = JsonIgnoreProperties.class
+    private static final String JSON_IGNORE_PROPERTIES = JsonIgnoreProperties.class
             .getName();
 
-    public static final String JSON_IGNORE_TYPE = JsonIgnoreType.class
+    private static final String JSON_IGNORE_TYPE = JsonIgnoreType.class
             .getName();
 
     @Override

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/JSONPlugin.java
@@ -63,10 +63,9 @@ public class JSONPlugin extends AbstractPlugin<PluginConfiguration> {
                 .concat(ignoredByAnnotation, ignoredByClassAnnotation)
                 .collect(Collectors.toSet());
 
-        // Filter out ignored fields and rebuild dependencies stream for the
-        // node
+        // Filter out ignored fields
         return nodeDependencies
-                .withChildNodes(nodeDependencies.getChildNodes().filter(n -> {
+                .processChildNodes(nodeStream -> nodeStream.filter(n -> {
                     if (n instanceof FieldNode) {
                         var fieldNode = (FieldNode) n;
 

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/module-info.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/module-info.java
@@ -5,7 +5,7 @@ module dev.hilla.parser.plugins.backbone {
     requires jsr305;
     requires com.fasterxml.jackson.databind;
     requires dev.hilla.parser.utils;
-    requires dev.hilla.parser.core;
+    requires transitive dev.hilla.parser.core;
     requires org.slf4j;
 
     exports dev.hilla.parser.plugins.backbone;

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/Endpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/Endpoint.java
@@ -1,0 +1,11 @@
+package dev.hilla.parser.plugins.backbone.json;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Endpoint {
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JSONAnnotationsEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JSONAnnotationsEndpoint.java
@@ -19,5 +19,7 @@ public class JSONAnnotationsEndpoint {
         public String ignoredA;
 
         public String ignoredB;
+
+        public JsonIgnoredType ignoredType;
     }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JSONAnnotationsEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JSONAnnotationsEndpoint.java
@@ -1,0 +1,23 @@
+package dev.hilla.parser.plugins.backbone.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@Endpoint
+public class JSONAnnotationsEndpoint {
+    public AnnotatedEntity getEntity() {
+        return new AnnotatedEntity();
+    }
+
+    @JsonIgnoreProperties({ "ignoredA", "ignoredB" })
+    private static class AnnotatedEntity {
+        public String normal;
+
+        @JsonIgnore
+        public String ignored;
+
+        public String ignoredA;
+
+        public String ignoredB;
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JSONAnnotationsTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JSONAnnotationsTest.java
@@ -1,0 +1,25 @@
+package dev.hilla.parser.plugins.backbone.json;
+
+import dev.hilla.parser.core.ParserConfig;
+import dev.hilla.parser.plugins.backbone.BackbonePlugin;
+import dev.hilla.parser.plugins.backbone.test.helpers.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+public class JSONAnnotationsTest {
+    private final TestHelper helper = new TestHelper(getClass());
+
+    @Test
+    public void should_CorrectlyIgnoreFieldsBasedOnJSONAnnotations()
+            throws IOException, URISyntaxException {
+        var config = new ParserConfig.Builder()
+                .classPath(Set.of(helper.getTargetDir().toString()))
+                .endpointAnnotation(Endpoint.class.getName())
+                .addPlugin(new BackbonePlugin()).finish();
+
+        helper.executeParserWithConfig(config);
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JsonIgnoredType.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/json/JsonIgnoredType.java
@@ -1,0 +1,8 @@
+package dev.hilla.parser.plugins.backbone.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+
+@JsonIgnoreType
+public class JsonIgnoredType {
+    public String field;
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/json/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/json/openapi.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Vaadin Application",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080/connect",
+      "description": "Vaadin Backend"
+    }
+  ],
+  "tags": [
+    {
+      "name": "JSONAnnotationsEndpoint"
+    }
+  ],
+  "paths": {
+    "/JSONAnnotationsEndpoint/getEntity": {
+      "post": {
+        "tags": ["JSONAnnotationsEndpoint"],
+        "operationId": "JSONAnnotationsEndpoint_getEntity_POST",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.json.JSONAnnotationsEndpoint$AnnotatedEntity"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "dev.hilla.parser.plugins.backbone.json.JSONAnnotationsEndpoint$AnnotatedEntity": {
+        "type": "object",
+        "properties": {
+          "normal": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <license>
       <name>Apache License Version 2.0</name>
       <distribution>repo</distribution>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
   <scm>
@@ -144,7 +144,7 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.2</version>
+        <version>${jsr305.version}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger.core.v3</groupId>


### PR DESCRIPTION
To make the multi-module engine more compatible with the source-based generator, this PR excludes fields that have the `JsonIgnore` annotation, fields whose type has the `JsonIgnoreType` annotation, and also fields that are listed in the `JsonIgnoreProperties` annotation, if present.

In passing, two small corrections are made in the main `pom.xml`, feel free to revert that commit if too out of scope.

Fixes #440 
Fixes #297 (for the multi-module engine)