### PR TITLE
feat(form): consider errors from HTML and Vaadin components built-in validation

### DIFF
--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -31,6 +31,7 @@ import {
   ObjectModel,
 } from './Models.js';
 import type { Validator, ValueError } from './Validation.js';
+import { _validity } from './Validity.js';
 
 const _ownErrors = Symbol('ownErrorsSymbol');
 const _visited = Symbol('visited');
@@ -55,11 +56,11 @@ export class ValidityStateValidator<T, M extends AbstractModel<T>> implements Va
   }
 
   validate(): boolean {
-    if (!this.binderNode.validity) {
+    if (!this.binderNode[_validity]) {
       return true;
     }
 
-    return this.binderNode.validity.valid;
+    return this.binderNode[_validity].valid;
   }
 }
 
@@ -89,7 +90,7 @@ export class BinderNode<T, M extends AbstractModel<T>> {
    * For elements with `validity.valid === false`, the value in the
    * bound element is considered as invalid.
    */
-  public validity?: ValidityState;
+  public [_validity]?: ValidityState;
 
   private readonly validityStateValidator: ValidityStateValidator<T, M>;
 
@@ -389,7 +390,7 @@ export class BinderNode<T, M extends AbstractModel<T>> {
   }
 
   private runOwnValidators(): ReadonlyArray<Promise<ReadonlyArray<ValueError<any>>>> {
-    if (this.validity && !this.validity.valid) {
+    if (this[_validity] && !this[_validity].valid) {
       // The element's internal validation reported invalid state.
       // This means the `value` cannot be used and even meaningfully
       // validated with the validators in the binder, because it is

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -31,6 +31,7 @@ import {
   ObjectModel,
 } from './Models.js';
 import type { Validator, ValueError } from './Validation.js';
+import { ValidityStateValidator } from './Validators.js';
 import { _validity } from './Validity.js';
 
 const _ownErrors = Symbol('ownErrorsSymbol');
@@ -38,24 +39,6 @@ const _visited = Symbol('visited');
 
 function getErrorPropertyName(valueError: ValueError<any>): string {
   return typeof valueError.property === 'string' ? valueError.property : getBinderNode(valueError.property).name;
-}
-
-/**
- * Validator that reports an error when the bound HTML element validation
- * returns false from `element.checkValidity()` and `element.validity.valid`.
- */
-export class ValidityStateValidator<T, M extends AbstractModel<T>> implements Validator<T> {
-  public message = '';
-
-  private binderNode: BinderNode<T, M>;
-
-  constructor(binderNode: BinderNode<T, M>) {
-    this.binderNode = binderNode;
-  }
-
-  validate(): boolean {
-    return false;
-  }
 }
 
 /**
@@ -86,12 +69,12 @@ export class BinderNode<T, M extends AbstractModel<T>> {
    */
   public [_validity]?: ValidityState;
 
-  private readonly validityStateValidator: ValidityStateValidator<T, M>;
+  private readonly validityStateValidator: ValidityStateValidator<T>;
 
   public constructor(model: M) {
     this.model = model;
     model[_binderNode] = this;
-    this.validityStateValidator = new ValidityStateValidator<T, M>(this);
+    this.validityStateValidator = new ValidityStateValidator<T>();
     this.initializeValue();
     this[_validators] = model[_validators];
   }

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -41,26 +41,20 @@ function getErrorPropertyName(valueError: ValueError<any>): string {
 }
 
 /**
- * Validator for verifyng that the `validity.valid` state is true. Used
- * internally in the binder nodes to take the bound HTML element's internal
- * validation state into account.
+ * Validator that reports an error when the bound HTML element validation
+ * returns false from `element.checkValidity()` and `element.validity.valid`.
  */
 export class ValidityStateValidator<T, M extends AbstractModel<T>> implements Validator<T> {
   public message = '';
 
   private binderNode: BinderNode<T, M>;
 
-  // eslint-disable-next-line no-useless-constructor
   constructor(binderNode: BinderNode<T, M>) {
     this.binderNode = binderNode;
   }
 
   validate(): boolean {
-    if (!this.binderNode[_validity]) {
-      return true;
-    }
-
-    return this.binderNode[_validity].valid;
+    return false;
   }
 }
 

--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -396,8 +396,11 @@ export class Pattern extends AbstractValidator<string> {
  * returns false from `element.checkValidity()` and `element.validity.valid`.
  */
 export class ValidityStateValidator<T> extends AbstractValidator<T> {
-  public constructor(attrs: ValidatorAttributes = {}) {
-    super({ message: '', ...attrs });
+  public override message = '';
+
+  // eslint-disable-next-line no-useless-constructor
+  public constructor() {
+    super();
   }
 
   public override validate(): boolean {

--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -390,3 +390,17 @@ export class Pattern extends AbstractValidator<string> {
     return matches(value, this.regexp);
   }
 }
+
+/**
+ * Validator that reports an error when the bound HTML element validation
+ * returns false from `element.checkValidity()` and `element.validity.valid`.
+ */
+export class ValidityStateValidator<T> extends AbstractValidator<T> {
+  public constructor(attrs: ValidatorAttributes = {}) {
+    super({ message: '', ...attrs });
+  }
+
+  public override validate(): boolean {
+    return false;
+  }
+}

--- a/packages/ts/form/src/Validity.ts
+++ b/packages/ts/form/src/Validity.ts
@@ -1,0 +1,21 @@
+/**
+ * Symbol for storing `ValidityState` in the binder nodes.
+ */
+export const _validity = Symbol('validity');
+
+/**
+ * Default validity state with `valid` flag set, assuming a valid state.
+ */
+export const defaultValidity: ValidityState = {
+  badInput: false,
+  customError: false,
+  patternMismatch: false,
+  rangeOverflow: false,
+  rangeUnderflow: false,
+  stepMismatch: false,
+  tooLong: false,
+  tooShort: false,
+  typeMismatch: false,
+  valueMissing: false,
+  valid: true,
+};

--- a/packages/ts/form/test/Binder.test.ts
+++ b/packages/ts/form/test/Binder.test.ts
@@ -76,6 +76,7 @@ describe('form/Binder', () => {
       notes: '',
       priority: 0,
       products: [],
+      total: undefined,
     };
 
     beforeEach(() => {

--- a/packages/ts/form/test/TestModels.ts
+++ b/packages/ts/form/test/TestModels.ts
@@ -74,6 +74,7 @@ export interface Order extends IdEntity {
   notes: string;
   priority: number;
   products: ReadonlyArray<Product>;
+  total?: number;
 }
 export class OrderModel<T extends Order = Order> extends IdEntityModel<T> {
   public declare static createEmptyValue: () => Order;
@@ -96,6 +97,10 @@ export class OrderModel<T extends Order = Order> extends IdEntityModel<T> {
       ArrayModel as ModelConstructor<ReadonlyArray<Product>, ArrayModel<Product, ProductModel>>,
       [false, ProductModel, [false]],
     );
+  }
+
+  public get total(): NumberModel {
+    return this[_getPropertyModel]('total', NumberModel, [true]);
   }
 }
 

--- a/packages/ts/form/test/Validation.test.ts
+++ b/packages/ts/form/test/Validation.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable lit/no-template-arrow, no-unused-expressions, no-shadow */
 import { assert, expect } from '@open-wc/testing';
 import sinon from 'sinon';
-import { css, html, LitElement, property } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 // TODO: remove when the new version of eslint-config-vaadin is released.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -111,7 +111,7 @@ class OrderView extends LitElement {
           </output>
         </div>`,
       )}
-      <h4>Total: <number-output id="total" ${field(total)}"></number-output></h4>
+      <h4>Total: <number-output id="total" ${field(total)}></number-output></h4>
       <div id="submitting">${this.binder.submitting}</div>
     `;
   }

--- a/packages/ts/form/test/Validation.test.ts
+++ b/packages/ts/form/test/Validation.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable lit/no-template-arrow, no-unused-expressions, no-shadow */
 import { assert, expect } from '@open-wc/testing';
 import sinon from 'sinon';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, property } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 // TODO: remove when the new version of eslint-config-vaadin is released.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -29,6 +29,22 @@ import {
   TestMessageInterpolationEntity,
   TestMessageInterpolationModel,
 } from './TestModels';
+
+class NumberOutput extends HTMLElement {
+  public get value(): string {
+    return this.checkValidity() ? this.textContent || '' : '';
+  }
+
+  public set value(value: string) {
+    this.textContent = value;
+  }
+
+  public checkValidity(): boolean {
+    const numericValue = Number(this.textContent);
+    return !Number.isNaN(numericValue) && numericValue.toString() === this.textContent;
+  }
+}
+customElements.define('number-output', NumberOutput);
 
 @customElement('order-view')
 class OrderView extends LitElement {
@@ -58,6 +74,9 @@ class OrderView extends LitElement {
   @query('#priceError0')
   public priceError!: HTMLOutputElement;
 
+  @query('#total')
+  public total!: NumberOutput;
+
   public static override get styles() {
     return css`
       input[invalid] {
@@ -71,6 +90,7 @@ class OrderView extends LitElement {
       notes,
       products,
       customer: { fullName, nickName },
+      total,
     } = this.binder.model;
 
     return html`
@@ -91,6 +111,7 @@ class OrderView extends LitElement {
           </output>
         </div>`,
       )}
+      <h4>Total: <number-output id="total" ${field(total)}"></number-output></h4>
       <div id="submitting">${this.binder.submitting}</div>
     `;
   }
@@ -692,6 +713,34 @@ describe('form/Validation', () => {
       await fireEvent(orderView.price, 'change');
 
       expect(String(orderView.priceError.textContent)).to.contain('must be a number');
+    });
+
+    it('should fail validation when element.checkValidity() is false', async () => {
+      const value = binder.defaultValue;
+      value.customer.fullName = 'Jane Doe';
+      value.notes = '42';
+      value.total = 1;
+      binder.value = value;
+      await orderView.updateComplete;
+
+      // Verify initially valid state
+      let errors = await binder.validate();
+      expect(errors).to.have.length(0);
+
+      // Simulate good user input
+      orderView.total.value = '2';
+      await fireEvent(orderView.total, 'change');
+
+      errors = await binder.validate();
+      expect(errors).to.have.length(0);
+
+      // Simulate bad user input
+      orderView.total.value = 'not a number';
+      await fireEvent(orderView.total, 'change');
+
+      errors = await binder.validate();
+      expect(errors).to.have.length(1);
+      expect(errors[0]).to.have.property('property', 'total');
     });
   });
 

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -309,7 +309,7 @@ describe('form/Validators', () => {
   });
 
   it('ValidityStateValidator', () => {
-    let validator = new ValidityStateValidator();
+    const validator = new ValidityStateValidator();
     assert.isNotTrue(validator.impliesRequired);
     assert.equal(validator.validate(), false);
     assert.equal(validator.message, '');

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -313,9 +313,5 @@ describe('form/Validators', () => {
     assert.isNotTrue(validator.impliesRequired);
     assert.equal(validator.validate(), false);
     assert.equal(validator.message, '');
-
-    validator = new ValidityStateValidator({ message: 'custom' });
-    assert.equal(validator.validate(), false);
-    assert.equal(validator.message, 'custom');
   });
 });

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -23,6 +23,7 @@ import {
   PositiveOrZero,
   Required,
   Size,
+  ValidityStateValidator,
 } from '../src';
 
 describe('form/Validators', () => {
@@ -305,5 +306,16 @@ describe('form/Validators', () => {
     // https://www.kermitproject.org/utf8.html
     assert.isTrue(validator.validate("I can eat glass and it doesn't hurt me."));
     assert.isTrue(validator.validate('Я могу есть стекло, оно мне не вредит.'));
+  });
+
+  it('ValidityStateValidator', () => {
+    let validator = new ValidityStateValidator();
+    assert.isNotTrue(validator.impliesRequired);
+    assert.equal(validator.validate(), false);
+    assert.equal(validator.message, '');
+
+    validator = new ValidityStateValidator({ message: 'custom' });
+    assert.equal(validator.validate(), false);
+    assert.equal(validator.message, 'custom');
   });
 });


### PR DESCRIPTION
Fixes #702

In some form element binding cases (notably, for user-typed value in
`<vaadin-date-picker>`), the binder validation additionally verify
the value from the element using the element's own internal validation
defined by the `checkValidity()` result and the `validity` property.

This change implements such verification, so that a value invalidated
by the element's internal validation is considered invalid by the
binder.