### PR TITLE
feat: enable setting productionMode through hilla instead of using vaadin extension

### DIFF
--- a/packages/java/gradle-plugin/src/functionalTest/kotlin/dev/hilla/gradle/plugin/SingleModuleTest.kt
+++ b/packages/java/gradle-plugin/src/functionalTest/kotlin/dev/hilla/gradle/plugin/SingleModuleTest.kt
@@ -203,6 +203,10 @@ class SingleModuleTest : AbstractGradleTest() {
             """.trimIndent()
         } else ""
 
+        // We don't want to actually run the build in production,
+        // but we just want to make sure of the task dependency.
+        // Running gradle using --dry-run does not create the task, just prints the dependency order.
+        // This is a workaround to simulate a dry run. The tasks are created in order but skipped during the build:
         val disableAllTasks = if (disableAllTasksToSimulateDryRun) {
             """
                 tasks.configureEach {

--- a/packages/java/gradle-plugin/src/functionalTest/kotlin/dev/hilla/gradle/plugin/SingleModuleTest.kt
+++ b/packages/java/gradle-plugin/src/functionalTest/kotlin/dev/hilla/gradle/plugin/SingleModuleTest.kt
@@ -85,7 +85,7 @@ class SingleModuleTest : AbstractGradleTest() {
     }
 
     @Test
-    fun `productionMode set to true then building the project executes vaadinBuildFrontend`() {
+    fun `when hilla productionMode=true in build file then building the project executes vaadinBuildFrontend`() {
         createProject(withNpmInstall = true, productionMode = true, disableAllTasksToSimulateDryRun = true)
 
         addHelloReactEndpoint()
@@ -94,6 +94,32 @@ class SingleModuleTest : AbstractGradleTest() {
 
         expect(TaskOutcome.SKIPPED, "Building project while hilla.productionMode=true should plan to execute vaadinBuildFrontend task") {
             buildResult.task(":vaadinBuildFrontend")?.outcome
+        }
+    }
+
+    @Test
+    fun `when hilla productionMode not set in build file then building the project with productionMode commandline arg executes vaadinBuildFrontend`() {
+        createProject(withNpmInstall = true, productionMode = false, disableAllTasksToSimulateDryRun = true)
+
+        addHelloReactEndpoint()
+
+        val buildResult: BuildResult = testProject.build("-Philla.productionMode=true", "build", checkTasksSuccessful = false)
+
+        expect(TaskOutcome.SKIPPED, "Building project while hilla.productionMode=true should plan to execute vaadinBuildFrontend task") {
+            buildResult.task(":vaadinBuildFrontend")?.outcome
+        }
+    }
+
+    @Test
+    fun `when hilla productionMode=true in build file then building the project with commandline arg productionMode=false does not execute vaadinBuildFrontend`() {
+        createProject(withNpmInstall = true, productionMode = true, disableAllTasksToSimulateDryRun = true)
+
+        addHelloReactEndpoint()
+
+        val buildResult: BuildResult = testProject.build("-Philla.productionMode=false", "build", checkTasksSuccessful = false)
+
+        expect(null, "Building project while hilla.productionMode=true should plan to execute vaadinBuildFrontend task") {
+            buildResult.task(":vaadinBuildFrontend")
         }
     }
 

--- a/packages/java/gradle-plugin/src/main/kotlin/dev/hilla/gradle/plugin/EngineProjectExtension.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/dev/hilla/gradle/plugin/EngineProjectExtension.kt
@@ -15,6 +15,7 @@
  */
 package dev.hilla.gradle.plugin
 
+import com.vaadin.gradle.getBooleanProperty
 import org.gradle.api.Project
 import java.io.File
 
@@ -31,6 +32,12 @@ public open class EngineProjectExtension(project: Project) {
      * packages in the build.gradle file.
      */
     public var exposedPackagesToParser: List<String> = mutableListOf()
+
+    /**
+     * Indicates whether the application should run in production mode, defaults to false.
+     * Responds to the `-Philla.productionMode` property.
+     */
+    public var productionMode: Boolean = false
 
     /**
      * The folder where flow will put TS API files for client projects.
@@ -61,9 +68,16 @@ public open class EngineProjectExtension(project: Project) {
           project.extensions.getByType(EngineProjectExtension::class.java)
     }
 
+    internal fun autoconfigure(project: Project) {
+        val productionModeProperty: Boolean? = project.getBooleanProperty("hilla.productionMode")
+        if (productionModeProperty != null) {
+            productionMode = productionModeProperty
+        }
+    }
 
     override fun toString(): String = "HillaPluginExtension(" +
             "exposedPackagesToParser=$exposedPackagesToParser, " +
+            "productionMode=$productionMode, " +
             "generatedTsFolder=$generatedTsFolder, " +
             "sourceSetName=$sourceSetName, " +
             "nodeCommand=$nodeCommand, " +

--- a/packages/java/gradle-plugin/src/main/kotlin/dev/hilla/gradle/plugin/HillaPlugin.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/dev/hilla/gradle/plugin/HillaPlugin.kt
@@ -15,12 +15,14 @@
  */
 package dev.hilla.gradle.plugin
 
+import com.vaadin.gradle.VaadinFlowPluginExtension
 import com.vaadin.gradle.VaadinPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.bundling.Jar
 
 /**
  * The main class of the Hilla Gradle Plugin
@@ -48,6 +50,17 @@ public class HillaPlugin : Plugin<Project> {
             val copyTask = it as? Copy
             if (copyTask != null) {
                 copyTask.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            }
+        }
+
+        project.afterEvaluate {
+            val extension: EngineProjectExtension = EngineProjectExtension.get(it)
+            extension.autoconfigure(it)
+            if (extension.productionMode) {
+                // this will also catch the War task since it extends from Jar
+                project.tasks.withType(Jar::class.java) { task: Jar ->
+                    task.dependsOn("vaadinBuildFrontend")
+                }
             }
         }
     }

--- a/packages/java/tests/gradle/single-module-tests/build.gradle
+++ b/packages/java/tests/gradle/single-module-tests/build.gradle
@@ -1,18 +1,7 @@
-buildscript {
-    repositories {
-		mavenLocal()
-    	mavenCentral()
-	    maven { setUrl("https://maven.vaadin.com/vaadin-prereleases") }
-	}
-	dependencies {
-		classpath("dev.hilla:hilla-gradle-plugin:$hillaVersion")
-	}
-}
 plugins {
 	id 'org.springframework.boot' version '3.0.2'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'java'
-	//id 'dev.hilla'
 }
 
 apply plugin: 'dev.hilla'

--- a/packages/java/tests/gradle/single-module-tests/settings.gradle
+++ b/packages/java/tests/gradle/single-module-tests/settings.gradle
@@ -1,10 +1,10 @@
-pluginManagement {
-  repositories {
-      mavenLocal()
-      maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
-      gradlePluginPortal()
-  }
-  plugins {
-      id 'dev.hilla' version "${hillaVersion}"
-  }
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven { setUrl("https://maven.vaadin.com/vaadin-prereleases") }
+    }
+    dependencies {
+        classpath("dev.hilla:hilla-gradle-plugin:$hillaVersion")
+    }
 }

--- a/packages/java/tests/gradle/single-module-tests/src/test/java/dev/hilla/gradle/plugin/test/ProductionBuildFunctionalIT.java
+++ b/packages/java/tests/gradle/single-module-tests/src/test/java/dev/hilla/gradle/plugin/test/ProductionBuildFunctionalIT.java
@@ -67,7 +67,7 @@ public class ProductionBuildFunctionalIT {
         } catch (IOException e) {
             fail(e);
         }
-        runGradleCommand("./gradlew -Pvaadin.productionMode=true build");
+        runGradleCommand("./gradlew -Philla.productionMode=true build");
     }
 
     private void runGradleCommand(String executable) throws CommandRunnerException {

--- a/packages/java/tests/gradle/single-module/build.gradle
+++ b/packages/java/tests/gradle/single-module/build.gradle
@@ -1,18 +1,7 @@
-buildscript {
-    repositories {
-		mavenLocal()
-    	mavenCentral()
-	    maven { setUrl("https://maven.vaadin.com/vaadin-prereleases") }
-	}
-	dependencies {
-		classpath("dev.hilla:hilla-gradle-plugin:$hillaVersion")
-	}
-}
 plugins {
 	id 'org.springframework.boot' version '3.0.2'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'java'
-	//id 'dev.hilla'
 }
 
 apply plugin: 'dev.hilla'
@@ -28,20 +17,12 @@ repositories {
 	maven { setUrl("https://maven.vaadin.com/vaadin-addons") }
 }
 
-configurations {
-	developmentOnly
-	runtimeClasspath {
-		extendsFrom developmentOnly
-	}
-}
-
 test {
     useJUnitPlatform()
 }
 
 dependencies {
-	implementation 'dev.hilla:hilla-react'
-	implementation 'dev.hilla:hilla-spring-boot-starter'
+	implementation 'dev.hilla:hilla-react-spring-boot-starter'
 	implementation 'org.parttio:line-awesome:1.1.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/packages/java/tests/gradle/single-module/settings.gradle
+++ b/packages/java/tests/gradle/single-module/settings.gradle
@@ -1,10 +1,11 @@
-pluginManagement {
-  repositories {
-      mavenLocal()
-      maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
-      gradlePluginPortal()
-  }
-  plugins {
-      id 'dev.hilla' version "${hillaVersion}"
-  }
+buildscript {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven { setUrl("https://maven.vaadin.com/vaadin-prereleases") }
+    }
+    dependencies {
+        classpath("dev.hilla:hilla-gradle-plugin:$hillaVersion")
+    }
 }
+


### PR DESCRIPTION
## Description

This enables the possibility of using the `hilla` extension to  
set the `productionMode` either in the `build.gradle`:
```
hilla {
    productionMode = true
}
```
or via command-line arguments:
```
./gradlew -Philla.productionMode=true build
```
 
Fixes #984

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
