### PR TITLE
fix: fix package extraction failure when package declaration is not first line

### DIFF
--- a/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
+++ b/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
@@ -161,10 +161,12 @@ public class HillaAppInitUtility {
         try {
             var content = Files.readString(path);
             var regexToExcludeCommentsAndStringLiterals = "//.*|(\"(?:\\\\[^\"]|\\\\\"|.)*?\")|(?s)/\\*.*?\\*/";
-            var codeWithoutComments = content.replaceAll(regexToExcludeCommentsAndStringLiterals, "");
+            var codeWithoutComments = content
+                    .replaceAll(regexToExcludeCommentsAndStringLiterals, "");
 
             var regexToExtractPackage = "package\\b\\s+([a-zA-Z_][\\w.]*)\\s*;";
-            var matcher = Pattern.compile(regexToExtractPackage).matcher(codeWithoutComments);
+            var matcher = Pattern.compile(regexToExtractPackage)
+                    .matcher(codeWithoutComments);
             if (matcher.find()) {
                 return matcher.group(1);
             }

--- a/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
+++ b/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipFile;
 import org.slf4j.Logger;

--- a/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
+++ b/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipFile;
 import org.slf4j.Logger;
@@ -159,8 +160,11 @@ public class HillaAppInitUtility {
     private static String extractPackage(Path path) {
         try {
             var content = Files.readString(path);
-            var matcher = Pattern.compile("^\\s*package\\s+([\\w.]+)\\s*;")
-                    .matcher(content);
+            var regexToExcludeCommentsAndStringLiterals = "//.*|(\"(?:\\\\[^\"]|\\\\\"|.)*?\")|(?s)/\\*.*?\\*/";
+            var codeWithoutComments = content.replaceAll(regexToExcludeCommentsAndStringLiterals, "");
+
+            var regexToExtractPackage = "package\\b\\s+([a-zA-Z_][\\w.]*)\\s*;";
+            var matcher = Pattern.compile(regexToExtractPackage).matcher(codeWithoutComments);
             if (matcher.find()) {
                 return matcher.group(1);
             }

--- a/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
+++ b/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
@@ -193,15 +193,16 @@ public class HillaAppInitUtilityTest {
                 // single line comments might also contain package declarations:
                 // package my.single.line.comment;
 
+                /**
+                 * javadocs may contain package declarations:
+                 * package my.javadoc.package1;
+                 */
+
                 package   my ;
 
                 import org.springframework.boot.SpringApplication;
                 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-                /**
-                 * javadocs may contain package declarations:
-                 * package my.javadoc.package1;
-                 */
                 @SpringBootApplication
                 public class Application {
                     String myPackage = "my.package1.in.string.literal";

--- a/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
+++ b/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
@@ -190,6 +190,12 @@ public class HillaAppInitUtilityTest {
                 * package my.package1.app;
                 */
 
+                /*
+                 Some multi-line comments might not have * at the begiining
+                 of each line, especially before package declaration statement:
+                 package my.package1.app;
+                */
+
                 // single line comments might also contain package declarations:
                 // package my.single.line.comment;
 

--- a/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
+++ b/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
@@ -167,18 +167,18 @@ public class HillaAppInitUtilityTest {
     }
 
     private void assertEndpointIsNotGeneratedForInvalidPackages() {
-        Assertions.assertFalse(projectDirectory
-            .resolve("src/main/java/my/package1/app/endpoints/HelloEndpoint.java")
-            .toFile().exists());
-        Assertions.assertFalse(projectDirectory
-            .resolve("src/main/java/my/single/line/comment/endpoints/HelloEndpoint.java")
-            .toFile().exists());
-        Assertions.assertFalse(projectDirectory
-            .resolve("src/main/java/my/javadoc/package1/endpoints/HelloEndpoint.java")
-            .toFile().exists());
-        Assertions.assertFalse(projectDirectory
-            .resolve("src/main/java/my/package1/in/string/literal/endpoints/HelloEndpoint.java")
-            .toFile().exists());
+        Assertions.assertFalse(projectDirectory.resolve(
+                "src/main/java/my/package1/app/endpoints/HelloEndpoint.java")
+                .toFile().exists());
+        Assertions.assertFalse(projectDirectory.resolve(
+                "src/main/java/my/single/line/comment/endpoints/HelloEndpoint.java")
+                .toFile().exists());
+        Assertions.assertFalse(projectDirectory.resolve(
+                "src/main/java/my/javadoc/package1/endpoints/HelloEndpoint.java")
+                .toFile().exists());
+        Assertions.assertFalse(projectDirectory.resolve(
+                "src/main/java/my/package1/in/string/literal/endpoints/HelloEndpoint.java")
+                .toFile().exists());
     }
 
     private void createSpringBootApplicationClass() throws IOException {

--- a/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
+++ b/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
@@ -93,6 +93,8 @@ public class HillaAppInitUtilityTest {
                 .toFile().exists());
         Assertions.assertTrue(projectDirectory
                 .resolve("frontend/views/MainView.tsx").toFile().exists());
+
+        assertEndpointIsNotGeneratedForInvalidPackages();
     }
 
     @Test
@@ -127,6 +129,8 @@ public class HillaAppInitUtilityTest {
                 .toFile().exists());
         Assertions.assertTrue(projectDirectory
                 .resolve("frontend/views/MainView.tsx").toFile().exists());
+
+        assertEndpointIsNotGeneratedForInvalidPackages();
     }
 
     @Test
@@ -158,18 +162,49 @@ public class HillaAppInitUtilityTest {
                 .toFile().exists());
         Assertions.assertTrue(projectDirectory
                 .resolve("frontend/views/main-view.ts").toFile().exists());
+
+        assertEndpointIsNotGeneratedForInvalidPackages();
+    }
+
+    private void assertEndpointIsNotGeneratedForInvalidPackages() {
+        Assertions.assertFalse(projectDirectory
+            .resolve("src/main/java/my/package1/app/endpoints/HelloEndpoint.java")
+            .toFile().exists());
+        Assertions.assertFalse(projectDirectory
+            .resolve("src/main/java/my/single/line/comment/endpoints/HelloEndpoint.java")
+            .toFile().exists());
+        Assertions.assertFalse(projectDirectory
+            .resolve("src/main/java/my/javadoc/package1/endpoints/HelloEndpoint.java")
+            .toFile().exists());
+        Assertions.assertFalse(projectDirectory
+            .resolve("src/main/java/my/package1/in/string/literal/endpoints/HelloEndpoint.java")
+            .toFile().exists());
     }
 
     private void createSpringBootApplicationClass() throws IOException {
 
         var content = """
-                package my;
+                /*
+                * Some comments that might also contains a package
+                * declaration statement:
+                * package my.package1.app;
+                */
+
+                // single line comments might also contain package declarations:
+                // package my.single.line.comment;
+
+                package   my ;
 
                 import org.springframework.boot.SpringApplication;
                 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+                /**
+                 * javadocs may contain package declarations:
+                 * package my.javadoc.package1;
+                 */
                 @SpringBootApplication
                 public class Application {
+                    String myPackage = "my.package1.in.string.literal";
                     public static void main(String[] args) {
                         SpringApplication.run(Application.class, args);
                     }


### PR DESCRIPTION
## Description
This changes the package extraction approach for the class 
annotated with `@SpringBootApplication` by excluding all type
of java comments (single and multi-line), javadocs, and string 
literals, and then tries to extract the package declaration.  

Fixes #1048

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
