### PR TITLE
fix: scaffold `types.d.ts` and `vite.config.ts` in React

### DIFF
--- a/packages/java/hilla-plugin-base/src/main/java/dev/hilla/plugin/base/InitFileExtractor.java
+++ b/packages/java/hilla-plugin-base/src/main/java/dev/hilla/plugin/base/InitFileExtractor.java
@@ -16,8 +16,9 @@ public class InitFileExtractor {
             .getLogger(InitFileExtractor.class);
     private static final String REACT_SKELETON = "https://github.com/vaadin/skeleton-starter-hilla-react/archive/refs/heads/v2.1.zip";
     private static final List<String> REACT_FILE_LIST = List.of("package.json",
-            "package-lock.json", "frontend/App.tsx", "frontend/index.ts",
-            "frontend/routes.tsx", "frontend/views/MainView.tsx",
+            "package-lock.json", "types.d.ts", "vite.config.ts",
+            "frontend/App.tsx", "frontend/index.ts", "frontend/routes.tsx",
+            "frontend/views/MainView.tsx",
             "src/main/java/org/vaadin/example/endpoints/HelloEndpoint.java");
     private static final String LIT_SKELETON = "https://github.com/vaadin/skeleton-starter-hilla-lit/archive/refs/heads/v2.1.zip";
     private static final List<String> LIT_FILE_LIST = List.of("package.json",


### PR DESCRIPTION
Add those files to the React-related list, as the ones provided by Flow are Lit-based.