### PR TITLE
(POC) New approach to the Maven plugin

### DIFF
--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/EngineConfiguration.java
@@ -30,7 +30,7 @@ public class EngineConfiguration {
     private Path outputDir;
     private ParserConfiguration parser;
 
-    private EngineConfiguration() {
+    public EngineConfiguration() {
     }
 
     /**

--- a/packages/java/engine-runtime/pom.xml
+++ b/packages/java/engine-runtime/pom.xml
@@ -29,6 +29,27 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-container-default</artifactId>
+      <version>2.1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-server</artifactId>
       <version>${flow.version}</version>

--- a/packages/java/engine-runtime/pom.xml
+++ b/packages/java/engine-runtime/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.9.1</version>
+      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/AbstractTaskEndpointGenerator.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/AbstractTaskEndpointGenerator.java
@@ -39,8 +39,6 @@ import com.vaadin.flow.server.frontend.FallibleCommand;
 import dev.hilla.engine.ConfigurationException;
 import dev.hilla.engine.EngineConfiguration;
 
-import jakarta.annotation.Nonnull;
-
 /**
  * Abstract class for endpoint related generators.
  */
@@ -52,9 +50,9 @@ abstract class AbstractTaskEndpointGenerator implements FallibleCommand {
     protected final ClassLoader classLoader;
     private EngineConfiguration engineConfiguration;
 
-    AbstractTaskEndpointGenerator(@Nonnull File projectDirectory,
-            @Nonnull String buildDirectoryName, @Nonnull File outputDirectory,
-            @Nonnull ClassLoader classLoader) {
+    AbstractTaskEndpointGenerator(File projectDirectory,
+            String buildDirectoryName, File outputDirectory,
+            ClassLoader classLoader) {
         this.projectDirectory = Objects.requireNonNull(projectDirectory,
                 "Project directory cannot be null");
         this.buildDirectoryName = Objects.requireNonNull(buildDirectoryName,

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/AbstractTaskEndpointGenerator.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/AbstractTaskEndpointGenerator.java
@@ -99,7 +99,7 @@ abstract class AbstractTaskEndpointGenerator implements FallibleCommand {
                 var plugins = model.getBuild().getPlugins();
                 config = plugins.stream()
                         .filter(p -> p.getGroupId().equals("dev.hilla") && p
-                                .getArtifactId().equals("engine-maven-plugin"))
+                                .getArtifactId().equals("hilla-maven-plugin"))
                         .findFirst()
                         .map(plugin -> getPluginConfiguration(plugin,
                                 EngineConfiguration.class))

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/EndpointGeneratorTaskFactoryImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/EndpointGeneratorTaskFactoryImpl.java
@@ -62,7 +62,8 @@ public class EndpointGeneratorTaskFactoryImpl
 
         return new TaskGenerateEndpointImpl(options.getNpmFolder(),
                 options.getBuildDirectoryName(),
-                options.getFrontendGeneratedFolder(), nodeExecutable);
+                options.getFrontendGeneratedFolder(), nodeExecutable,
+                options.getClassFinder().getClassLoader());
     }
 
     @Override

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/EndpointGeneratorTaskFactoryImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/EndpointGeneratorTaskFactoryImpl.java
@@ -62,8 +62,8 @@ public class EndpointGeneratorTaskFactoryImpl
 
         return new TaskGenerateEndpointImpl(options.getNpmFolder(),
                 options.getBuildDirectoryName(),
-                options.getFrontendGeneratedFolder(), nodeExecutable,
-                options.getClassFinder().getClassLoader());
+                options.getFrontendGeneratedFolder(),
+                options.getClassFinder().getClassLoader(), nodeExecutable);
     }
 
     @Override

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateEndpointImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateEndpointImpl.java
@@ -49,8 +49,9 @@ public class TaskGenerateEndpointImpl extends AbstractTaskEndpointGenerator
      *            executable or PATH-related command
      */
     TaskGenerateEndpointImpl(File projectDirectory, String buildDirectoryName,
-            File outputDirectory, String nodeCommand) {
-        super(projectDirectory, buildDirectoryName, outputDirectory);
+            File outputDirectory, String nodeCommand, ClassLoader classLoader) {
+        super(projectDirectory, buildDirectoryName, outputDirectory,
+                classLoader);
         this.nodeCommand = nodeCommand;
     }
 

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateEndpointImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateEndpointImpl.java
@@ -49,7 +49,7 @@ public class TaskGenerateEndpointImpl extends AbstractTaskEndpointGenerator
      *            executable or PATH-related command
      */
     TaskGenerateEndpointImpl(File projectDirectory, String buildDirectoryName,
-            File outputDirectory, String nodeCommand, ClassLoader classLoader) {
+            File outputDirectory, ClassLoader classLoader, String nodeCommand) {
         super(projectDirectory, buildDirectoryName, outputDirectory,
                 classLoader);
         this.nodeCommand = nodeCommand;

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateOpenAPIImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateOpenAPIImpl.java
@@ -31,8 +31,6 @@ import com.vaadin.flow.server.frontend.TaskGenerateOpenAPI;
 public class TaskGenerateOpenAPIImpl extends AbstractTaskEndpointGenerator
         implements TaskGenerateOpenAPI {
 
-    private final ClassLoader classLoader;
-
     /**
      * Create a task for generating OpenAPI spec.
      *
@@ -51,9 +49,8 @@ public class TaskGenerateOpenAPIImpl extends AbstractTaskEndpointGenerator
      */
     TaskGenerateOpenAPIImpl(File projectDirectory, String buildDirectoryName,
             File outputDirectory, @Nonnull ClassLoader classLoader) {
-        super(projectDirectory, buildDirectoryName, outputDirectory);
-        this.classLoader = Objects.requireNonNull(classLoader,
-                "ClassLoader should not be null");
+        super(projectDirectory, buildDirectoryName, outputDirectory,
+                classLoader);
     }
 
     /**

--- a/packages/java/engine-runtime/src/test/java/dev/hilla/internal/AbstractTaskEndpointGeneratorTest.java
+++ b/packages/java/engine-runtime/src/test/java/dev/hilla/internal/AbstractTaskEndpointGeneratorTest.java
@@ -39,7 +39,8 @@ class AbstractTaskEndpointGeneratorTest extends TaskTest {
             extends AbstractTaskEndpointGenerator {
         TestTaskEndpointGenerator(File projectDirectory,
                 String buildDirectoryName, File outputDirectory) {
-            super(projectDirectory, buildDirectoryName, outputDirectory);
+            super(projectDirectory, buildDirectoryName, outputDirectory,
+                    AbstractTaskEndpointGeneratorTest.class.getClassLoader());
         }
 
         @Override

--- a/packages/java/engine-runtime/src/test/java/dev/hilla/internal/TaskGenerateEndpointTest.java
+++ b/packages/java/engine-runtime/src/test/java/dev/hilla/internal/TaskGenerateEndpointTest.java
@@ -48,7 +48,7 @@ public class TaskGenerateEndpointTest extends TaskTest {
 
         taskGenerateEndpoint = new TaskGenerateEndpointImpl(
                 getTemporaryDirectory().toFile(), getBuildDirectory(),
-                outputDirectory.toFile(), "node");
+                outputDirectory.toFile(), "node", getClass().getClassLoader());
         taskGenerateEndpoint.execute();
 
         assertTrue(ts1.exists());
@@ -82,7 +82,7 @@ public class TaskGenerateEndpointTest extends TaskTest {
 
         taskGenerateEndpoint = new TaskGenerateEndpointImpl(
                 getTemporaryDirectory().toFile(), getBuildDirectory(),
-                outputDirectory.toFile(), "node");
+                outputDirectory.toFile(), "node", getClass().getClassLoader());
         taskGenerateEndpoint.execute();
 
         assertTrue(ts1.exists());

--- a/packages/java/engine-runtime/src/test/java/dev/hilla/internal/TaskGenerateEndpointTest.java
+++ b/packages/java/engine-runtime/src/test/java/dev/hilla/internal/TaskGenerateEndpointTest.java
@@ -48,7 +48,7 @@ public class TaskGenerateEndpointTest extends TaskTest {
 
         taskGenerateEndpoint = new TaskGenerateEndpointImpl(
                 getTemporaryDirectory().toFile(), getBuildDirectory(),
-                outputDirectory.toFile(), "node", getClass().getClassLoader());
+                outputDirectory.toFile(), getClass().getClassLoader(), "node");
         taskGenerateEndpoint.execute();
 
         assertTrue(ts1.exists());
@@ -82,7 +82,7 @@ public class TaskGenerateEndpointTest extends TaskTest {
 
         taskGenerateEndpoint = new TaskGenerateEndpointImpl(
                 getTemporaryDirectory().toFile(), getBuildDirectory(),
-                outputDirectory.toFile(), "node", getClass().getClassLoader());
+                outputDirectory.toFile(), getClass().getClassLoader(), "node");
         taskGenerateEndpoint.execute();
 
         assertTrue(ts1.exists());

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -10,7 +10,7 @@
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>engine-maven-plugin</artifactId>
+  <artifactId>hilla-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>Maven Plugin for Hilla Engine</name>
 
@@ -93,19 +93,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.8.2</version>
-          <configuration>
-            <goalPrefix>hilla</goalPrefix>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -15,11 +15,16 @@
   <name>Maven Plugin for Hilla Engine</name>
 
   <properties>
-    <maven.version>3.8.6</maven.version>
+    <maven.version>3.9.1</maven.version>
     <formatter.basedir>${project.parent.basedir}</formatter.basedir>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-maven-plugin</artifactId>
+      <version>${flow.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
@@ -41,7 +46,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.7.0</version>
+      <version>3.8.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -95,7 +100,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.8.2</version>
           <configuration>
             <goalPrefix>hilla</goalPrefix>
           </configuration>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -93,4 +93,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>3.6.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -100,7 +100,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.8.2</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/PrepareFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/PrepareFrontendMojo.java
@@ -1,0 +1,66 @@
+package dev.hilla.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.LinkedHashSet;
+
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+import dev.hilla.engine.EngineConfiguration;
+import dev.hilla.engine.GeneratorConfiguration;
+import dev.hilla.engine.ParserConfiguration;
+
+@Mojo(name = "prepare-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class PrepareFrontendMojo
+        extends com.vaadin.flow.plugin.maven.PrepareFrontendMojo {
+    @Parameter(readonly = true)
+    private final GeneratorConfiguration generator = new GeneratorConfiguration();
+
+    @Parameter(readonly = true)
+    private final ParserConfiguration parser = new ParserConfiguration();
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject mavenProject;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            var buildDir = mavenProject.getBuild().getDirectory();
+            var conf = new EngineConfiguration.Builder(
+                    mavenProject.getBasedir().toPath())
+                            .classPath(new LinkedHashSet<>(
+                                    mavenProject.getRuntimeClasspathElements()))
+                            .outputDir(generatedTsFolder().toPath())
+                            .generator(generator).parser(parser)
+                            .buildDir(buildDir).classesDir(mavenProject
+                                    .getBuild().getOutputDirectory())
+                            .create();
+
+            // The configuration gathered from the Maven plugin is saved in a
+            // file so that further runs can skip running a separate Maven
+            // mavenProject just to get this configuration again
+            var configDir = mavenProject.getBasedir().toPath()
+                    .resolve(buildDir);
+            Files.createDirectories(configDir);
+            conf.store(configDir
+                    .resolve(EngineConfiguration.DEFAULT_CONFIG_FILE_NAME)
+                    .toFile());
+        } catch (DependencyResolutionRequiredException e) {
+            throw new EngineConfigureMojoException("Configuration failed", e);
+        } catch (IOException e) {
+            throw new EngineConfigureMojoException(
+                    "Maven configuration has not been saved to file", e);
+        }
+
+        super.execute();
+    }
+
+}

--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/PrepareFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/PrepareFrontendMojo.java
@@ -27,6 +27,8 @@ public class PrepareFrontendMojo
     @Parameter(readonly = true)
     private final ParserConfiguration parser = new ParserConfiguration();
 
+    // This has been renamed to not hide <code>project</code> from the ancestor
+    // class, otherwise that's not given a value
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject mavenProject;
 

--- a/packages/java/maven-plugin/src/test/resources/dev/hilla/maven/EngineConfigureMojoTest.xml
+++ b/packages/java/maven-plugin/src/test/resources/dev/hilla/maven/EngineConfigureMojoTest.xml
@@ -14,7 +14,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
 
                 <configuration>
                   <generatedTsFolder>frontend/maven-generated</generatedTsFolder>

--- a/packages/java/maven-plugin/src/test/resources/dev/hilla/maven/EngineGenerateMojoTest.xml
+++ b/packages/java/maven-plugin/src/test/resources/dev/hilla/maven/EngineGenerateMojoTest.xml
@@ -15,7 +15,7 @@
       <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
 
                 <configuration>
                   <!-- intentionally empty, expected to use EngineConfiguration.load() -->

--- a/packages/java/tests/csrf-context/pom.xml
+++ b/packages/java/tests/csrf-context/pom.xml
@@ -42,7 +42,7 @@
     <plugins>
       <plugin>
         <groupId>dev.hilla</groupId>
-        <artifactId>engine-maven-plugin</artifactId>
+        <artifactId>hilla-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/packages/java/tests/csrf/pom.xml
+++ b/packages/java/tests/csrf/pom.xml
@@ -52,7 +52,7 @@
     <plugins>
       <plugin>
         <groupId>dev.hilla</groupId>
-        <artifactId>engine-maven-plugin</artifactId>
+        <artifactId>hilla-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -138,7 +138,7 @@
       <plugins>
         <plugin>
           <groupId>dev.hilla</groupId>
-          <artifactId>engine-maven-plugin</artifactId>
+          <artifactId>hilla-maven-plugin</artifactId>
           <version>${project.version}</version>
         </plugin>
 

--- a/packages/java/tests/spring/endpoints discovery/pom.xml
+++ b/packages/java/tests/spring/endpoints discovery/pom.xml
@@ -56,7 +56,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
                 <configuration>
                     <parser>
                         <packages>

--- a/packages/java/tests/spring/endpoints-custom-client/pom.xml
+++ b/packages/java/tests/spring/endpoints-custom-client/pom.xml
@@ -41,7 +41,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/packages/java/tests/spring/endpoints-latest-java/pom.xml
+++ b/packages/java/tests/spring/endpoints-latest-java/pom.xml
@@ -52,7 +52,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/packages/java/tests/spring/endpoints-maven-engine/pom.xml
+++ b/packages/java/tests/spring/endpoints-maven-engine/pom.xml
@@ -107,7 +107,7 @@
 
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>default</id>

--- a/packages/java/tests/spring/endpoints/pom.xml
+++ b/packages/java/tests/spring/endpoints/pom.xml
@@ -56,7 +56,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/packages/java/tests/spring/security-contextpath/pom.xml
+++ b/packages/java/tests/spring/security-contextpath/pom.xml
@@ -64,7 +64,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/packages/java/tests/spring/security-jwt/pom.xml
+++ b/packages/java/tests/spring/security-jwt/pom.xml
@@ -75,7 +75,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/packages/java/tests/spring/security-urlmapping/pom.xml
+++ b/packages/java/tests/spring/security-urlmapping/pom.xml
@@ -66,7 +66,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/packages/java/tests/spring/security/pom.xml
+++ b/packages/java/tests/spring/security/pom.xml
@@ -81,7 +81,7 @@
         <plugins>
             <plugin>
                 <groupId>dev.hilla</groupId>
-                <artifactId>engine-maven-plugin</artifactId>
+                <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This draft PR has two (utopic?) goals:
- remove the need to run Maven from the running app
- remove the need to merge the Flow and Engine plugin in Platform to create the Hilla plugin.

First of all, this is a draft, the code is ugly, incomplete, and the tests don't pass, at least due to missing `build-frontend` goal. But example applications run, with or without `<configuration>` in `pom.xml` and I don't want to invest other time before discussing if this is a good plan.

What this PR does:
- rename `engine-maven-plugin` to `hilla-maven-plugin` and remove the need of a custom prefix
- create a new `prepare-frontend` goal which extends the Flow one
- instead of calling Maven, parse `pom.xml` using Maven APIs to get the same behavior

What does it mean for Gradle? I'd refrain using the same approach to put configuration inside `build.gradle` and have to get it back. I propose to rather define a new configuration method and keep the Maven `<configuration>` as a fallback for compatibility. The Gradle plugin being a new thing, I think that we have the choice.