### PR TITLE
chore: refine branches to trigger validation build

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,7 +2,7 @@ name: Validation
 
 on:
   push:
-    branches: [ main, '1.1', '1.0' ]
+    branches: [ main, '2.1', '2.0', '1.3' ]
     paths-ignore:
       - 'hilla-logo.svg'
       - 'README.md'


### PR DESCRIPTION
Refine the branches to trigger the validation build instead of 1.1 and 1.0.