### PR TITLE
fix: Make push work with native compile

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/push/PushConfigurer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/push/PushConfigurer.java
@@ -48,7 +48,7 @@ public class PushConfigurer {
         return registration;
     }
 
-    private static class EmbeddedAtmosphereInitializer
+    static class EmbeddedAtmosphereInitializer
             extends ContainerInitializer implements ServletContextInitializer {
 
         @Override


### PR DESCRIPTION
Fixes the problem
```
[ERROR] dev.hilla.push.PushConfigurer.EmbeddedAtmosphereInitializer has private access in dev.hilla.push.PushConfigurer /.../spring-aot/main/sources/dev/hilla/push/PushConfigurer__BeanDefinitions.java 52:53
```
