### PR TITLE
feat: use Spring Validator when available

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
@@ -68,8 +68,7 @@ public class EndpointInvoker {
     private final EndpointRegistry endpointRegistry;
     private final ExplicitNullableTypeChecker explicitNullableTypeChecker;
     private final ServletContext servletContext;
-    private final Validator validator = Validation
-            .buildDefaultValidatorFactory().getValidator();
+    private final Validator validator;
 
     /**
      * Creates an instance of this bean.
@@ -106,6 +105,17 @@ public class EndpointInvoker {
         }
         this.explicitNullableTypeChecker = explicitNullableTypeChecker;
         this.endpointRegistry = endpointRegistry;
+
+        Validator validator = null;
+        try {
+            validator = applicationContext.getBean(Validator.class);
+        } catch (Exception e) {
+            getLogger().debug(
+                    "Validator not found in Spring Context, will instantiate directly");
+        }
+        this.validator = validator == null
+                ? Validation.buildDefaultValidatorFactory().getValidator()
+                : validator;
     }
 
     private static ObjectMapper createDefaultEndpointMapper(


### PR DESCRIPTION
The `EndpointInvoker` gets the Spring `ApplicationContext` as constructor parameter, so we can use the Spring Validator Bean instead of the explicit one.

Closes #964.