### PR TITLE
fix: Make push compatible with Spring native

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/push/PushConfigurer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/push/PushConfigurer.java
@@ -1,13 +1,18 @@
 package dev.hilla.push;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-
+import org.atmosphere.client.TrackMessageSizeInterceptor;
 import org.atmosphere.cpr.ApplicationConfig;
+import org.atmosphere.cpr.AtmosphereFramework;
+import org.atmosphere.cpr.AtmosphereInterceptor;
 import org.atmosphere.cpr.AtmosphereServlet;
 import org.atmosphere.cpr.ContainerInitializer;
+import org.atmosphere.interceptor.AtmosphereResourceLifecycleInterceptor;
+import org.atmosphere.interceptor.SuspendTrackerInterceptor;
+import org.atmosphere.util.SimpleBroadcaster;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +21,8 @@ import org.springframework.core.Ordered;
 
 import dev.hilla.ConditionalOnFeatureFlag;
 import dev.hilla.EndpointInvoker;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 
 /**
  * Defines the beans needed for push in Hilla.
@@ -25,7 +32,13 @@ import dev.hilla.EndpointInvoker;
 public class PushConfigurer {
 
     @Bean
-    PushMessageHandler pushMessageHandler(EndpointInvoker endpointInvoker) {
+    PushEndpoint pushEndpoint() {
+        return new PushEndpoint();
+    }
+
+    @Bean
+    public PushMessageHandler pushMessageHandler(
+            EndpointInvoker endpointInvoker) {
         return new PushMessageHandler(endpointInvoker);
     }
 
@@ -35,9 +48,19 @@ public class PushConfigurer {
     }
 
     @Bean
-    ServletRegistrationBean<AtmosphereServlet> atmosphereServlet() {
+    ServletRegistrationBean<AtmosphereServlet> atmosphereServlet(
+            PushEndpoint pushEndpoint) {
+        AtmosphereServlet atmosphereServlet = new AtmosphereServlet();
         ServletRegistrationBean<AtmosphereServlet> registration = new ServletRegistrationBean<>(
-                new AtmosphereServlet(), "/HILLA/push");
+                atmosphereServlet, "/HILLA/push");
+
+        List<AtmosphereInterceptor> interceptors = Arrays.asList(
+                new AtmosphereResourceLifecycleInterceptor(),
+                new TrackMessageSizeInterceptor(),
+                new SuspendTrackerInterceptor());
+        AtmosphereFramework fw = atmosphereServlet.framework();
+        fw.setDefaultBroadcasterClassName(SimpleBroadcaster.class.getName());
+        fw.addAtmosphereHandler("/HILLA/push", pushEndpoint, interceptors);
 
         // Override the global mapping set by Flow
         registration.addInitParameter(ApplicationConfig.JSR356_MAPPING_PATH,

--- a/packages/java/endpoint/src/main/java/dev/hilla/springnative/HillaHintsRegistrar.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/springnative/HillaHintsRegistrar.java
@@ -1,0 +1,45 @@
+package dev.hilla.springnative;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
+import dev.hilla.push.PushEndpoint;
+import dev.hilla.push.messages.fromclient.AbstractServerMessage;
+import dev.hilla.push.messages.toclient.AbstractClientMessage;
+
+/**
+ * Registers runtime hints for Spring 3 native support for Hilla.
+ */
+public class HillaHintsRegistrar implements RuntimeHintsRegistrar {
+
+    @Override
+    public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+        hints.reflection().registerType(PushEndpoint.class,
+                MemberCategory.values());
+
+        List<Class<?>> pushMessageTypes = new ArrayList<>();
+        pushMessageTypes.addAll(getMessageTypes(AbstractServerMessage.class));
+        pushMessageTypes.addAll(getMessageTypes(AbstractClientMessage.class));
+        for (Class<?> cls : pushMessageTypes) {
+            hints.reflection().registerType(cls, MemberCategory.values());
+        }
+    }
+
+    private Collection<Class<?>> getMessageTypes(Class<?> cls) {
+        List<Class<?>> classes = new ArrayList<>();
+        classes.add(cls);
+        JsonSubTypes subTypes = cls.getAnnotation(JsonSubTypes.class);
+        for (JsonSubTypes.Type t : subTypes.value()) {
+            classes.add(t.value());
+        }
+        return classes;
+    }
+
+}

--- a/packages/java/endpoint/src/main/resources/META-INF/spring/aot.factories
+++ b/packages/java/endpoint/src/main/resources/META-INF/spring/aot.factories
@@ -1,1 +1,2 @@
 org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=dev.hilla.EndpointInitializationAotProcessor
+org.springframework.aot.hint.RuntimeHintsRegistrar=dev.hilla.springnative.HillaHintsRegistrar


### PR DESCRIPTION
Uses manual registration of the atmosphere handler instead of the annotation scanning in Atmosphere. This also allows us to create the handler using Spring so that autowiring works out of the box
