### PR TITLE
feat: support ES-module application by adding .js to generated imports

### DIFF
--- a/packages/ts/generator-typescript-utils/src/dependencies/ImportManager.ts
+++ b/packages/ts/generator-typescript-utils/src/dependencies/ImportManager.ts
@@ -68,7 +68,6 @@ export class NamedImportManager extends StatementRecordManager<ImportDeclaration
         path,
         ts.factory.createImportDeclaration(
           undefined,
-          undefined,
           ts.factory.createImportClause(
             false,
             undefined,
@@ -119,9 +118,8 @@ export class NamespaceImportManager extends StatementRecordManager<ImportDeclara
         path,
         ts.factory.createImportDeclaration(
           undefined,
-          undefined,
           ts.factory.createImportClause(false, undefined, ts.factory.createNamespaceImport(id)),
-          ts.factory.createStringLiteral(path),
+          ts.factory.createStringLiteral(`${path}.js`),
         ),
       ];
     }
@@ -165,9 +163,8 @@ export class DefaultImportManager extends StatementRecordManager<ImportDeclarati
         path,
         ts.factory.createImportDeclaration(
           undefined,
-          undefined,
           ts.factory.createImportClause(isType, id, undefined),
-          ts.factory.createStringLiteral(path),
+          ts.factory.createStringLiteral(`${path}.js`),
         ),
       ];
     }


### PR DESCRIPTION
As part of fixing https://github.com/vaadin/react-components/issues/64, we want to offer Hilla developer the possibility to switch to ES modules by adding `"type": "module"` to `package.json`.

This PR adds `.js` to generated imports to make generated code compatible with such projects.