### PR TITLE
chore!: Upgrade to SLF4J 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <junit.version>5.8.0</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>24.0-SNAPSHOT</flow.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>2.0.3</slf4j.version>
     <spring.version>6.0.0-M6</spring.version>
     <spring.boot.version>3.0.0-M5</spring.boot.version>
     <spring.data.version>2.7.3</spring.data.version>


### PR DESCRIPTION
Spring Boot 3 RC1 uses SLF4J 2
