### PR TITLE
chore: set the POM version to 2.0-SNAPSHOT

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>hilla-project</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>endpoint</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <name>Hilla Endpoint</name>
     <packaging>jar</packaging>
 

--- a/packages/java/engine-runtime/pom.xml
+++ b/packages/java/engine-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-core/pom.xml
+++ b/packages/java/parser-jvm-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-plugin-backbone/pom.xml
+++ b/packages/java/parser-jvm-plugin-backbone/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-plugin-model/pom.xml
+++ b/packages/java/parser-jvm-plugin-model/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-plugin-nonnull/pom.xml
+++ b/packages/java/parser-jvm-plugin-nonnull/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-plugin-transfertypes/pom.xml
+++ b/packages/java/parser-jvm-plugin-transfertypes/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-test-utils/pom.xml
+++ b/packages/java/parser-jvm-test-utils/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/parser-jvm-utils/pom.xml
+++ b/packages/java/parser-jvm-utils/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/runtime-plugin-transfertypes/pom.xml
+++ b/packages/java/runtime-plugin-transfertypes/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/tests/csrf-context/pom.xml
+++ b/packages/java/tests/csrf-context/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>tests</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tests-csrf-context</artifactId>

--- a/packages/java/tests/csrf/pom.xml
+++ b/packages/java/tests/csrf/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>tests</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tests-csrf</artifactId>

--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla-project</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/java/tests/spring/endpoints-custom-client/pom.xml
+++ b/packages/java/tests/spring/endpoints-custom-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-endpoints-custom-client</artifactId>
     <name>ITs for Endpoints / custom client</name>

--- a/packages/java/tests/spring/endpoints-latest-java/pom.xml
+++ b/packages/java/tests/spring/endpoints-latest-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-endpoints-latest-java</artifactId>
     <name>ITs for Endpoints / latest Java</name>

--- a/packages/java/tests/spring/endpoints/pom.xml
+++ b/packages/java/tests/spring/endpoints/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-endpoints</artifactId>
     <name>ITs for Endpoints</name>

--- a/packages/java/tests/spring/pom.xml
+++ b/packages/java/tests/spring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.hilla</groupId>
     <artifactId>tests</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>tests-spring</artifactId>

--- a/packages/java/tests/spring/security-contextpath/pom.xml
+++ b/packages/java/tests/spring/security-contextpath/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-security-contextpath</artifactId>
     <name>ITs for Vaadin Spring Security and Hilla / context path</name>

--- a/packages/java/tests/spring/security-jwt/pom.xml
+++ b/packages/java/tests/spring/security-jwt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-security-jwt</artifactId>
     <name>ITs for Vaadin Spring Security and Hilla / JWT</name>

--- a/packages/java/tests/spring/security-urlmapping/pom.xml
+++ b/packages/java/tests/spring/security-urlmapping/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-security-urlmapping</artifactId>
     <name>ITs for Vaadin Spring Security and Hilla / URL mapping</name>

--- a/packages/java/tests/spring/security/pom.xml
+++ b/packages/java/tests/spring/security/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.hilla</groupId>
         <artifactId>tests-spring</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <artifactId>tests-spring-security</artifactId>
     <name>ITs for Vaadin Spring Security and Hilla</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>dev.hilla</groupId>
   <artifactId>hilla-project</artifactId>
-  <version>1.3-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <name>Hilla</name>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
## Description

This PR sets `2.0-SNAPSHOT` as the current POM version for the `main` branch.

Part of https://github.com/vaadin/flow/issues/14785

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
