### PR TITLE
chore: remove the permission checking step

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,15 +27,8 @@ jobs:
       packages-it: ${{ steps.packages-it.outputs.packages }}
 
     steps:
-      - uses: ZheSun88/check-user-permission@triggering-actor
-        id: check
-        with:
-          require: 'write'
       - name: Check Secrets
         run: |
-          [ "${{ steps.check.outputs.require-result }}" != "true" ] \
-            && echo "::error::!! NO USER PERMISSIONS FOR RUNNING VALIDATION: Check if the PR is from an external contributor !!" \
-            && exit 1 || exit 0
           TB_LICENSE="${{secrets.TB_LICENSE}}"
           [ -z "$TB_LICENSE" ] \
             && echo "::error::!! ERROR NO TB_LICENSE: Check that this repo has a valid TB_LICENSE secret !!" \


### PR DESCRIPTION
github action offers a feature that asking the team member to trigger the build.

![image](https://user-images.githubusercontent.com/31067185/201855155-87ef40b8-fd83-4cf0-9d19-4986894c96e7.png)
