### PR TITLE
chore(gradle-plugin): fix URLs in Gradle Plugin metadata

### DIFF
--- a/packages/java/gradle-plugin/build.gradle
+++ b/packages/java/gradle-plugin/build.gradle
@@ -152,8 +152,8 @@ gradlePlugin {
 }
 
 pluginBundle {
-    website = 'https://hilla.dev/docs/latest/hilla/guide/start/gradle'
-    vcsUrl = 'https://github.com/vaadin/hilla'
+    website = 'https://hilla.dev/docs/react/start/gradle'
+    vcsUrl = 'https://github.com/vaadin/hilla/tree/main/packages/java/gradle-plugin'
     description = 'Build Hilla applications with Gradle.'
     tags = ['hilla']
     plugins {


### PR DESCRIPTION
This change fixes the documentation and source VCS URLs in the Gradle Plugin description.