### PR TITLE
fix: enable overriding the plugins

### DIFF
--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/ParserConfiguration.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/ParserConfiguration.java
@@ -97,6 +97,11 @@ public final class ParserConfiguration {
             this.name = name;
         }
 
+        public Plugin(String name, PluginConfiguration configuration) {
+            this(name);
+            this.configuration = configuration;
+        }
+
         @Override
         public boolean equals(Object other) {
             if (this == other) {

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/EngineConfigurationTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/EngineConfigurationTest.java
@@ -13,6 +13,8 @@ import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
 
+import dev.hilla.parser.plugins.nonnull.AnnotationMatcher;
+import dev.hilla.parser.plugins.nonnull.NonnullPluginConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,9 +44,12 @@ public class EngineConfigurationTest {
         parserConfiguration.setEndpointAnnotation("dev.hilla.test.Endpoint");
         parserConfiguration
                 .setEndpointExposedAnnotation("dev.hilla.test.EndpointExposed");
-        parserConfiguration.setPlugins(new ParserConfiguration.Plugins(
-                List.of(new ParserConfiguration.Plugin(
-                        "parser-jvm-plugin-use")),
+        parserConfiguration.setPlugins(new ParserConfiguration.Plugins(List.of(
+                new ParserConfiguration.Plugin("parser-jvm-plugin-use"),
+                new ParserConfiguration.Plugin("parser-jvm-plugin-nonnull",
+                        new NonnullPluginConfig(List.of(new AnnotationMatcher(
+                                "com.example.application.annotations.NeverNull",
+                                false, 50)), List.of()))),
                 List.of(new ParserConfiguration.Plugin(
                         "parser-jvm-plugin-disable")),
                 true));

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/PluginConfiguration.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/PluginConfiguration.java
@@ -1,4 +1,7 @@
 package dev.hilla.parser.core;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
 public interface PluginConfiguration {
 }

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/AnnotationMatcher.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/AnnotationMatcher.java
@@ -9,14 +9,17 @@ import javax.annotation.Nonnull;
  * and non-nullable: their name, meaning, and score
  */
 public final class AnnotationMatcher {
-    private final boolean makesNullable;
-    private final String name;
-    private final int score;
+    private boolean makesNullable;
+    private String name;
+    private int score;
 
-    public AnnotationMatcher(@Nonnull String name, boolean nullable,
+    public AnnotationMatcher() {
+    }
+
+    public AnnotationMatcher(@Nonnull String name, boolean makesNullable,
             int score) {
         this.name = Objects.requireNonNull(name);
-        this.makesNullable = nullable;
+        this.makesNullable = makesNullable;
         this.score = score;
     }
 
@@ -53,6 +56,18 @@ public final class AnnotationMatcher {
      */
     public int getScore() {
         return score;
+    }
+
+    public void setMakesNullable(boolean makesNullable) {
+        this.makesNullable = makesNullable;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
     }
 
     @Override

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/basic/BasicTest.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/basic/BasicTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import dev.hilla.parser.core.Parser;
@@ -31,5 +32,19 @@ public class BasicTest {
                 .addPlugin(new BackbonePlugin()).addPlugin(plugin).execute();
 
         helper.executeParserWithConfig(openAPI);
+    }
+
+    @Test
+    public void annotationMatcher_shouldHaveDefaultConstructorAndSetter() {
+        // to enable maven initialize instances of AnnotationMatcher from
+        // pom.xml configurations,
+        // properly, it should have the default constructor and setter methods:
+        AnnotationMatcher annotationMatcher = new AnnotationMatcher();
+        annotationMatcher.setName("name");
+        annotationMatcher.setScore(100);
+        annotationMatcher.setMakesNullable(true);
+        Assertions.assertEquals("name", annotationMatcher.getName());
+        Assertions.assertEquals(100, annotationMatcher.getScore());
+        Assertions.assertTrue(annotationMatcher.doesMakeNullable());
     }
 }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/basic/BasicTest.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/basic/BasicTest.java
@@ -37,8 +37,8 @@ public class BasicTest {
     @Test
     public void annotationMatcher_shouldHaveDefaultConstructorAndSetter() {
         // to enable maven initialize instances of AnnotationMatcher from
-        // pom.xml configurations,
-        // properly, it should have the default constructor and setter methods:
+        // pom.xml configurations, properly, it should have the default
+        // constructor and setter methods:
         AnnotationMatcher annotationMatcher = new AnnotationMatcher();
         annotationMatcher.setName("name");
         annotationMatcher.setScore(100);


### PR DESCRIPTION
## Description

* Add default constructor to AnnotationMatcher to enable maven initialize it properly
* Enable PluginConfiguration to be serialized properly into configuration file 
 
Fixes #923

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
