### PR TITLE
Trim whitespace before checking length of string. Fixes #833

### DIFF
--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -139,7 +139,7 @@ export class NotBlank extends Required<any> {
   }
 
   public override validate(value: any) {
-    return new NotEmpty().validate(value);
+    return super.validate(value) && new NotNull().validate(value) && value.trim().length > 0;
   }
 }
 export class AssertTrue extends AbstractValidator<any> {

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -92,6 +92,8 @@ describe('form/Validators', () => {
     assert.isTrue(validator.validate('a'));
     assert.isFalse(validator.validate(''));
     assert.isFalse(validator.validate(undefined));
+    assert.isFalse(validator.validate(' '));
+    assert.isFalse(validator.validate('\t'));
   });
 
   it('AssertTrue', () => {


### PR DESCRIPTION
## Description

Fix the NotBlank validator to trim whitespace in line with it's jakarta.validator equivalent.

Fixes #833

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
