### PR TITLE
fix: use classloader from current class to find packages

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
@@ -32,7 +32,6 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     private List<ClassInfoModel> innerClasses;
     private List<ClassRefSignatureModel> interfaces;
     private List<MethodInfoModel> methods;
-    private PackageInfoModel pkg;
     private List<PackageInfoModel> ancestors;
     private Optional<ClassRefSignatureModel> superClass;
     private List<TypeParameterModel> typeParameters;
@@ -300,14 +299,6 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
         return methods;
     }
 
-    public PackageInfoModel getPackage() {
-        if (pkg == null) {
-            pkg = preparePackage();
-        }
-
-        return pkg;
-    }
-
     /**
      * Tries to find all packages that are ancestors of this class. From the
      * list of all possible ancestor packages, only those whose existence is
@@ -449,8 +440,6 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     protected abstract List<ClassRefSignatureModel> prepareInterfaces();
 
     protected abstract List<MethodInfoModel> prepareMethods();
-
-    protected abstract PackageInfoModel preparePackage();
 
     protected abstract List<PackageInfoModel> prepareAncestors();
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
@@ -33,6 +33,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     private List<ClassRefSignatureModel> interfaces;
     private List<MethodInfoModel> methods;
     private PackageInfoModel pkg;
+    private List<PackageInfoModel> ancestors;
     private Optional<ClassRefSignatureModel> superClass;
     private List<TypeParameterModel> typeParameters;
 
@@ -307,6 +308,22 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
         return pkg;
     }
 
+    /**
+     * Tries to find all packages that are ancestors of this class. From the
+     * list of all possible ancestor packages, only those whose existence is
+     * confirmed are returned. This is a "best effort" to find them as, even if
+     * they exist, there is no guarantee that they have already been loaded.
+     *
+     * @return a list of packages that are ancestors of this class
+     */
+    public List<PackageInfoModel> findAllAvailableAncestors() {
+        if (ancestors == null) {
+            ancestors = prepareAncestors();
+        }
+
+        return ancestors;
+    }
+
     public abstract String getSimpleName();
 
     @Override
@@ -318,6 +335,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
         return typeParameters;
     }
 
+    @Override
     public int hashCode() {
         return 3 + getName().hashCode();
     }
@@ -394,6 +412,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
         return isAssignableFrom(cls.getClass());
     }
 
+    @Override
     public abstract boolean isEnum();
 
     public abstract boolean isFinal();
@@ -432,6 +451,8 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     protected abstract List<MethodInfoModel> prepareMethods();
 
     protected abstract PackageInfoModel preparePackage();
+
+    protected abstract List<PackageInfoModel> prepareAncestors();
 
     protected abstract ClassRefSignatureModel prepareSuperClass();
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
@@ -307,7 +307,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
      *
      * @return a list of packages that are ancestors of this class
      */
