### PR TITLE
fix: fix main view file name in lit file list

### DIFF
--- a/packages/java/hilla-plugin-base/src/main/java/dev/hilla/plugin/base/InitFileExtractor.java
+++ b/packages/java/hilla-plugin-base/src/main/java/dev/hilla/plugin/base/InitFileExtractor.java
@@ -23,7 +23,7 @@ public class InitFileExtractor {
     private static final String LIT_SKELETON = "https://github.com/vaadin/skeleton-starter-hilla-lit/archive/refs/heads/v2.1.zip";
     private static final List<String> LIT_FILE_LIST = List.of("package.json",
             "package-lock.json", "frontend/App.ts", "frontend/index.ts",
-            "frontend/routes.ts", "frontend/views/MainView.tsx",
+            "frontend/routes.ts", "frontend/views/main-view.ts",
             "src/main/java/org/vaadin/example/endpoints/HelloEndpoint.java");
 
     private final Path projectDirectory;


### PR DESCRIPTION
## Description

This change fixes the file name of the main view to be extracted in a Lit starter project

Fixes #1037

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
