### PR TITLE
fix: generate default parameter names when they are not available in compiled classes

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/MethodParameterInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/MethodParameterInfoModel.java
@@ -49,6 +49,13 @@ public abstract class MethodParameterInfoModel extends AnnotatedAbstractModel
 
     public abstract int getModifiers();
 
+    /**
+     * Returns a zero-based index of the parameter in the method parameter list.
+     * 
+     * @return the index, from 0 to n-1
+     */
+    public abstract int getIndex();
+
     @Override
     public MethodInfoModel getOwner() {
         if (owner == null) {

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/MethodParameterInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/MethodParameterInfoReflectionModel.java
@@ -23,6 +23,20 @@ final class MethodParameterInfoReflectionModel extends MethodParameterInfoModel
     }
 
     @Override
+    public int getIndex() {
+        var parameters = origin.getDeclaringExecutable().getParameters();
+
+        for (var i = 0; i < parameters.length; i++) {
+            if (parameters[i].equals(origin)) {
+                return i;
+            }
+        }
+
+        throw new IllegalStateException(
+                "The parameter has not been found in the method parameter list");
+    }
+
+    @Override
     public String getName() {
         return origin.getName();
     }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/MethodParameterInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/MethodParameterInfoSourceModel.java
@@ -23,8 +23,22 @@ final class MethodParameterInfoSourceModel extends MethodParameterInfoModel
     }
 
     @Override
+    public int getIndex() {
+        var parameters = origin.getMethodInfo().getParameterInfo();
+
+        for (var i = 0; i < parameters.length; i++) {
+            if (parameters[i].equals(origin)) {
+                return i;
+            }
+        }
+
+        throw new IllegalStateException(
+                "The parameter has not been found in the method parameter list");
+    }
+
+    @Override
     public String getName() {
-        return origin.getName();
+        return origin.getName() == null ? "arg" + getIndex() : origin.getName();
     }
 
     @Override

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/MethodParameterInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/MethodParameterInfoModelTests.java
@@ -100,6 +100,13 @@ public class MethodParameterInfoModelTests {
         }
     }
 
+    @DisplayName("It should index parameters correctly")
+    @ParameterizedTest(name = ModelProvider.testNamePattern)
+    @ArgumentsSource(ModelProvider.class)
+    public void should_IndexParameters(MethodParameterInfoModel model) {
+        assertEquals(1, model.getIndex());
+    }
+
     static final class ModelProvider implements ArgumentsProvider {
         public static final String testNamePattern = "{1}";
 

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointPlugin.java
@@ -66,9 +66,9 @@ public final class EndpointPlugin extends AbstractPlugin<PluginConfiguration> {
                 .ifPresent((parameter) -> {
                     if (parameter.getName() == null) {
                         logger.info("Missing endpoint method parameter names"
-                                + "in JVM bytecode, probably because they were not enabled"
-                                + " during compilation. For Java compiler, add the "
-                                + "\"-parameters\" flag to enable those.");
+                                + " in JVM bytecode, probably because they were not enabled"
+                                + " during compilation. For the Java compiler, set the"
+                                + " \"parameters\" flag to true to enable them.");
                     }
                 });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -301,9 +301,7 @@
         <version>3.10.1</version>
         <configuration>
           <encoding>UTF-8</encoding>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
+          <parameters>true</parameters>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fixes #571 by adding a `getIndex` method in `MethodParameterInfoModel` and its subclasses, and using that method to generate missing parameter names in the form `argN`.