-    public List<PackageInfoModel> findAllAvailableAncestors() {
+    public List<PackageInfoModel> findAncestors() {
         if (ancestors == null) {
             ancestors = prepareAncestors();
         }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -234,12 +234,13 @@ final class ClassInfoReflectionModel extends ClassInfoModel
      * Returns a stream of all ancestor package names, starting with the package
      * itself.
      *
-     * @param name
-     *            the package name
+     * @param packageName
+     *            the package packageName
      * @return the stream of all ancestor package names
      */
-    private static Stream<String> getAllAncestorPackageNames(String name) {
-        return Stream.iterate(name, n -> n.contains("."),
+    private static Stream<String> getAllAncestorPackageNames(
+            String packageName) {
+        return Stream.iterate(packageName, n -> n.contains("."),
                 n -> n.substring(0, n.lastIndexOf('.')));
     }
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -6,8 +6,10 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 final class ClassInfoReflectionModel extends ClassInfoModel
         implements ReflectionModel {
@@ -222,6 +224,28 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     @Override
     protected PackageInfoModel preparePackage() {
         return PackageInfoModel.of(origin.getPackage());
+    }
+
+    @Override
+    protected List<PackageInfoModel> prepareAncestors() {
+        var classLoader = origin.getClassLoader();
+
+        return getAllAncestorPackageNames(origin.getPackageName())
+                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
+                .map(PackageInfoModel::of).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a stream of all ancestor package names, starting with the package
+     * itself.
+     *
+     * @param name
+     *            the package name
+     * @return the stream of all ancestor package names
+     */
+    private static Stream<String> getAllAncestorPackageNames(String name) {
+        return Stream.iterate(name, n -> n.contains("."),
+                n -> n.substring(0, n.lastIndexOf('.')));
     }
 
     @Override

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -222,11 +222,6 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     }
 
     @Override
-    protected PackageInfoModel preparePackage() {
-        return PackageInfoModel.of(origin.getPackage());
-    }
-
-    @Override
     protected List<PackageInfoModel> prepareAncestors() {
         var classLoader = origin.getClassLoader();
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
@@ -226,7 +226,8 @@ final class ClassInfoSourceModel extends ClassInfoModel implements SourceModel {
 
     @Override
     protected List<PackageInfoModel> prepareAncestors() {
-        // This is just a dummy implementation, as source models are no longer used
+        // This is just a dummy implementation, as source models are no longer
+        // used
         return List.of(getPackage());
     }
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
@@ -220,15 +220,10 @@ final class ClassInfoSourceModel extends ClassInfoModel implements SourceModel {
     }
 
     @Override
-    protected PackageInfoModel preparePackage() {
-        return PackageInfoModel.of(origin.getPackageInfo());
-    }
-
-    @Override
     protected List<PackageInfoModel> prepareAncestors() {
         // This is just a dummy implementation, as source models are no longer
-        // used
-        return List.of(getPackage());
+        // used. It only returns the package of the class.
+        return List.of(PackageInfoModel.of(origin.getPackageInfo()));
     }
 
     @Override

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
@@ -225,6 +225,12 @@ final class ClassInfoSourceModel extends ClassInfoModel implements SourceModel {
     }
 
     @Override
+    protected List<PackageInfoModel> prepareAncestors() {
+        // This is just a dummy implementation, as source models are no longer used
+        return List.of(getPackage());
+    }
+
+    @Override
     protected ClassRefSignatureModel prepareSuperClass() {
         var superClass = origin.getTypeSignatureOrTypeDescriptor()
                 .getSuperclassSignature();

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
@@ -1,7 +1,5 @@
 package dev.hilla.parser.models;
 
-import java.util.List;
-
 import io.github.classgraph.PackageInfo;
 
 public abstract class PackageInfoModel extends AnnotatedAbstractModel
@@ -34,15 +32,6 @@ public abstract class PackageInfoModel extends AnnotatedAbstractModel
     public Class<PackageInfoModel> getCommonModelClass() {
         return PackageInfoModel.class;
     }
-
-    /**
-     * Returns a list of all ancestor packages, starting with the immediate
-     * parent package. Note that not all packages are available in the
-     * hierarchy, so the list can have "holes".
-     *
-     * @return the list of all valid ancestor packages
-     */
-    public abstract List<PackageInfoModel> getAncestors();
 
     @Override
     public int hashCode() {

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
@@ -1,5 +1,7 @@
 package dev.hilla.parser.models;
 
+import java.util.List;
+
 import io.github.classgraph.PackageInfo;
 
 public abstract class PackageInfoModel extends AnnotatedAbstractModel
@@ -32,6 +34,18 @@ public abstract class PackageInfoModel extends AnnotatedAbstractModel
     public Class<PackageInfoModel> getCommonModelClass() {
         return PackageInfoModel.class;
     }
+
+    /**
+     * Returns a list of all ancestor packages, starting with the immediate
+     * parent package. Note that not all packages are available in the
+     * hierarchy, so the list can have "holes".
+     *
+     * @return the list of all valid ancestor packages
+     * @deprecated the implementation is flawed and cannot be fixed, will be
+     *             replaced by a similar method in {@link ClassInfoModel}
+     */
+    @Deprecated(forRemoval = true)
+    public abstract List<PackageInfoModel> getAncestors();
 
     @Override
     public int hashCode() {

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoModel.java
@@ -1,7 +1,5 @@
 package dev.hilla.parser.models;
 
-import java.util.List;
-
 import io.github.classgraph.PackageInfo;
 
 public abstract class PackageInfoModel extends AnnotatedAbstractModel
@@ -34,18 +32,6 @@ public abstract class PackageInfoModel extends AnnotatedAbstractModel
     public Class<PackageInfoModel> getCommonModelClass() {
         return PackageInfoModel.class;
     }
-
-    /**
-     * Returns a list of all ancestor packages, starting with the immediate
-     * parent package. Note that not all packages are available in the
-     * hierarchy, so the list can have "holes".
-     *
-     * @return the list of all valid ancestor packages
-     * @deprecated the implementation is flawed and cannot be fixed, will be
-     *             replaced by a similar method in {@link ClassInfoModel}
-     */
-    @Deprecated(forRemoval = true)
-    public abstract List<PackageInfoModel> getAncestors();
 
     @Override
     public int hashCode() {

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -1,9 +1,6 @@
 package dev.hilla.parser.models;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 class PackageInfoReflectionModel extends PackageInfoModel {
     private final Package origin;
@@ -25,27 +22,5 @@ class PackageInfoReflectionModel extends PackageInfoModel {
     @Override
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getDeclaredAnnotations());
-    }
-
-    @Override
-    public List<PackageInfoModel> getAncestors() {
-        var classLoader = getClass().getClassLoader();
-        return getAllAncestorPackageNames(origin.getName())
-                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
-                .map(PackageInfoModel::of).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns a stream of all ancestor package names, starting with the
-     * immediate parent package.
-     *
-     * @param packageName
-     *            the package name
-     * @return the stream of all ancestor package names
-     */
-    private static Stream<String> getAllAncestorPackageNames(
-            String packageName) {
-        return Stream.iterate(packageName, p -> p.contains("."),
-                p -> p.substring(0, p.lastIndexOf('.')));
     }
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -1,9 +1,6 @@
 package dev.hilla.parser.models;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 class PackageInfoReflectionModel extends PackageInfoModel {
     private final Package origin;
@@ -25,30 +22,5 @@ class PackageInfoReflectionModel extends PackageInfoModel {
     @Override
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getDeclaredAnnotations());
-    }
-
-    @Override
-    public List<PackageInfoModel> getAncestors() {
-        // This classloader is not always the good one. This method should not
-        // exist and a similar one should be created in ClassInfoReflectionModel
-        // using the classloader of the class.
-        var classLoader = getClass().getClassLoader();
-        return getAllAncestorPackageNames(origin.getName())
-                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
-                .map(PackageInfoModel::of).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns a stream of all ancestor package names, starting with the
-     * immediate parent package.
-     *
-     * @param packageName
-     *            the package name
-     * @return the stream of all ancestor package names
-     */
-    private static Stream<String> getAllAncestorPackageNames(
-            String packageName) {
-        return Stream.iterate(packageName, p -> p.contains("."),
-                p -> p.substring(0, p.lastIndexOf('.')));
     }
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoReflectionModel.java
@@ -1,6 +1,9 @@
 package dev.hilla.parser.models;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 class PackageInfoReflectionModel extends PackageInfoModel {
     private final Package origin;
@@ -22,5 +25,30 @@ class PackageInfoReflectionModel extends PackageInfoModel {
     @Override
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getDeclaredAnnotations());
+    }
+
+    @Override
+    public List<PackageInfoModel> getAncestors() {
+        // This classloader is not always the good one. This method should not
+        // exist and a similar one should be created in ClassInfoReflectionModel
+        // using the classloader of the class.
+        var classLoader = getClass().getClassLoader();
+        return getAllAncestorPackageNames(origin.getName())
+                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
+                .map(PackageInfoModel::of).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a stream of all ancestor package names, starting with the
+     * immediate parent package.
+     *
+     * @param packageName
+     *            the package name
+     * @return the stream of all ancestor package names
+     */
+    private static Stream<String> getAllAncestorPackageNames(
+            String packageName) {
+        return Stream.iterate(packageName, p -> p.contains("."),
+                p -> p.substring(0, p.lastIndexOf('.')));
     }
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
@@ -25,10 +25,4 @@ class PackageInfoSourceModel extends PackageInfoModel {
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getAnnotationInfo());
     }
-
-    @Override
-    public List<PackageInfoModel> getAncestors() {
-        // not implemented
-        return List.of();
-    }
 }

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/PackageInfoSourceModel.java
@@ -25,4 +25,10 @@ class PackageInfoSourceModel extends PackageInfoModel {
     protected List<AnnotationInfoModel> prepareAnnotations() {
         return processAnnotations(origin.getAnnotationInfo());
     }
+
+    @Override
+    public List<PackageInfoModel> getAncestors() {
+        // not implemented
+        return List.of();
+    }
 }

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/Dummy.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/Dummy.java
@@ -1,0 +1,10 @@
+package dev.hilla;
+
+/**
+ * This class only exists to make its package exist and be able to test the
+ * {@link dev.hilla.parser.models.ClassInfoModel#findAllAvailableAncestors()}
+ * method.
+ */
+public class Dummy {
+
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/Dummy.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/Dummy.java
@@ -2,8 +2,7 @@ package dev.hilla;
 
 /**
  * This class only exists to make its package exist and be able to test the
- * {@link dev.hilla.parser.models.ClassInfoModel#findAllAvailableAncestors()}
- * method.
+ * {@link dev.hilla.parser.models.ClassInfoModel#findAncestors()} method.
  */
 public class Dummy {
 

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
@@ -350,13 +350,13 @@ public class ClassInfoModelTests {
         // Load the `dev.hilla` package
         var dummy = new dev.hilla.Dummy();
         var model = ClassInfoModel.of(ctx.getReflectionOrigin());
-        var ancestors = model.findAllAvailableAncestors();
+        var ancestors = model.findAncestors();
         var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
                 .sorted().collect(Collectors.toList());
 
-        // `findAllAvailableAncestors()` returns only valid packages, so the
-        // result of this test could vary if some class is added to, or removed
-        // from, any ancestor package
+        // `findAncestors()` returns only valid packages, so the result of this
+        // test could vary if some class is added to, or removed from, any
+        // ancestor package
         assertEquals(List.of("dev.hilla", "dev.hilla.parser.models"),
                 ancestorNames);
     }

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
@@ -344,6 +344,23 @@ public class ClassInfoModelTests {
         }
     }
 
+    @DisplayName("It should return all valid ancestors packages")
+    @Test
+    public void should_ReturnAllValidAncestorsPackages() {
+        // Load the `dev.hilla` package
+        var dummy = new dev.hilla.Dummy();
+        var model = ClassInfoModel.of(ctx.getReflectionOrigin());
+        var ancestors = model.findAllAvailableAncestors();
+        var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
+                .sorted().collect(Collectors.toList());
+
+        // `findAllAvailableAncestors()` returns only valid packages, so the
+        // result of this test could vary if some class is added to, or removed
+        // from, any ancestor package
+        assertEquals(List.of("dev.hilla", "dev.hilla.parser.models"),
+                ancestorNames);
+    }
+
     static final class Characteristics {
         enum Enum {
         }

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -99,6 +99,21 @@ public class PackageInfoModelTests {
         }
     }
 
+    @DisplayName("It should return all valid ancestors")
+    @Test
+    public void should_ReturnAllValidAncestors() {
+        var model = PackageInfoModel.of(ctx.getReflectionOrigin());
+        var ancestors = model.getAncestors();
+        var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
+                .sorted().collect(Collectors.toList());
+
+        // `getAncestors()` returns only valid packages, so the result of this
+        // test could vary if some class is added to, or removed from, any
+        // ancestor package
+        assertEquals(List.of("dev.hilla.parser.models",
+                "dev.hilla.parser.models.pack"), ancestorNames);
+    }
+
     static class Context {
         private static final Package reflectionOrigin = PackageInfoModelSample.class
                 .getPackage();

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/PackageInfoModelTests.java
@@ -99,21 +99,6 @@ public class PackageInfoModelTests {
         }
     }
 
-    @DisplayName("It should return all valid ancestors")
-    @Test
-    public void should_ReturnAllValidAncestors() {
-        var model = PackageInfoModel.of(ctx.getReflectionOrigin());
-        var ancestors = model.getAncestors();
-        var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
-                .sorted().collect(Collectors.toList());
-
-        // `getAncestors()` returns only valid packages, so the result of this
-        // test could vary if some class is added to, or removed from, any
-        // ancestor package
-        assertEquals(List.of("dev.hilla.parser.models",
-                "dev.hilla.parser.models.pack"), ancestorNames);
-    }
-
     static class Context {
         private static final Package reflectionOrigin = PackageInfoModelSample.class
                 .getPackage();

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
@@ -129,8 +129,8 @@ public final class NonnullPlugin extends AbstractPlugin<NonnullPluginConfig> {
     }
 
     /**
-     * Returns a stream of all ancestor package names, starting with the
-     * immediate parent package.
+     * Returns a stream of all ancestor package names, starting with the package
+     * itself.
      *
      * @param packageName
      *            the package name

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
@@ -117,8 +117,8 @@ public final class NonnullPlugin extends AbstractPlugin<NonnullPluginConfig> {
             NodePath<?> nodePath) {
         return findClosestClass(nodePath)
                 // Find all available ancestor packages
-                .map(ClassInfoModel::findAllAvailableAncestors)
-                .map(Collection::stream).orElseGet(Stream::empty)
+                .map(ClassInfoModel::findAncestors).map(Collection::stream)
+                .orElseGet(Stream::empty)
                 // Get all annotations from packages
                 .map(PackageInfoModel::getAnnotations)
                 .flatMap(Collection::stream);

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -107,20 +106,40 @@ public final class NonnullPlugin extends AbstractPlugin<NonnullPluginConfig> {
                         .process());
     }
 
-    private Optional<PackageInfoModel> findClosestPackage(
-            NodePath<?> nodePath) {
-        return nodePath.stream().map(NodePath::getNode)
-                .filter(node -> node.getSource() instanceof ClassInfoModel)
-                .map(node -> (ClassInfoModel) node.getSource()).findFirst()
-                .map(ClassInfoModel::getPackage);
-    }
-
     private Stream<AnnotationInfoModel> getPackageAnnotationsStream(
             NodePath<?> nodePath) {
-        return findClosestPackage(nodePath).map(PackageInfoModel::getAncestors)
-                .map(Collection::stream).orElseGet(Stream::empty)
-                .map(PackageInfoModel::getAnnotations)
+        // Find the closest (enclosing) class
+        var classModel = nodePath.stream().map(NodePath::getNode)
+                .filter(node -> node.getSource() instanceof ClassInfoModel)
+                .map(node -> (ClassInfoModel) node.getSource()).findFirst();
+
+        // Get the classloader of that class, defaults to the system one
+        var classLoader = classModel.map(ClassInfoModel::get)
+                .map(Class.class::cast).map(Class::getClassLoader)
+                .orElse(ClassLoader.getSystemClassLoader());
+
+        return classModel.map(ClassInfoModel::getPackage).stream()
+                // Convert the package to a list of all ancestor package names
+                .flatMap(p -> getAllAncestorPackageNames(p.getName()))
+                // Convert names to real packages and remove those not found
+                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
+                // Convert packages to models and finally to their annotations
+                .map(PackageInfoModel::of).map(PackageInfoModel::getAnnotations)
                 .flatMap(Collection::stream);
+    }
+
+    /**
+     * Returns a stream of all ancestor package names, starting with the
+     * immediate parent package.
+     *
+     * @param packageName
+     *            the package name
+     * @return the stream of all ancestor package names
+     */
+    private static Stream<String> getAllAncestorPackageNames(
+            String packageName) {
+        return Stream.iterate(packageName, p -> p.contains("."),
+                p -> p.substring(0, p.lastIndexOf('.')));
     }
 
     /**


### PR DESCRIPTION
Move the API to the ClassInfoModel where we have the good class loader. Finding ancestors is still a "best effort" since packages start existing when a class is loaded from them (see test for an example).

Fixes #816