### PR TITLE
chore: align TB version in hilla 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <spring.boot.version>2.7.4</spring.boot.version>
     <spring.data.version>2.7.3</spring.data.version>
     <spring.security.version>5.7.3</spring.security.version>
-    <testbench.version>8.1.3</testbench.version>
+    <testbench.version>8.2.0</testbench.version>
     <javax.validation.version>2.0.1.Final</javax.validation.version>
     <hibernate.validator.version>6.2.3.Final</hibernate.validator.version>
   </properties>


### PR DESCRIPTION
seems TB in hilla 1.3 should be 8.2.0 instead of 8.1.x https://github.com/vaadin/platform/blob/23.3/versions.json#L677


