### PR TITLE
test: use VaadinWebSecurity instead of deprecated VaadinWebSecurityConfigurerAdapter

### DIFF
--- a/packages/java/tests/spring/endpoints/src/main/java/com/vaadin/flow/connect/SecurityConfig.java
+++ b/packages/java/tests/spring/endpoints/src/main/java/com/vaadin/flow/connect/SecurityConfig.java
@@ -1,15 +1,20 @@
 package com.vaadin.flow.connect;
 
-import com.vaadin.flow.spring.security.VaadinWebSecurityConfigurerAdapter;
+import com.vaadin.flow.spring.security.VaadinWebSecurity;
 
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 @EnableWebSecurity
 @Configuration
-public class SecurityConfig extends VaadinWebSecurityConfigurerAdapter {
+public class SecurityConfig extends VaadinWebSecurity {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -18,13 +23,13 @@ public class SecurityConfig extends VaadinWebSecurityConfigurerAdapter {
         setLoginView(http, "/login");
     }
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth)
-            throws Exception {
-        // Configure users and roles in memory
-        auth.inMemoryAuthentication().withUser("user").password("{noop}user")
-                .roles("USER").and().withUser("admin").password("{noop}admin")
-                .roles("ADMIN", "USER");
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService() {
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        manager.createUser(new User("user", "{noop}user",
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        manager.createUser(new User("admin", "{noop}admin",
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"))));
+        return manager;
     }
-
 }

--- a/packages/java/tests/spring/endpoints/src/main/java/com/vaadin/flow/connect/SecurityConfig.java
+++ b/packages/java/tests/spring/endpoints/src/main/java/com/vaadin/flow/connect/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig extends VaadinWebSecurity {
         manager.createUser(new User("user", "{noop}user",
                 List.of(new SimpleGrantedAuthority("ROLE_USER"))));
         manager.createUser(new User("admin", "{noop}admin",
-                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"))));
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"),
+                        new SimpleGrantedAuthority("ROLE_USER"))));
         return manager;
     }
 }

--- a/packages/java/tests/spring/security/src/main/java/com/vaadin/flow/spring/fusionsecurity/SecurityConfig.java
+++ b/packages/java/tests/spring/security/src/main/java/com/vaadin/flow/spring/fusionsecurity/SecurityConfig.java
@@ -9,25 +9,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 import com.vaadin.flow.spring.fusionsecurity.data.UserInfo;
 import com.vaadin.flow.spring.fusionsecurity.data.UserInfoRepository;
 import com.vaadin.flow.spring.security.RequestUtil;
-import com.vaadin.flow.spring.security.VaadinWebSecurityConfigurerAdapter;
+import com.vaadin.flow.spring.security.VaadinWebSecurity;
 
 @EnableWebSecurity
 @Configuration
-public class SecurityConfig extends VaadinWebSecurityConfigurerAdapter {
+public class SecurityConfig extends VaadinWebSecurity {
 
     public static String ROLE_USER = "user";
     public static String ROLE_ADMIN = "admin";
@@ -49,6 +49,7 @@ public class SecurityConfig extends VaadinWebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         // Public access
+        http.authorizeRequests().antMatchers("/public/**").permitAll();
         http.authorizeRequests().antMatchers(applyUrlMapping("/")).permitAll();
         http.authorizeRequests().antMatchers(applyUrlMapping("/form"))
                 .permitAll();
@@ -69,28 +70,25 @@ public class SecurityConfig extends VaadinWebSecurityConfigurerAdapter {
         }
     }
 
-    @Override
-    public void configure(WebSecurity web) throws Exception {
-        super.configure(web);
-        web.ignoring().antMatchers("/public/**");
-    }
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth)
-            throws Exception {
-        auth.userDetailsService(username -> {
-            UserInfo userInfo = userInfoRepository.findByUsername(username);
-            if (userInfo == null) {
-                throw new UsernameNotFoundException(
-                        "No user present with username: " + username);
-            } else {
-                return new User(userInfo.getUsername(),
-                        userInfo.getEncodedPassword(),
-                        userInfo.getRoles().stream()
-                                .map(role -> new SimpleGrantedAuthority(
-                                        "ROLE_" + role))
-                                .collect(Collectors.toList()));
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService() {
+        return new InMemoryUserDetailsManager() {
+            @Override
+            public UserDetails loadUserByUsername(String username)
+                    throws UsernameNotFoundException {
+                UserInfo userInfo = userInfoRepository.findByUsername(username);
+                if (userInfo == null) {
+                    throw new UsernameNotFoundException(
+                            "No user present with username: " + username);
+                } else {
+                    return new User(userInfo.getUsername(),
+                            userInfo.getEncodedPassword(),
+                            userInfo.getRoles().stream()
+                                    .map(role -> new SimpleGrantedAuthority(
+                                            "ROLE_" + role))
+                                    .collect(Collectors.toList()));
+                }
             }
-        });
+        };
     }
 }


### PR DESCRIPTION
## Description

This PR refactors some of the integration tests to get them extended from `VaadinWebSecurity` which is officially advised for use instead of the deprecated `VaadinWebSecurityConfigurerAdapter` class.

This change is required for #599 to prevent a circular reference that otherwise emerges when using Spring Security 6.

Part of https://github.com/vaadin/flow/issues/14785

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
