### PR TITLE
chore: add missing maven goals for backward compatibility

### DIFF
--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/CleanFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/CleanFrontendMojo.java
@@ -20,11 +20,11 @@ public class CleanFrontendMojo
     @Override
     public void execute() throws MojoFailureException {
         getLog().warn(
-            """
-                    The 'clean-frontend' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
-                    Note: The 'clean-frontend' goal is deprecated and would be removed in future releases.
-                    """
-                .stripIndent());
+                """
+                        The 'clean-frontend' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
+                        Note: The 'clean-frontend' goal is deprecated and would be removed in future releases.
+                        """
+                        .stripIndent());
         super.execute();
     }
 }

--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/CleanFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/CleanFrontendMojo.java
@@ -1,0 +1,30 @@
+package dev.hilla.maven;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * This is the `hilla:clean-frontend` goal which exists just for backward
+ * compatibility purposes, and to warn the user about the incompatibility of its
+ * functionality within Hilla applications.
+ * <p>
+ * NOTE: This goal is deprecated and will be removed in the future major
+ * release.
+ */
+@Deprecated
+@Mojo(name = "clean-frontend", defaultPhase = LifecyclePhase.PRE_CLEAN)
+public class CleanFrontendMojo
+        extends com.vaadin.flow.plugin.maven.CleanFrontendMojo {
+
+    @Override
+    public void execute() throws MojoFailureException {
+        getLog().warn(
+            """
+                    The 'clean-frontend' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
+                    Note: The 'clean-frontend' goal is deprecated and would be removed in future releases.
+                    """
+                .stripIndent());
+        super.execute();
+    }
+}

--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/ConvertPolymerMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/ConvertPolymerMojo.java
@@ -1,0 +1,29 @@
+package dev.hilla.maven;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * This is the `hilla:convert-polymer` goal which exists just for backward
+ * compatibility purposes, and to warn the user about the incompatibility of its
+ * functionality within Hilla applications.
+ * <p>
+ * NOTE: This goal is deprecated and will be removed in the future major
+ * release.
+ */
+@Deprecated
+@Mojo(name = "convert-polymer")
+public class ConvertPolymerMojo
+        extends com.vaadin.flow.plugin.maven.ConvertPolymerMojo {
+
+    @Override
+    public void execute() throws MojoFailureException {
+        getLog().warn(
+                """
+                        The 'convert-polymer' goal is not meant to be used in Hilla projects as polymer templates are not supported.
+                        Note: The 'convert-polymer' goal is deprecated and would be removed in future releases.
+                        """
+                        .stripIndent());
+        super.execute();
+    }
+}

--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/FrontendDanceMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/FrontendDanceMojo.java
@@ -1,0 +1,30 @@
+package dev.hilla.maven;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * This is the `hilla:dance` goal which exists just for backward compatibility
+ * purposes, and to warn the user about the incompatibility of its functionality
+ * within Hilla applications.
+ * <p>
+ * NOTE: This goal is deprecated and will be removed in the future major
+ * release.
+ */
+@Deprecated
+@Mojo(name = "dance", defaultPhase = LifecyclePhase.PRE_CLEAN)
+public class FrontendDanceMojo
+        extends com.vaadin.flow.plugin.maven.FrontendDanceMojo {
+
+    @Override
+    public void execute() throws MojoFailureException {
+        getLog().warn(
+                """
+                        The 'dance' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
+                        Note: The 'dance' goal is deprecated and would be removed in future releases.
+                        """
+                        .stripIndent());
+        super.execute();
+    }
+}


### PR DESCRIPTION
## Description

In #929 the necessary goals from flow-maven-plugin is adopted 
into hilla-maven-plugin directly. But, just to prevent introducin a
breaking change in a minor release, the following goals are added 
to the plugin and marked as `deprecated` as there is no actual use 
for them in a Hilla project:

- convert-polymer
- clean-frontend
- dance

Fixes #988 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
