### PR TITLE
fix: use Options in endpoint task

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/frontend/EndpointGeneratorTaskFactoryImpl.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/frontend/EndpointGeneratorTaskFactoryImpl.java
@@ -15,10 +15,10 @@
  */
 package dev.hilla.frontend;
 
-import java.io.File;
 import java.util.Objects;
 
 import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
+import com.vaadin.flow.server.frontend.Options;
 import com.vaadin.flow.server.frontend.TaskGenerateEndpoint;
 import com.vaadin.flow.server.frontend.TaskGenerateOpenAPI;
 
@@ -27,30 +27,31 @@ import com.vaadin.flow.server.frontend.TaskGenerateOpenAPI;
  * generator tasks.
  */
 public class EndpointGeneratorTaskFactoryImpl
-        implements EndpointGeneratorTaskFactory {
+    implements EndpointGeneratorTaskFactory {
 
     @Override
-    public TaskGenerateEndpoint createTaskGenerateEndpoint(
-            File applicationProperties, File openApi, File outputFolder,
-            File frontendDirectory) {
-        Objects.requireNonNull(openApi,
-                "Vaadin OpenAPI file should not be null.");
-        Objects.requireNonNull(outputFolder,
-                "Vaadin output folder should not be null.");
-        return new TaskGenerateEndpointImpl(applicationProperties, openApi,
-                outputFolder, frontendDirectory);
+    public TaskGenerateEndpoint createTaskGenerateEndpoint(Options options) {
+        Objects.requireNonNull(options.getEndpointGeneratedOpenAPIFile(),
+            "Vaadin OpenAPI file should not be null.");
+        Objects.requireNonNull(options.getFrontendGeneratedFolder(),
+            "Vaadin output folder should not be null.");
+        return new TaskGenerateEndpointImpl(options.getApplicationProperties(),
+            options.getEndpointGeneratedOpenAPIFile(),
+            options.getFrontendGeneratedFolder(),
+            options.getFrontendDirectory());
     }
 
     @Override
-    public TaskGenerateOpenAPI createTaskGenerateOpenAPI(File properties,
-            File javaSourceFolder, ClassLoader classLoader, File output) {
-        Objects.requireNonNull(javaSourceFolder,
-                "Source paths should not be null.");
-        Objects.requireNonNull(output,
-                "OpenAPI output file should not be null.");
-        Objects.requireNonNull(classLoader, "ClassLoader should not be null.");
-        return new TaskGenerateOpenAPIImpl(properties, javaSourceFolder,
-                classLoader, output);
+    public TaskGenerateOpenAPI createTaskGenerateOpenAPI(Options options) {
+        Objects.requireNonNull(options.getEndpointSourceFolder(),
+            "Source paths should not be null.");
+        Objects.requireNonNull(options.getEndpointGeneratedOpenAPIFile(),
+            "OpenAPI output file should not be null.");
+        Objects.requireNonNull(options.getClassFinder().getClassLoader(),
+            "ClassLoader should not be null.");
+        return new TaskGenerateOpenAPIImpl(options.getApplicationProperties(),
+            options.getEndpointSourceFolder(),
+            options.getClassFinder().getClassLoader(),
+            options.getEndpointGeneratedOpenAPIFile());
     }
-
 }


### PR DESCRIPTION
Following the API changes in Flow (see vaadin/flow#15335 and vaadin/flow#15371), this updates `EndpointGeneratorTaskFactoryImpl` to use the `Options` parameter.