### PR TITLE
test(java/tests): add required webdrivermanager dependency

### DIFF
--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -90,6 +90,11 @@
       <artifactId>vaadin-text-field-testbench</artifactId>
       <version>${vaadin.component.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.2.1</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
A new dependency seems to be required by webdrivermanager v5.3.2,
introduced in https://github.com/vaadin/flow/pull/15734