### PR TITLE
fix: create CommandRunner instance if build.gradle.kts was available

### DIFF
--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
@@ -39,7 +39,8 @@ public class GradleRunner implements CommandRunner {
      */
     public static Optional<CommandRunner> forProject(File projectDir,
             String... args) {
-        if (new File(projectDir, "build.gradle").exists()) {
+        if (new File(projectDir, "build.gradle").exists()
+                || new File(projectDir, "build.gradle.kts").exists()) {
             return Optional.of(new GradleRunner(projectDir, args));
         }
 

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/GradleRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/GradleRunnerTest.java
@@ -11,6 +11,46 @@ import static org.junit.jupiter.api.Assertions.*;
 public class GradleRunnerTest {
 
     @Test
+    void shouldRunIfBuildGradleIsAvailable() throws IOException {
+        Path tmpDir = null;
+
+        try {
+            tmpDir = Files.createTempDirectory("prepareCommandGradle");
+            Files.createFile(tmpDir.resolve("build.gradle"));
+            var opt = GradleRunner.forProject(tmpDir.toFile(), "-v");
+            assertTrue(opt.isPresent());
+            var runner = opt.orElseThrow();
+            assertEquals(1, runner.arguments().length);
+            assertDoesNotThrow(() -> runner.run(null));
+        } finally {
+            if (tmpDir != null) {
+                Files.deleteIfExists(tmpDir.resolve("build.gradle"));
+                Files.deleteIfExists(tmpDir);
+            }
+        }
+    }
+
+    @Test
+    void shouldRunIfBuildGradleKtsIsAvailable() throws IOException {
+        Path tmpDir = null;
+
+        try {
+            tmpDir = Files.createTempDirectory("prepareCommandGradle");
+            Files.createFile(tmpDir.resolve("build.gradle.kts"));
+            var opt = GradleRunner.forProject(tmpDir.toFile(), "-v");
+            assertTrue(opt.isPresent());
+            var runner = opt.orElseThrow();
+            assertEquals(1, runner.arguments().length);
+            assertDoesNotThrow(() -> runner.run(null));
+        } finally {
+            if (tmpDir != null) {
+                Files.deleteIfExists(tmpDir.resolve("build.gradle.kts"));
+                Files.deleteIfExists(tmpDir);
+            }
+        }
+    }
+
+    @Test
     void shouldNotCreateRunnerForUnknownProjectType() throws IOException {
         Path tmpDir = null;
 


### PR DESCRIPTION
## Description

This adds the support for having the Gradle Build file in Kotlin (build.gradle.kts)

Fixes #1039 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
