### PR TITLE
build: simplify build matrix

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,7 +14,6 @@ on:
       - 'README.md'
       - '.github/ISSUE_TEMPLATE/*'
       - 'packages/**/README.md'
-  workflow_dispatch:
 
 jobs:
   init:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,6 +14,7 @@ on:
       - 'README.md'
       - '.github/ISSUE_TEMPLATE/*'
       - 'packages/**/README.md'
+  workflow_dispatch:
 
 jobs:
   init:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -181,14 +181,17 @@ jobs:
           echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
       - name: Verify
         run: |
-          mvn -B -am -ntp -fae \
-            -Dfailsafe.forkCount=4 \
-            -Dcom.vaadin.testbench.Parameters.testsInParallel=5 \
-            -Dfailsafe.rerunFailingTestsCount=2 \
-            -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
-            -Dmaven.wagon.http.retryHandler.count=3 \
-            -Dvaadin.hillaEngine=${{ matrix.hillaEngine }} \
-            verify
+          (
+            cd packages/java/tests && \
+            mvn -B -am -ntp -fae \
+              -Dfailsafe.forkCount=4 \
+              -Dcom.vaadin.testbench.Parameters.testsInParallel=5 \
+              -Dfailsafe.rerunFailingTestsCount=2 \
+              -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
+              -Dmaven.wagon.http.retryHandler.count=3 \
+              -Dvaadin.hillaEngine=${{ matrix.hillaEngine }} \
+              verify
+          )
       - uses: actions/upload-artifact@v3
         if: ${{ failure() || success() }}
         with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -157,8 +157,6 @@ jobs:
       fail-fast: false
       matrix:
         hillaEngine: [false, true]
-        include:
-            hilla-engine: false
 
     steps:
       - name: Checkout Project Code

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,7 +2,7 @@ name: Validation
 
 on:
   push:
-    branches: [ main, '1.3', '1.2', '1.1', '1.0' ]
+    branches: [ main, '1.1', '1.0' ]
     paths-ignore:
       - 'hilla-logo.svg'
       - 'README.md'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,7 +2,7 @@ name: Validation
 
 on:
   push:
-    branches: [ main, '1.1', '1.0' ]
+    branches: [ main, '1.3', '1.2', '1.1', '1.0' ]
     paths-ignore:
       - 'hilla-logo.svg'
       - 'README.md'
@@ -21,11 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    outputs:
-      packages-java: ${{ steps.packages-java.outputs.packages }}
-      packages-ts: ${{ steps.packages-ts.outputs.packages }}
-      packages-it: ${{ steps.packages-it.outputs.packages }}
-
     steps:
       - name: Check Secrets
         run: |
@@ -38,33 +33,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: List Java Unit
-        id: packages-java
-        run: |
-          echo "packages=$(node -e "console.log(JSON.stringify(
-            require('fs').readdirSync('packages/java')
-              .filter(name => name !== 'tests')
-          ))")" >> $GITHUB_OUTPUT
-      - name: List TypeScript Unit
-        id: packages-ts
-        run: >-
-          echo "packages=$(node -e "console.log(JSON.stringify(
-            require('fs').readdirSync('packages/ts')
-          ))")" >> $GITHUB_OUTPUT
-      - name: List IT
-        id: packages-it
-        run: >-
-          echo "packages=$(node -e "console.log(JSON.stringify(
-            [
-              require('fs').readdirSync('packages/java/tests/')
-                .filter(name => name !== 'spring'),
-              require('fs').readdirSync('packages/java/tests/spring/')
-                .map(name => 'spring/' + name)
-            ].flat()
-              .filter(path =>
-                require('fs').lstatSync('packages/java/tests/' + path).isDirectory()
-              )
-          ))")" >> $GITHUB_OUTPUT
       - name: Setup
         uses: ./.github/actions/setup
       - name: Validate Java Format
@@ -102,8 +70,6 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        package: ${{ fromJSON(needs.init.outputs.packages-java) }}
 
     steps:
       - name: Checkout Project Code
@@ -122,7 +88,7 @@ jobs:
           tar xf workspace.tar
           tar cf - .m2 | (cd ~ && tar xf -)
       - name: Test
-        run: (cd packages/java/${{ matrix.package }} && mvn -B -am -P\!it-modules verify)
+        run: mvn -B -am -P\!it-modules verify
       - name: Collect Coverage
         run: |
           COVFILES=$(find packages/java -wholename 'target/site/jacoco/jacoco.xml' | tr '\n' ',' | sed '$s/,$//')
@@ -144,8 +110,6 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        package: ${{ fromJSON(needs.init.outputs.packages-ts) }}
 
     steps:
       - name: Checkout Project Code
@@ -164,7 +128,7 @@ jobs:
           tar xf workspace.tar
           tar cf - .m2 | (cd ~ && tar xf -)
       - name: Test
-        run: (cd packages/ts/${{ matrix.package }} && npm run test:coverage)
+        run: npm run test:coverage
         env:
           CI: true
       - name: Collect Coverage
@@ -192,12 +156,7 @@ jobs:
       fail-fast: false
       matrix:
         hillaEngine: [false, true]
-        package: ${{ fromJSON(needs.init.outputs.packages-it) }}
-        java-version:
-            - 17
         include:
-          - package: spring/endpoints-latest-java
-            java-version: 17
             hilla-engine: false
 
     steps:
@@ -208,8 +167,6 @@ jobs:
           fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          java-version: ${{ matrix.java-version }}
       - uses: actions/download-artifact@v3
         with:
           name: saved-workspace
@@ -225,17 +182,14 @@ jobs:
           echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
       - name: Verify
         run: |
-          (
-            cd packages/java/tests/${{ matrix.package }} && \
-            mvn -B -am -ntp -fae \
-              -Dfailsafe.forkCount=4 \
-              -Dcom.vaadin.testbench.Parameters.testsInParallel=5 \
-              -Dfailsafe.rerunFailingTestsCount=2 \
-              -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
-              -Dmaven.wagon.http.retryHandler.count=3 \
-              -Dvaadin.hillaEngine=${{ matrix.hillaEngine }} \
-              verify
-          )
+          mvn -B -am -ntp -fae \
+            -Dfailsafe.forkCount=4 \
+            -Dcom.vaadin.testbench.Parameters.testsInParallel=5 \
+            -Dfailsafe.rerunFailingTestsCount=2 \
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
+            -Dmaven.wagon.http.retryHandler.count=3 \
+            -Dvaadin.hillaEngine=${{ matrix.hillaEngine }} \
+            verify
       - uses: actions/upload-artifact@v3
         if: ${{ failure() || success() }}
         with:


### PR DESCRIPTION
This removes package-based matrix variables from the GitHub Actions Validation workflow. The aim is to reduce parallel quota pressure and save on the container start / stop overhead.