### PR TITLE
test: make test code compatible with flow latest changes

### DIFF
--- a/packages/java/engine-runtime/src/test/java/dev/hilla/internal/NodeTasksEndpointTest.java
+++ b/packages/java/engine-runtime/src/test/java/dev/hilla/internal/NodeTasksEndpointTest.java
@@ -54,7 +54,7 @@ public class NodeTasksEndpointTest extends TaskTest {
 
     @Test
     public void should_GenerateEndpointFilesInDevBuildTask() throws Exception {
-        options = options.withDevBundleBuild(true);
+        options = options.withBundleBuild(true);
 
         new NodeTasks(options).execute();
         assertEndpointFiles(true);

--- a/packages/java/parser-jvm-utils/pom.xml
+++ b/packages/java/parser-jvm-utils/pom.xml
@@ -41,6 +41,10 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@
     <formatter.basedir>${project.basedir}</formatter.basedir>
     <classgraph.version>4.8.154</classgraph.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <swagger.core.version>2.2.8</swagger.core.version>
-    <swagger.models.version>2.2.8</swagger.models.version>
+    <swagger.core.version>2.2.9</swagger.core.version>
+    <swagger.models.version>2.2.9</swagger.models.version>
     <swagger.parser.v3.version>2.1.12</swagger.parser.v3.version>
     <jackson.version>2.15.0</jackson.version>
-    <jackson.databind.version>2.14.2</jackson.databind.version>
+    <jackson.databind.version>2.15.0</jackson.databind.version>
     <junit.version>5.8.0</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>24.1-SNAPSHOT</flow.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <swagger.core.version>2.2.8</swagger.core.version>
     <swagger.models.version>2.2.8</swagger.models.version>
     <swagger.parser.v3.version>2.1.12</swagger.parser.v3.version>
-    <jackson.version>2.14.2</jackson.version>
+    <jackson.version>2.15.0</jackson.version>
     <jackson.databind.version>2.14.2</jackson.databind.version>
     <junit.version>5.8.0</junit.version>
     <mockito.version>4.5.0</mockito.version>


### PR DESCRIPTION
## Description

After https://github.com/vaadin/flow/pull/16653 is merged, 
the com.vaadin.flow.server.frontend.Options class does not 
have the withDevBundleBuild method, and the new name is 
withBundleBuild.
