### PR TITLE
fix(engine): change how model checks for nullable fields

### DIFF
--- a/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
@@ -6,6 +6,7 @@ import {
   isComposedSchema,
   isEmptyObject,
   isEnumSchema,
+  isNullableSchema,
   isObjectSchema,
   isReferenceSchema,
   ObjectSchema,
@@ -139,18 +140,15 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
     return this.#processModelClass(entitySchema, this[$entity].id, parent);
   }
 
-  #processClassElements({ required, properties }: ObjectSchema): readonly ClassElement[] {
+  #processClassElements({ properties }: ObjectSchema): readonly ClassElement[] {
     if (!properties) {
       return [];
     }
 
-    const requiredSet = new Set(required);
     return Object.entries(properties).map(([name, schema]) => {
       const type = new ModelSchemaTypeProcessor(schema, this[$dependencies]).process();
-      const args = new ModelSchemaExpressionProcessor(
-        schema,
-        this[$dependencies],
-        (_) => !requiredSet.has(name),
+      const args = new ModelSchemaExpressionProcessor(schema, this[$dependencies], (_) =>
+        isNullableSchema(schema),
       ).process();
 
       return ts.factory.createGetAccessorDeclaration(

--- a/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
@@ -6,7 +6,6 @@ import {
   isComposedSchema,
   isEmptyObject,
   isEnumSchema,
-  isNullableSchema,
   isObjectSchema,
   isReferenceSchema,
   ObjectSchema,
@@ -147,9 +146,7 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
 
     return Object.entries(properties).map(([name, schema]) => {
       const type = new ModelSchemaTypeProcessor(schema, this[$dependencies]).process();
-      const args = new ModelSchemaExpressionProcessor(schema, this[$dependencies], (_) =>
-        isNullableSchema(schema),
-      ).process();
+      const args = new ModelSchemaExpressionProcessor(schema, this[$dependencies]).process();
 
       return ts.factory.createGetAccessorDeclaration(
         undefined,

--- a/packages/ts/generator-typescript-plugin-model/src/ModelSchemaProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/ModelSchemaProcessor.ts
@@ -220,12 +220,10 @@ export class ModelSchemaTypeProcessor extends ModelSchemaPartProcessor<TypeRefer
 }
 
 export class ModelSchemaExpressionProcessor extends ModelSchemaPartProcessor<readonly Expression[]> {
-  readonly #checkOptional: OptionalChecker;
   readonly #parse: typeof AnnotationParser.prototype.parse;
 
-  constructor(schema: Schema, dependencies: DependencyManager, checkOptional: OptionalChecker = isNullableSchema) {
+  constructor(schema: Schema, dependencies: DependencyManager) {
     super(schema, dependencies);
-    this.#checkOptional = checkOptional;
     const parser = new AnnotationParser((name) => importBuiltInFormModel(name, dependencies));
     this.#parse = parser.parse.bind(parser);
   }
@@ -243,7 +241,7 @@ export class ModelSchemaExpressionProcessor extends ModelSchemaPartProcessor<rea
       result = [...result, ...this.#getValidatorsFromValidationConstraints(schema)];
     }
 
-    return [this.#checkOptional(this[$originalSchema]) ? ts.factory.createTrue() : ts.factory.createFalse(), ...result];
+    return [isNullableSchema(this[$originalSchema]) ? ts.factory.createTrue() : ts.factory.createFalse(), ...result];
   }
 
   protected override [$processArray](schema: ArraySchema): readonly Expression[] {

--- a/packages/ts/generator-typescript-plugin-model/test/model/Model.json
+++ b/packages/ts/generator-typescript-plugin-model/test/model/Model.json
@@ -25,7 +25,6 @@
           "content": {
             "application/json": {
               "schema": {
-                "required": ["name"],
                 "type": "object",
                 "properties": {
                   "name": {
@@ -316,7 +315,6 @@
         }
       },
       "com.example.application.endpoints.TsFormEndpoint.FormAnnotations": {
-        "required": ["decimalMax", "decimalMin", "negative", "negativeOrZero", "positive", "positiveOrZero"],
         "type": "object",
         "properties": {
           "list": {
@@ -424,7 +422,6 @@
         }
       },
       "com.example.application.endpoints.TsFormEndpoint.FormValidationConstraints": {
-        "required": ["decimalMax", "decimalMin", "negative", "negativeOrZero", "positive", "positiveOrZero"],
         "type": "object",
         "properties": {
           "list": {
@@ -654,7 +651,6 @@
         }
       },
       "com.example.application.endpoints.TsFormEndpoint.FormDataPrimitives": {
-        "required": ["booleanProp", "doubleProp", "floatProp", "integerProp", "longProp"],
         "type": "object",
         "properties": {
           "stringProp": {
@@ -810,7 +806,6 @@
         }
       },
       "com.example.application.endpoints.TsFormEndpoint.FormNonnullTypes": {
-        "required": ["nonNullableList", "nonNullableMatrix", "nonNullableString"],
         "type": "object",
         "properties": {
           "nonNullableString": {

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormAnnotationsModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormAnnotationsModel.snap.ts
@@ -4,37 +4,37 @@ import FormEntityModel_1 from "./FormEntityModel";
 class FormAnnotationsModel<T extends FormAnnotations_1 = FormAnnotations_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormAnnotations_1;
     get list(): ArrayModel_1<string, StringModel_1> {
-        return this[_getPropertyModel_1]("list", ArrayModel_1, [true, StringModel_1, [true], new NotEmpty_1()]) as ArrayModel_1<string, StringModel_1>;
+        return this[_getPropertyModel_1]("list", ArrayModel_1, [false, StringModel_1, [true], new NotEmpty_1()]) as ArrayModel_1<string, StringModel_1>;
     }
     get email(): StringModel_1 {
-        return this[_getPropertyModel_1]("email", StringModel_1, [true, new Email_1({ message: "foo" })]) as StringModel_1;
+        return this[_getPropertyModel_1]("email", StringModel_1, [false, new Email_1({ message: "foo" })]) as StringModel_1;
     }
     get isNull(): StringModel_1 {
-        return this[_getPropertyModel_1]("isNull", StringModel_1, [true, new Null_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("isNull", StringModel_1, [false, new Null_1()]) as StringModel_1;
     }
     get notNull(): StringModel_1 {
-        return this[_getPropertyModel_1]("notNull", StringModel_1, [true, new NotNull_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("notNull", StringModel_1, [false, new NotNull_1()]) as StringModel_1;
     }
     get notEmpty(): StringModel_1 {
-        return this[_getPropertyModel_1]("notEmpty", StringModel_1, [true, new NotEmpty_1(), new NotNull_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("notEmpty", StringModel_1, [false, new NotEmpty_1(), new NotNull_1()]) as StringModel_1;
     }
     get notNullEntity(): FormEntityModel_1 {
-        return this[_getPropertyModel_1]("notNullEntity", FormEntityModel_1, [true]) as FormEntityModel_1;
+        return this[_getPropertyModel_1]("notNullEntity", FormEntityModel_1, [false]) as FormEntityModel_1;
     }
     get notBlank(): StringModel_1 {
-        return this[_getPropertyModel_1]("notBlank", StringModel_1, [true, new NotBlank_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("notBlank", StringModel_1, [false, new NotBlank_1()]) as StringModel_1;
     }
     get assertTrue(): StringModel_1 {
-        return this[_getPropertyModel_1]("assertTrue", StringModel_1, [true, new AssertTrue_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("assertTrue", StringModel_1, [false, new AssertTrue_1()]) as StringModel_1;
     }
     get assertFalse(): StringModel_1 {
-        return this[_getPropertyModel_1]("assertFalse", StringModel_1, [true, new AssertFalse_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("assertFalse", StringModel_1, [false, new AssertFalse_1()]) as StringModel_1;
     }
     get min(): NumberModel_1 {
-        return this[_getPropertyModel_1]("min", NumberModel_1, [true, new Min_1({ value: 1, message: "foo" })]) as NumberModel_1;
+        return this[_getPropertyModel_1]("min", NumberModel_1, [false, new Min_1({ value: 1, message: "foo" })]) as NumberModel_1;
     }
     get max(): NumberModel_1 {
-        return this[_getPropertyModel_1]("max", NumberModel_1, [true, new Max_1(2)]) as NumberModel_1;
+        return this[_getPropertyModel_1]("max", NumberModel_1, [false, new Max_1(2)]) as NumberModel_1;
     }
     get decimalMin(): NumberModel_1 {
         return this[_getPropertyModel_1]("decimalMin", NumberModel_1, [false, new DecimalMin_1("0.01")]) as NumberModel_1;
@@ -55,22 +55,22 @@ class FormAnnotationsModel<T extends FormAnnotations_1 = FormAnnotations_1> exte
         return this[_getPropertyModel_1]("positiveOrZero", NumberModel_1, [false, new PositiveOrZero_1()]) as NumberModel_1;
     }
     get size(): StringModel_1 {
-        return this[_getPropertyModel_1]("size", StringModel_1, [true, new Size_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("size", StringModel_1, [false, new Size_1()]) as StringModel_1;
     }
     get size1(): StringModel_1 {
-        return this[_getPropertyModel_1]("size1", StringModel_1, [true, new Size_1({ min: 1 })]) as StringModel_1;
+        return this[_getPropertyModel_1]("size1", StringModel_1, [false, new Size_1({ min: 1 })]) as StringModel_1;
     }
     get digits(): StringModel_1 {
-        return this[_getPropertyModel_1]("digits", StringModel_1, [true, new Digits_1({ integer: 5, fraction: 2 })]) as StringModel_1;
+        return this[_getPropertyModel_1]("digits", StringModel_1, [false, new Digits_1({ integer: 5, fraction: 2 })]) as StringModel_1;
     }
     get past(): StringModel_1 {
-        return this[_getPropertyModel_1]("past", StringModel_1, [true, new Past_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("past", StringModel_1, [false, new Past_1()]) as StringModel_1;
     }
     get future(): StringModel_1 {
-        return this[_getPropertyModel_1]("future", StringModel_1, [true, new Future_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("future", StringModel_1, [false, new Future_1()]) as StringModel_1;
     }
     get pattern(): StringModel_1 {
-        return this[_getPropertyModel_1]("pattern", StringModel_1, [true, new Pattern_1({ regexp: "\\d+\\..+" })]) as StringModel_1;
+        return this[_getPropertyModel_1]("pattern", StringModel_1, [false, new Pattern_1({ regexp: "\\d+\\..+" })]) as StringModel_1;
     }
 }
 export default FormAnnotationsModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormArrayTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormArrayTypesModel.snap.ts
@@ -8,25 +8,25 @@ import FormEntityModel_1 from "./FormEntityModel";
 class FormArrayTypesModel<T extends FormArrayTypes_1 = FormArrayTypes_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormArrayTypes_1;
     get stringList(): ArrayModel_1<string, StringModel_1> {
-        return this[_getPropertyModel_1]("stringList", ArrayModel_1, [true, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
+        return this[_getPropertyModel_1]("stringList", ArrayModel_1, [false, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
     }
     get entityHierarchyList(): ArrayModel_1<FormEntityHierarchy_1, FormEntityHierarchyModel_1> {
-        return this[_getPropertyModel_1]("entityHierarchyList", ArrayModel_1, [true, FormEntityHierarchyModel_1, [true]]) as ArrayModel_1<FormEntityHierarchy_1, FormEntityHierarchyModel_1>;
+        return this[_getPropertyModel_1]("entityHierarchyList", ArrayModel_1, [false, FormEntityHierarchyModel_1, [true]]) as ArrayModel_1<FormEntityHierarchy_1, FormEntityHierarchyModel_1>;
     }
     get selfReferenceList(): ArrayModel_1<FormArrayTypes_1, FormArrayTypesModel_1> {
-        return this[_getPropertyModel_1]("selfReferenceList", ArrayModel_1, [true, FormArrayTypesModel_1, [true]]) as ArrayModel_1<FormArrayTypes_1, FormArrayTypesModel_1>;
+        return this[_getPropertyModel_1]("selfReferenceList", ArrayModel_1, [false, FormArrayTypesModel_1, [true]]) as ArrayModel_1<FormArrayTypes_1, FormArrayTypesModel_1>;
     }
     get stringArray(): ArrayModel_1<string, StringModel_1> {
-        return this[_getPropertyModel_1]("stringArray", ArrayModel_1, [true, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
+        return this[_getPropertyModel_1]("stringArray", ArrayModel_1, [false, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
     }
     get numberMatrix(): ArrayModel_1<ReadonlyArray<number>, ArrayModel_1<number, NumberModel_1>> {
-        return this[_getPropertyModel_1]("numberMatrix", ArrayModel_1, [true, ArrayModel_1, [true, NumberModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<number>, ArrayModel_1<number, NumberModel_1>>;
+        return this[_getPropertyModel_1]("numberMatrix", ArrayModel_1, [false, ArrayModel_1, [true, NumberModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<number>, ArrayModel_1<number, NumberModel_1>>;
     }
     get entityMatrix(): ArrayModel_1<ReadonlyArray<FormEntity_1>, ArrayModel_1<FormEntity_1, FormEntityModel_1>> {
-        return this[_getPropertyModel_1]("entityMatrix", ArrayModel_1, [true, ArrayModel_1, [true, FormEntityModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<FormEntity_1>, ArrayModel_1<FormEntity_1, FormEntityModel_1>>;
+        return this[_getPropertyModel_1]("entityMatrix", ArrayModel_1, [false, ArrayModel_1, [true, FormEntityModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<FormEntity_1>, ArrayModel_1<FormEntity_1, FormEntityModel_1>>;
     }
     get nestedArrays(): ArrayModel_1<ReadonlyArray<Record<string, ReadonlyArray<string>>>, ArrayModel_1<Record<string, ReadonlyArray<string>>, ObjectModel_1<Record<string, ReadonlyArray<string>>>>> {
-        return this[_getPropertyModel_1]("nestedArrays", ArrayModel_1, [true, ArrayModel_1, [true, ObjectModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<Record<string, ReadonlyArray<string>>>, ArrayModel_1<Record<string, ReadonlyArray<string>>, ObjectModel_1<Record<string, ReadonlyArray<string>>>>>;
+        return this[_getPropertyModel_1]("nestedArrays", ArrayModel_1, [false, ArrayModel_1, [true, ObjectModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<Record<string, ReadonlyArray<string>>>, ArrayModel_1<Record<string, ReadonlyArray<string>>, ObjectModel_1<Record<string, ReadonlyArray<string>>>>>;
     }
 }
 export default FormArrayTypesModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormDataPrimitivesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormDataPrimitivesModel.snap.ts
@@ -3,34 +3,34 @@ import type FormDataPrimitives_1 from "./FormDataPrimitives";
 class FormDataPrimitivesModel<T extends FormDataPrimitives_1 = FormDataPrimitives_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormDataPrimitives_1;
     get stringProp(): StringModel_1 {
-        return this[_getPropertyModel_1]("stringProp", StringModel_1, [true]) as StringModel_1;
+        return this[_getPropertyModel_1]("stringProp", StringModel_1, [false]) as StringModel_1;
     }
     get longWrapperProp(): NumberModel_1 {
-        return this[_getPropertyModel_1]("longWrapperProp", NumberModel_1, [true]) as NumberModel_1;
+        return this[_getPropertyModel_1]("longWrapperProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get longProp(): NumberModel_1 {
         return this[_getPropertyModel_1]("longProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get integerWrapperProp(): NumberModel_1 {
-        return this[_getPropertyModel_1]("integerWrapperProp", NumberModel_1, [true]) as NumberModel_1;
+        return this[_getPropertyModel_1]("integerWrapperProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get integerProp(): NumberModel_1 {
         return this[_getPropertyModel_1]("integerProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get doubleWrapperProp(): NumberModel_1 {
-        return this[_getPropertyModel_1]("doubleWrapperProp", NumberModel_1, [true]) as NumberModel_1;
+        return this[_getPropertyModel_1]("doubleWrapperProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get doubleProp(): NumberModel_1 {
         return this[_getPropertyModel_1]("doubleProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get floatWrapperProp(): NumberModel_1 {
-        return this[_getPropertyModel_1]("floatWrapperProp", NumberModel_1, [true]) as NumberModel_1;
+        return this[_getPropertyModel_1]("floatWrapperProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get floatProp(): NumberModel_1 {
         return this[_getPropertyModel_1]("floatProp", NumberModel_1, [false]) as NumberModel_1;
     }
     get booleanWrapperProp(): BooleanModel_1 {
-        return this[_getPropertyModel_1]("booleanWrapperProp", BooleanModel_1, [true]) as BooleanModel_1;
+        return this[_getPropertyModel_1]("booleanWrapperProp", BooleanModel_1, [false]) as BooleanModel_1;
     }
     get booleanProp(): BooleanModel_1 {
         return this[_getPropertyModel_1]("booleanProp", BooleanModel_1, [false]) as BooleanModel_1;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityHierarchyModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityHierarchyModel.snap.ts
@@ -4,10 +4,10 @@ import FormEntityIdModel_1 from "./FormEntityIdModel";
 class FormEntityHierarchyModel<T extends FormEntityHierarchy_1 = FormEntityHierarchy_1> extends FormEntityIdModel_1<T> {
     declare static createEmptyValue: () => FormEntityHierarchy_1;
     get lorem(): StringModel_1 {
-        return this[_getPropertyModel_1]("lorem", StringModel_1, [true]) as StringModel_1;
+        return this[_getPropertyModel_1]("lorem", StringModel_1, [false]) as StringModel_1;
     }
     get ipsum(): NumberModel_1 {
-        return this[_getPropertyModel_1]("ipsum", NumberModel_1, [true]) as NumberModel_1;
+        return this[_getPropertyModel_1]("ipsum", NumberModel_1, [false]) as NumberModel_1;
     }
 }
 export default FormEntityHierarchyModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityIdModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityIdModel.snap.ts
@@ -3,7 +3,7 @@ import type FormEntityId_1 from "./FormEntityId";
 class FormEntityIdModel<T extends FormEntityId_1 = FormEntityId_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormEntityId_1;
     get Id(): NumberModel_1 {
-        return this[_getPropertyModel_1]("Id", NumberModel_1, [true, new NotNull_1()]) as NumberModel_1;
+        return this[_getPropertyModel_1]("Id", NumberModel_1, [false, new NotNull_1()]) as NumberModel_1;
     }
 }
 export default FormEntityIdModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityModel.snap.ts
@@ -14,37 +14,37 @@ import FormValidationConstraintsModel_1 from "./FormValidationConstraintsModel";
 class FormEntityModel<T extends FormEntity_1 = FormEntity_1> extends FormEntityIdModel_1<T> {
     declare static createEmptyValue: () => FormEntity_1;
     get myId(): NumberModel_1 {
-        return this[_getPropertyModel_1]("myId", NumberModel_1, [true]) as NumberModel_1;
+        return this[_getPropertyModel_1]("myId", NumberModel_1, [false]) as NumberModel_1;
     }
     get dataPrimitives(): FormDataPrimitivesModel_1 {
-        return this[_getPropertyModel_1]("dataPrimitives", FormDataPrimitivesModel_1, [true]) as FormDataPrimitivesModel_1;
+        return this[_getPropertyModel_1]("dataPrimitives", FormDataPrimitivesModel_1, [false]) as FormDataPrimitivesModel_1;
     }
     get entityHierarchy(): FormEntityHierarchyModel_1 {
-        return this[_getPropertyModel_1]("entityHierarchy", FormEntityHierarchyModel_1, [true]) as FormEntityHierarchyModel_1;
+        return this[_getPropertyModel_1]("entityHierarchy", FormEntityHierarchyModel_1, [false]) as FormEntityHierarchyModel_1;
     }
     get temporalTypes(): FormTemporalTypesModel_1 {
-        return this[_getPropertyModel_1]("temporalTypes", FormTemporalTypesModel_1, [true]) as FormTemporalTypesModel_1;
+        return this[_getPropertyModel_1]("temporalTypes", FormTemporalTypesModel_1, [false]) as FormTemporalTypesModel_1;
     }
     get arrayTypes(): FormArrayTypesModel_1 {
-        return this[_getPropertyModel_1]("arrayTypes", FormArrayTypesModel_1, [true]) as FormArrayTypesModel_1;
+        return this[_getPropertyModel_1]("arrayTypes", FormArrayTypesModel_1, [false]) as FormArrayTypesModel_1;
     }
     get enumTypes(): FormEnumTypesModel_1 {
-        return this[_getPropertyModel_1]("enumTypes", FormEnumTypesModel_1, [true]) as FormEnumTypesModel_1;
+        return this[_getPropertyModel_1]("enumTypes", FormEnumTypesModel_1, [false]) as FormEnumTypesModel_1;
     }
     get recordTypes(): FormRecordTypesModel_1 {
-        return this[_getPropertyModel_1]("recordTypes", FormRecordTypesModel_1, [true]) as FormRecordTypesModel_1;
+        return this[_getPropertyModel_1]("recordTypes", FormRecordTypesModel_1, [false]) as FormRecordTypesModel_1;
     }
     get annotations(): FormAnnotationsModel_1 {
-        return this[_getPropertyModel_1]("annotations", FormAnnotationsModel_1, [true]) as FormAnnotationsModel_1;
+        return this[_getPropertyModel_1]("annotations", FormAnnotationsModel_1, [false]) as FormAnnotationsModel_1;
     }
     get validationConstraints(): FormValidationConstraintsModel_1 {
-        return this[_getPropertyModel_1]("validationConstraints", FormValidationConstraintsModel_1, [true]) as FormValidationConstraintsModel_1;
+        return this[_getPropertyModel_1]("validationConstraints", FormValidationConstraintsModel_1, [false]) as FormValidationConstraintsModel_1;
     }
     get myOptionalTypes(): FormOptionalTypesModel_1 {
-        return this[_getPropertyModel_1]("myOptionalTypes", FormOptionalTypesModel_1, [true]) as FormOptionalTypesModel_1;
+        return this[_getPropertyModel_1]("myOptionalTypes", FormOptionalTypesModel_1, [false]) as FormOptionalTypesModel_1;
     }
     get nonnullTypes(): FormNonnullTypesModel_1 {
-        return this[_getPropertyModel_1]("nonnullTypes", FormNonnullTypesModel_1, [true]) as FormNonnullTypesModel_1;
+        return this[_getPropertyModel_1]("nonnullTypes", FormNonnullTypesModel_1, [false]) as FormNonnullTypesModel_1;
     }
     get unknownModel(): ObjectModel_1<unknown> {
         return this[_getPropertyModel_1]("unknownModel", ObjectModel_1, [true]) as ObjectModel_1<unknown>;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormOptionalTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormOptionalTypesModel.snap.ts
@@ -4,16 +4,16 @@ import type FormOptionalTypes_1 from "./FormOptionalTypes";
 class FormOptionalTypesModel<T extends FormOptionalTypes_1 = FormOptionalTypes_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormOptionalTypes_1;
     get optionalString(): StringModel_1 {
-        return this[_getPropertyModel_1]("optionalString", StringModel_1, [true]) as StringModel_1;
+        return this[_getPropertyModel_1]("optionalString", StringModel_1, [false]) as StringModel_1;
     }
     get optionalEntity(): FormEntityModel_1 {
-        return this[_getPropertyModel_1]("optionalEntity", FormEntityModel_1, [true]) as FormEntityModel_1;
+        return this[_getPropertyModel_1]("optionalEntity", FormEntityModel_1, [false]) as FormEntityModel_1;
     }
     get optionalList(): ArrayModel_1<string, StringModel_1> {
-        return this[_getPropertyModel_1]("optionalList", ArrayModel_1, [true, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
+        return this[_getPropertyModel_1]("optionalList", ArrayModel_1, [false, StringModel_1, [true]]) as ArrayModel_1<string, StringModel_1>;
     }
     get optionalMatrix(): ArrayModel_1<ReadonlyArray<string>, ArrayModel_1<string, StringModel_1>> {
-        return this[_getPropertyModel_1]("optionalMatrix", ArrayModel_1, [true, ArrayModel_1, [true, StringModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<string>, ArrayModel_1<string, StringModel_1>>;
+        return this[_getPropertyModel_1]("optionalMatrix", ArrayModel_1, [false, ArrayModel_1, [true, StringModel_1, [true]]]) as ArrayModel_1<ReadonlyArray<string>, ArrayModel_1<string, StringModel_1>>;
     }
 }
 export default FormOptionalTypesModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormRecordTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormRecordTypesModel.snap.ts
@@ -5,22 +5,22 @@ import type FormRecordTypes_1 from "./FormRecordTypes";
 class FormRecordTypesModel<T extends FormRecordTypes_1 = FormRecordTypes_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormRecordTypes_1;
     get stringMap(): ObjectModel_1<Record<string, string>> {
-        return this[_getPropertyModel_1]("stringMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, string>>;
+        return this[_getPropertyModel_1]("stringMap", ObjectModel_1, [false]) as ObjectModel_1<Record<string, string>>;
     }
     get entityHierarchyMap(): ObjectModel_1<Record<string, FormEntityHierarchy_1>> {
-        return this[_getPropertyModel_1]("entityHierarchyMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, FormEntityHierarchy_1>>;
+        return this[_getPropertyModel_1]("entityHierarchyMap", ObjectModel_1, [false]) as ObjectModel_1<Record<string, FormEntityHierarchy_1>>;
     }
     get stringListMap(): ObjectModel_1<Record<string, ReadonlyArray<string>>> {
-        return this[_getPropertyModel_1]("stringListMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, ReadonlyArray<string>>>;
+        return this[_getPropertyModel_1]("stringListMap", ObjectModel_1, [false]) as ObjectModel_1<Record<string, ReadonlyArray<string>>>;
     }
     get selfReferenceMap(): ObjectModel_1<Record<string, FormRecordTypes_1>> {
-        return this[_getPropertyModel_1]("selfReferenceMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, FormRecordTypes_1>>;
+        return this[_getPropertyModel_1]("selfReferenceMap", ObjectModel_1, [false]) as ObjectModel_1<Record<string, FormRecordTypes_1>>;
     }
     get complexMap(): ObjectModel_1<Record<string, Record<string, ReadonlyArray<FormOptionalTypes_1>>>> {
-        return this[_getPropertyModel_1]("complexMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, Record<string, ReadonlyArray<FormOptionalTypes_1>>>>;
+        return this[_getPropertyModel_1]("complexMap", ObjectModel_1, [false]) as ObjectModel_1<Record<string, Record<string, ReadonlyArray<FormOptionalTypes_1>>>>;
     }
     get objectMap(): ObjectModel_1<Record<string, unknown>> {
-        return this[_getPropertyModel_1]("objectMap", ObjectModel_1, [true]) as ObjectModel_1<Record<string, unknown>>;
+        return this[_getPropertyModel_1]("objectMap", ObjectModel_1, [false]) as ObjectModel_1<Record<string, unknown>>;
     }
 }
 export default FormRecordTypesModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormTemporalTypesModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormTemporalTypesModel.snap.ts
@@ -3,10 +3,10 @@ import type FormTemporalTypes_1 from "./FormTemporalTypes";
 class FormTemporalTypesModel<T extends FormTemporalTypes_1 = FormTemporalTypes_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormTemporalTypes_1;
     get localDate(): StringModel_1 {
-        return this[_getPropertyModel_1]("localDate", StringModel_1, [true]) as StringModel_1;
+        return this[_getPropertyModel_1]("localDate", StringModel_1, [false]) as StringModel_1;
     }
     get localTime(): StringModel_1 {
-        return this[_getPropertyModel_1]("localTime", StringModel_1, [true]) as StringModel_1;
+        return this[_getPropertyModel_1]("localTime", StringModel_1, [false]) as StringModel_1;
     }
 }
 export default FormTemporalTypesModel;

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormValidationConstraintsModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormValidationConstraintsModel.snap.ts
@@ -4,37 +4,37 @@ import type FormValidationConstraints_1 from "./FormValidationConstraints";
 class FormValidationConstraintsModel<T extends FormValidationConstraints_1 = FormValidationConstraints_1> extends ObjectModel_1<T> {
     declare static createEmptyValue: () => FormValidationConstraints_1;
     get list(): ArrayModel_1<string, StringModel_1> {
-        return this[_getPropertyModel_1]("list", ArrayModel_1, [true, StringModel_1, [true], new NotEmpty_1()]) as ArrayModel_1<string, StringModel_1>;
+        return this[_getPropertyModel_1]("list", ArrayModel_1, [false, StringModel_1, [true], new NotEmpty_1()]) as ArrayModel_1<string, StringModel_1>;
     }
     get email(): StringModel_1 {
-        return this[_getPropertyModel_1]("email", StringModel_1, [true, new Email_1({ message: "foo" })]) as StringModel_1;
+        return this[_getPropertyModel_1]("email", StringModel_1, [false, new Email_1({ message: "foo" })]) as StringModel_1;
     }
     get isNull(): StringModel_1 {
-        return this[_getPropertyModel_1]("isNull", StringModel_1, [true, new Null_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("isNull", StringModel_1, [false, new Null_1()]) as StringModel_1;
     }
     get notNull(): StringModel_1 {
-        return this[_getPropertyModel_1]("notNull", StringModel_1, [true, new NotNull_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("notNull", StringModel_1, [false, new NotNull_1()]) as StringModel_1;
     }
     get notEmpty(): StringModel_1 {
-        return this[_getPropertyModel_1]("notEmpty", StringModel_1, [true, new NotEmpty_1(), new NotNull_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("notEmpty", StringModel_1, [false, new NotEmpty_1(), new NotNull_1()]) as StringModel_1;
     }
     get notNullEntity(): FormEntityModel_1 {
-        return this[_getPropertyModel_1]("notNullEntity", FormEntityModel_1, [true]) as FormEntityModel_1;
+        return this[_getPropertyModel_1]("notNullEntity", FormEntityModel_1, [false]) as FormEntityModel_1;
     }
     get notBlank(): StringModel_1 {
-        return this[_getPropertyModel_1]("notBlank", StringModel_1, [true, new NotBlank_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("notBlank", StringModel_1, [false, new NotBlank_1()]) as StringModel_1;
     }
     get assertTrue(): StringModel_1 {
-        return this[_getPropertyModel_1]("assertTrue", StringModel_1, [true, new AssertTrue_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("assertTrue", StringModel_1, [false, new AssertTrue_1()]) as StringModel_1;
     }
     get assertFalse(): StringModel_1 {
-        return this[_getPropertyModel_1]("assertFalse", StringModel_1, [true, new AssertFalse_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("assertFalse", StringModel_1, [false, new AssertFalse_1()]) as StringModel_1;
     }
     get min(): NumberModel_1 {
-        return this[_getPropertyModel_1]("min", NumberModel_1, [true, new Min_1({ value: 1, message: "foo" })]) as NumberModel_1;
+        return this[_getPropertyModel_1]("min", NumberModel_1, [false, new Min_1({ value: 1, message: "foo" })]) as NumberModel_1;
     }
     get max(): NumberModel_1 {
-        return this[_getPropertyModel_1]("max", NumberModel_1, [true, new Max_1(2)]) as NumberModel_1;
+        return this[_getPropertyModel_1]("max", NumberModel_1, [false, new Max_1(2)]) as NumberModel_1;
     }
     get decimalMin(): NumberModel_1 {
         return this[_getPropertyModel_1]("decimalMin", NumberModel_1, [false, new DecimalMin_1("0.01")]) as NumberModel_1;
@@ -55,22 +55,22 @@ class FormValidationConstraintsModel<T extends FormValidationConstraints_1 = For
         return this[_getPropertyModel_1]("positiveOrZero", NumberModel_1, [false, new PositiveOrZero_1()]) as NumberModel_1;
     }
     get size(): StringModel_1 {
-        return this[_getPropertyModel_1]("size", StringModel_1, [true, new Size_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("size", StringModel_1, [false, new Size_1()]) as StringModel_1;
     }
     get size1(): StringModel_1 {
-        return this[_getPropertyModel_1]("size1", StringModel_1, [true, new Size_1({ min: 1 })]) as StringModel_1;
+        return this[_getPropertyModel_1]("size1", StringModel_1, [false, new Size_1({ min: 1 })]) as StringModel_1;
     }
     get digits(): StringModel_1 {
-        return this[_getPropertyModel_1]("digits", StringModel_1, [true, new Digits_1({ integer: 5, fraction: 2 })]) as StringModel_1;
+        return this[_getPropertyModel_1]("digits", StringModel_1, [false, new Digits_1({ integer: 5, fraction: 2 })]) as StringModel_1;
     }
     get past(): StringModel_1 {
-        return this[_getPropertyModel_1]("past", StringModel_1, [true, new Past_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("past", StringModel_1, [false, new Past_1()]) as StringModel_1;
     }
     get future(): StringModel_1 {
-        return this[_getPropertyModel_1]("future", StringModel_1, [true, new Future_1()]) as StringModel_1;
+        return this[_getPropertyModel_1]("future", StringModel_1, [false, new Future_1()]) as StringModel_1;
     }
     get pattern(): StringModel_1 {
-        return this[_getPropertyModel_1]("pattern", StringModel_1, [true, new Pattern_1({ regexp: "\\d+\\..+" })]) as StringModel_1;
+        return this[_getPropertyModel_1]("pattern", StringModel_1, [false, new Pattern_1({ regexp: "\\d+\\..+" })]) as StringModel_1;
     }
 }
 export default FormValidationConstraintsModel;


### PR DESCRIPTION
Parser no longer emits the list of required fields for an entity, but model generator was relying on it. The implementation changes to use `nullable` as in the entity generation.

Fixes #790.