### PR TITLE
fix(engine): let NonNullPlugin find `NonNullApi` annotation on parent packages

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
@@ -37,8 +37,8 @@ public abstract class PackageInfoModel extends AnnotatedAbstractModel
 
     /**
      * Returns a list of all ancestor packages, starting with the immediate
-     * parent package. Note that not all packages are available in the class
-     * loader, so the list can have "holes".
+     * parent package. Note that not all packages are available in the
+     * hierarchy, so the list can have "holes".
      *
      * @return the list of all valid ancestor packages
      */

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
@@ -1,5 +1,7 @@
 package dev.hilla.parser.models;
 
+import java.util.List;
+
 import io.github.classgraph.PackageInfo;
 
 public abstract class PackageInfoModel extends AnnotatedAbstractModel
@@ -32,6 +34,15 @@ public abstract class PackageInfoModel extends AnnotatedAbstractModel
     public Class<PackageInfoModel> getCommonModelClass() {
         return PackageInfoModel.class;
     }
+
+    /**
+     * Returns a list of all ancestor packages, starting with the immediate
+     * parent package. Note that not all packages are available in the class
+     * loader, so the list can have "holes".
+     *
+     * @return the list of all valid ancestor packages
+     */
+    public abstract List<PackageInfoModel> getAncestors();
 
     @Override
     public int hashCode() {

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -2,6 +2,7 @@ package dev.hilla.parser.models;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class PackageInfoReflectionModel extends PackageInfoModel {
@@ -31,7 +32,7 @@ class PackageInfoReflectionModel extends PackageInfoModel {
         var classLoader = getClass().getClassLoader();
         return getAllAncestorPackageNames(origin.getName())
                 .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
-                .map(PackageInfoModel::of).collect(Collectors::toList);
+                .map(PackageInfoModel::of).collect(Collectors.toList());
     }
 
     /**

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -1,6 +1,8 @@
 package dev.hilla.parser.models;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 class PackageInfoReflectionModel extends PackageInfoModel {
     private final Package origin;
@@ -22,5 +24,27 @@ class PackageInfoReflectionModel extends PackageInfoModel {
     @Override
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getDeclaredAnnotations());
+    }
+
+    @Override
+    public List<PackageInfoModel> getAncestors() {
+        var classLoader = getClass().getClassLoader();
+        return getAllAncestorPackageNames(origin.getName())
+                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
+                .map(PackageInfoModel::of).toList();
+    }
+
+    /**
+     * Returns a stream of all ancestor package names, starting with the
+     * immediate parent package.
+     *
+     * @param packageName
+     *            the package name
+     * @return the stream of all ancestor package names
+     */
+    private static Stream<String> getAllAncestorPackageNames(
+            String packageName) {
+        return Stream.iterate(packageName, p -> p.contains("."),
+                p -> p.substring(0, p.lastIndexOf('.')));
     }
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -31,7 +31,7 @@ class PackageInfoReflectionModel extends PackageInfoModel {
         var classLoader = getClass().getClassLoader();
         return getAllAncestorPackageNames(origin.getName())
                 .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
-                .map(PackageInfoModel::of).toList();
+                .map(PackageInfoModel::of).collect(Collectors::toList);
     }
 
     /**

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
@@ -25,4 +25,10 @@ class PackageInfoSourceModel extends PackageInfoModel {
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getAnnotationInfo());
     }
+
+    @Override
+    public List<PackageInfoModel> getAncestors() {
+        // not implemented
+        return List.of();
+    }
 }

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -105,7 +105,7 @@ public class PackageInfoModelTests {
         var model = PackageInfoModel.of(ctx.getReflectionOrigin());
         var ancestors = model.getAncestors();
         var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
-                .sorted().toList();
+                .sorted().collect(Collectors.toList());
 
         // `getAncestors()` returns only valid packages, so the result of this
         // test could vary if some class is added to, or removed from, any

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -99,6 +99,21 @@ public class PackageInfoModelTests {
         }
     }
 
+    @DisplayName("It should return all valid ancestors")
+    @Test
+    public void should_ReturnAllValidAncestors() {
+        var model = PackageInfoModel.of(ctx.getReflectionOrigin());
+        var ancestors = model.getAncestors();
+        var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
+                .sorted().toList();
+
+        // `getAncestors()` returns only valid packages, so the result of this
+        // test could vary if some class is added to, or removed from, any
+        // ancestor package
+        assertEquals(List.of("dev.hilla.parser.models",
+                "dev.hilla.parser.models.pack"), ancestorNames);
+    }
+
     static class Context {
         private static final Package reflectionOrigin = PackageInfoModelSample.class
                 .getPackage();

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
@@ -115,9 +115,43 @@ public final class NonnullPlugin extends AbstractPlugin<NonnullPluginConfig> {
                 .map(ClassInfoModel::getPackage);
     }
 
+    /**
+     * Returns a stream of all ancestor packages, starting with the immediate
+     * parent package.
+     *
+     * @param nodePath
+     *            the node path
+     * @return the stream of all ancestor packages
+     */
+    private Stream<PackageInfoModel> findAscendantPackages(
+            NodePath<?> nodePath) {
+        var pkg = (Package) findClosestPackage(nodePath).orElseThrow().get();
+        // Packages are searched by name using the class loader from the node
+        // source. Not all packages exist, so we need to filter them out.
+        var classLoader = nodePath.getNode().getSource().getClass()
+                .getClassLoader();
+        return getAllAncestorPackageNames(pkg.getName())
+                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
+                .map(PackageInfoModel::of);
+    }
+
+    /**
+     * Returns a stream of all ancestor package names, starting with the
+     * immediate parent package.
+     *
+     * @param packageName
+     *            the package name
+     * @return the stream of all ancestor package names
+     */
+    private static Stream<String> getAllAncestorPackageNames(
+            String packageName) {
+        return Stream.iterate(packageName, p -> p.contains("."),
+                p -> p.substring(0, p.lastIndexOf('.')));
+    }
+
     private Stream<AnnotationInfoModel> getPackageAnnotationsStream(
             NodePath<?> nodePath) {
-        return findClosestPackage(nodePath).stream()
+        return findAscendantPackages(nodePath)
                 .map(PackageInfoModel::getAnnotations)
                 .flatMap(Collection::stream);
     }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/NonNullApiEndpoint.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/NonNullApiEndpoint.java
@@ -4,6 +4,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import dev.hilla.parser.plugins.nonnull.nonnullapi.subpackage.SubPackageDependency;
+
 @Endpoint
 public class NonNullApiEndpoint {
     public Dependency defaultMethod(String param) {
@@ -40,5 +42,9 @@ public class NonNullApiEndpoint {
 
     public Optional<String> optionalMethod(Optional<String> opt) {
         return opt;
+    }
+
+    public SubPackageDependency subPackageMethod(SubPackageDependency entity) {
+        return entity;
     }
 }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/subpackage/SubPackageDependency.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/subpackage/SubPackageDependency.java
@@ -1,0 +1,5 @@
+package dev.hilla.parser.plugins.nonnull.nonnullapi.subpackage;
+
+public class SubPackageDependency {
+    public String defaultField;
+}

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/resources/dev/hilla/parser/plugins/nonnull/nonnullapi/openapi.json
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/resources/dev/hilla/parser/plugins/nonnull/nonnullapi/openapi.json
@@ -263,6 +263,46 @@
           }
         }
       }
+    },
+    "/NonNullApiEndpoint/subPackageMethod": {
+      "post": {
+        "tags": ["NonNullApiEndpoint"],
+        "operationId": "NonNullApiEndpoint_subPackageMethod_POST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "entity": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.nonnull.nonnullapi.subpackage.SubPackageDependency"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.nonnull.nonnullapi.subpackage.SubPackageDependency"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -280,6 +320,14 @@
           "nullableSignatureField": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "dev.hilla.parser.plugins.nonnull.nonnullapi.subpackage.SubPackageDependency": {
+        "type": "object",
+        "properties": {
+          "defaultField": {
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
Modifies the NonnullPlugin to apply `@NonNullApi` annotation from ancestor packages.

Fixes #788