### PR TITLE
fix: allow to create modules with spaces in names

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -64,7 +64,7 @@ jobs:
             | tr '.:' '/' \
             | sed -e 's/^/.m2\/repository\//' \
           )
-          tar rf workspace.tar $(find packages/java -d -name target)
+          find packages/java -type d -name target -print0 | xargs -0 tar rf workspace.tar
           tar rf workspace.tar $(find packages/ts -name node_modules -prune -o -print | git check-ignore --stdin)
       - uses: actions/upload-artifact@v3
         with:

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -3,7 +3,7 @@ const micromatch = require('micromatch');
 function exclude(files) {
   const matched = micromatch.not(files, ['node_modules/**/*', 'packages/java/**/*', '**/*.snap.{ts,js}']);
 
-  return matched.length > 0 ? [`prettier --write ${matched.join(' ')}`] : [];
+  return matched.length > 0 ? [`prettier --write "${matched.join('" "')}"`] : [];
 }
 
 module.exports = {


### PR DESCRIPTION
This PR is in preparation for #884, which will not pass until this one is merged.