### PR TITLE
fix(endpoint): websocket path matching is not matching because of trailing slash

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/push/SocketIoWebsocketConfigurer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/push/SocketIoWebsocketConfigurer.java
@@ -29,7 +29,7 @@ public class SocketIoWebsocketConfigurer implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(engineIoHandler, "/HILLA/push")
+        registry.addHandler(engineIoHandler, "/HILLA/push/", "/HILLA/push")
                 .addInterceptors(engineIoHandler);
     }
 


### PR DESCRIPTION
old fusion-endpoint had trailing slash

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
