### PR TITLE
fix: generate declare keyword for createEmptyValue methods

### DIFF
--- a/packages/java/endpoint/src/main/resources/dev/hilla/generator/EntityModelTemplate.mustache
+++ b/packages/java/endpoint/src/main/resources/dev/hilla/generator/EntityModelTemplate.mustache
@@ -23,7 +23,7 @@ import {Email,Null,NotNull,NotEmpty,NotBlank,AssertTrue,AssertFalse,Negative,Neg
 export default class {{{getClassNameFromImports classname ../../imports}}}Model<T extends {{{getClassNameFromImports classname ../../imports}}} = {{{getClassNameFromImports classname ../../imports}}}>
   {{~#parentSchema}} extends {{{getClassNameFromImports parentSchema ../../imports}}}Model<T> { {{~/parentSchema}}
   {{~^parentSchema}} extends ObjectModel<T> { {{~/parentSchema}}
-  static createEmptyValue: () => {{{getClassNameFromImports classname ../../imports}}};
+  declare static createEmptyValue: () => {{{getClassNameFromImports classname ../../imports}}};
 {{#vars}}
 
   get {{name}}(): {{{getModelFullType this ../../imports}}} {

--- a/packages/java/endpoint/src/test/resources/dev/hilla/generator/tsmodel/expected-TsFormEndpoint.ts
+++ b/packages/java/endpoint/src/test/resources/dev/hilla/generator/tsmodel/expected-TsFormEndpoint.ts
@@ -14,7 +14,7 @@ import {Email,Null,NotNull,NotEmpty,NotBlank,AssertTrue,AssertFalse,Negative,Neg
  * @see {@link file:///.../endpoint/src/test/java/dev/hilla/generator/tsmodel/TsFormEndpoint.java}
  */
 export default class MyEntityModel<T extends MyEntity = MyEntity> extends MyEntityIdModel<T> {
-  static createEmptyValue: () => MyEntity;
+  declare static createEmptyValue: () => MyEntity;
 
   get myId(): NumberModel {
     return this[_getPropertyModel]('myId', NumberModel, [true]);

--- a/packages/ts/form/test/TestModels.ts
+++ b/packages/ts/form/test/TestModels.ts
@@ -21,7 +21,7 @@ export interface IdEntity {
   idString: string;
 }
 export class IdEntityModel<T extends IdEntity = IdEntity> extends ObjectModel<T> {
-  public static override createEmptyValue: () => IdEntity;
+  public declare static createEmptyValue: () => IdEntity;
 
   public get idString(): StringModel {
     return this[_getPropertyModel]('idString', StringModel, [false]);
@@ -34,7 +34,7 @@ export interface Product extends IdEntity {
   isInStock: boolean;
 }
 export class ProductModel<T extends Product = Product> extends IdEntityModel<T> {
-  public static override createEmptyValue: () => Product;
+  public declare static createEmptyValue: () => Product;
 
   public get description() {
     return this[_getPropertyModel]('description', StringModel, [false, new Required()]);
@@ -54,7 +54,7 @@ export interface Customer extends IdEntity {
   nickName: string;
 }
 export class CustomerModel<T extends Customer = Customer> extends IdEntityModel<T> {
-  public static override createEmptyValue: () => Customer;
+  public declare static createEmptyValue: () => Customer;
 
   public get fullName() {
     return this[_getPropertyModel]('fullName', StringModel, [
@@ -76,7 +76,7 @@ export interface Order extends IdEntity {
   products: ReadonlyArray<Product>;
 }
 export class OrderModel<T extends Order = Order> extends IdEntityModel<T> {
-  public static override createEmptyValue: () => Order;
+  public declare static createEmptyValue: () => Order;
 
   public get customer(): CustomerModel {
     return this[_getPropertyModel]('customer', CustomerModel, [false, new Required()]);
@@ -111,7 +111,7 @@ export interface TestEntity {
   fieldAny: any;
 }
 export class TestModel<T extends TestEntity = TestEntity> extends ObjectModel<T> {
-  public static override createEmptyValue: () => TestEntity;
+  public declare static createEmptyValue: () => TestEntity;
 
   public get fieldString() {
     return this[_getPropertyModel]('fieldString', StringModel, [false]) as StringModel;
@@ -166,7 +166,7 @@ export interface Employee extends IdEntity {
   colleagues?: Employee[];
 }
 export class EmployeeModel<T extends Employee = Employee> extends IdEntityModel<T> {
-  public static override createEmptyValue: () => Employee;
+  public declare static createEmptyValue: () => Employee;
 
   public get fullName() {
     return this[_getPropertyModel]('fullName', StringModel, [false]) as StringModel;
@@ -188,7 +188,7 @@ export interface TestMessageInterpolationEntity {
 export class TestMessageInterpolationModel<
   T extends TestMessageInterpolationEntity = TestMessageInterpolationEntity,
 > extends ObjectModel<T> {
-  public static override createEmptyValue: () => TestMessageInterpolationEntity;
+  public declare static createEmptyValue: () => TestMessageInterpolationEntity;
 
   public get stringMinSize() {
     return this[_getPropertyModel]('stringMinSize', StringModel, [
@@ -222,7 +222,7 @@ export interface WithPossibleCharList {
 }
 
 export class WithPossibleCharListModel extends ObjectModel<WithPossibleCharList> {
-  public static override createEmptyValue: () => WithPossibleCharList;
+  public declare static createEmptyValue: () => WithPossibleCharList;
 
   public get charList() {
     return this[_getPropertyModel]('charList', StringModel, [true]) as StringModel;

--- a/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
@@ -126,7 +126,7 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
       const [parentSchema, childSchema] = decomposed;
 
       if (!isReferenceSchema(parentSchema)) {
-        logger.error(parent, 'Only reference schema allowed for parent class');
+        logger.error(parentSchema, 'Only reference schema allowed for parent class');
         return undefined;
       }
 
@@ -204,7 +204,7 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
 
     const emptyValueElement = ts.factory.createPropertyDeclaration(
       undefined,
-      [ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)],
+      [ts.factory.createModifier(ts.SyntaxKind.DeclareKeyword), ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)],
       'createEmptyValue',
       undefined,
       ts.factory.createFunctionTypeNode(undefined, [], ts.factory.createTypeReferenceNode(entity)),

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormAnnotationsModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormAnnotationsModel.snap.ts
@@ -2,7 +2,7 @@ import { _getPropertyModel as _getPropertyModel_1, ArrayModel as ArrayModel_1, A
 import type FormAnnotations_1 from "./FormAnnotations";
 import FormEntityModel_1 from "./FormEntityModel";
 class FormAnnotationsModel<T extends FormAnnotations_1 = FormAnnotations_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormAnnotations_1;
+    declare static createEmptyValue: () => FormAnnotations_1;
     get list(): ArrayModel_1<string, StringModel_1> {
         return this[_getPropertyModel_1]("list", ArrayModel_1, [true, StringModel_1, [true], new NotEmpty_1()]) as ArrayModel_1<string, StringModel_1>;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormArrayTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormArrayTypesModel.snap.ts
@@ -6,7 +6,7 @@ import type FormEntityHierarchy_1 from "./FormEntityHierarchy";
 import FormEntityHierarchyModel_1 from "./FormEntityHierarchyModel";
 import FormEntityModel_1 from "./FormEntityModel";
 class FormArrayTypesModel<T extends FormArrayTypes_1 = FormArrayTypes_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormArrayTypes_1;
+    declare static createEmptyValue: () => FormArrayTypes_1;
     get stringList(): ArrayModel_1<string, StringModel_1> {
         return this[_getPropertyModel_1]("stringList", ArrayModel_1, [true, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormDataPrimitivesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormDataPrimitivesModel.snap.ts
@@ -1,7 +1,7 @@
 import { _getPropertyModel as _getPropertyModel_1, BooleanModel as BooleanModel_1, NumberModel as NumberModel_1, ObjectModel as ObjectModel_1, StringModel as StringModel_1 } from "@hilla/form";
 import type FormDataPrimitives_1 from "./FormDataPrimitives";
 class FormDataPrimitivesModel<T extends FormDataPrimitives_1 = FormDataPrimitives_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormDataPrimitives_1;
+    declare static createEmptyValue: () => FormDataPrimitives_1;
     get stringProp(): StringModel_1 {
         return this[_getPropertyModel_1]("stringProp", StringModel_1, [true]) as StringModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityHierarchyModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityHierarchyModel.snap.ts
@@ -2,7 +2,7 @@ import { _getPropertyModel as _getPropertyModel_1, NumberModel as NumberModel_1,
 import type FormEntityHierarchy_1 from "./FormEntityHierarchy";
 import FormEntityIdModel_1 from "./FormEntityIdModel";
 class FormEntityHierarchyModel<T extends FormEntityHierarchy_1 = FormEntityHierarchy_1> extends FormEntityIdModel_1<T> {
-    static createEmptyValue: () => FormEntityHierarchy_1;
+    declare static createEmptyValue: () => FormEntityHierarchy_1;
     get lorem(): StringModel_1 {
         return this[_getPropertyModel_1]("lorem", StringModel_1, [true]) as StringModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityIdModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityIdModel.snap.ts
@@ -1,7 +1,7 @@
 import { _getPropertyModel as _getPropertyModel_1, NotNull as NotNull_1, NumberModel as NumberModel_1, ObjectModel as ObjectModel_1 } from "@hilla/form";
 import type FormEntityId_1 from "./FormEntityId";
 class FormEntityIdModel<T extends FormEntityId_1 = FormEntityId_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormEntityId_1;
+    declare static createEmptyValue: () => FormEntityId_1;
     get Id(): NumberModel_1 {
         return this[_getPropertyModel_1]("Id", NumberModel_1, [true, new NotNull_1()]) as NumberModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityModel.snap.ts
@@ -12,7 +12,7 @@ import FormRecordTypesModel_1 from "./FormRecordTypesModel";
 import FormTemporalTypesModel_1 from "./FormTemporalTypesModel";
 import FormValidationConstraintsModel_1 from "./FormValidationConstraintsModel";
 class FormEntityModel<T extends FormEntity_1 = FormEntity_1> extends FormEntityIdModel_1<T> {
-    static createEmptyValue: () => FormEntity_1;
+    declare static createEmptyValue: () => FormEntity_1;
     get myId(): NumberModel_1 {
         return this[_getPropertyModel_1]("myId", NumberModel_1, [true]) as NumberModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormNonnullTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormNonnullTypesModel.snap.ts
@@ -1,7 +1,7 @@
 import { _getPropertyModel as _getPropertyModel_1, ArrayModel as ArrayModel_1, ObjectModel as ObjectModel_1, StringModel as StringModel_1 } from "@hilla/form";
 import type FormNonnullTypes_1 from "./FormNonnullTypes";
 class FormNonnullTypesModel<T extends FormNonnullTypes_1 = FormNonnullTypes_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormNonnullTypes_1;
+    declare static createEmptyValue: () => FormNonnullTypes_1;
     get nonNullableString(): StringModel_1 {
         return this[_getPropertyModel_1]("nonNullableString", StringModel_1, [false]) as StringModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormOptionalTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormOptionalTypesModel.snap.ts
@@ -2,7 +2,7 @@ import { _getPropertyModel as _getPropertyModel_1, ArrayModel as ArrayModel_1, O
 import FormEntityModel_1 from "./FormEntityModel";
 import type FormOptionalTypes_1 from "./FormOptionalTypes";
 class FormOptionalTypesModel<T extends FormOptionalTypes_1 = FormOptionalTypes_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormOptionalTypes_1;
+    declare static createEmptyValue: () => FormOptionalTypes_1;
     get optionalString(): StringModel_1 {
         return this[_getPropertyModel_1]("optionalString", StringModel_1, [true]) as StringModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormRecordTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormRecordTypesModel.snap.ts
@@ -3,7 +3,7 @@ import type FormEntityHierarchy_1 from "./FormEntityHierarchy";
 import type FormOptionalTypes_1 from "./FormOptionalTypes";
 import type FormRecordTypes_1 from "./FormRecordTypes";
 class FormRecordTypesModel<T extends FormRecordTypes_1 = FormRecordTypes_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormRecordTypes_1;
+    declare static createEmptyValue: () => FormRecordTypes_1;
     get stringMap(): ObjectModel_1<Record<string, string>> {
         return this[_getPropertyModel_1]("stringMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, string>>;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormTemporalTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormTemporalTypesModel.snap.ts
@@ -1,7 +1,7 @@
 import { _getPropertyModel as _getPropertyModel_1, ObjectModel as ObjectModel_1, StringModel as StringModel_1 } from "@hilla/form";
 import type FormTemporalTypes_1 from "./FormTemporalTypes";
 class FormTemporalTypesModel<T extends FormTemporalTypes_1 = FormTemporalTypes_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormTemporalTypes_1;
+    declare static createEmptyValue: () => FormTemporalTypes_1;
     get localDate(): StringModel_1 {
         return this[_getPropertyModel_1]("localDate", StringModel_1, [true]) as StringModel_1;
     }

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormValidationConstraintsModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormValidationConstraintsModel.snap.ts
@@ -2,7 +2,7 @@ import { _getPropertyModel as _getPropertyModel_1, ArrayModel as ArrayModel_1, A
 import FormEntityModel_1 from "./FormEntityModel";
 import type FormValidationConstraints_1 from "./FormValidationConstraints";
 class FormValidationConstraintsModel<T extends FormValidationConstraints_1 = FormValidationConstraints_1> extends ObjectModel_1<T> {
-    static createEmptyValue: () => FormValidationConstraints_1;
+    declare static createEmptyValue: () => FormValidationConstraints_1;
     get list(): ArrayModel_1<string, StringModel_1> {
         return this[_getPropertyModel_1]("list", ArrayModel_1, [true, StringModel_1, [true], new NotEmpty_1()]) as ArrayModel_1<string, StringModel_1>;
     }


### PR DESCRIPTION
Fixes #655

When omitting the declare keyword, Vite v3.2.3 produces an empty
property in the JS output. Adding `declare` makes it explicit that it is
not expected in JS.