### PR TITLE
POC: feat: add support for re-generating endpoints without restart

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointControllerConfiguration.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointControllerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2022 Vaadin Ltd.
+ * Copyright 2000-2023 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package dev.hilla;
 
 import java.lang.reflect.Method;
 
+import dev.hilla.internal.hotswap.HotSwapConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.util.pattern.PathPatternParser;
@@ -41,6 +43,7 @@ import jakarta.servlet.ServletContext;
  * A configuration class for customizing the {@link EndpointController} class.
  */
 @Configuration
+@Import(HotSwapConfiguration.class)
 public class EndpointControllerConfiguration {
     private final EndpointProperties endpointProperties;
 

--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointControllerConfiguration.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointControllerConfiguration.java
@@ -18,7 +18,6 @@ package dev.hilla;
 
 import java.lang.reflect.Method;
 
-import dev.hilla.internal.hotswap.HotSwapConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -26,7 +25,6 @@ import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.util.pattern.PathPatternParser;
@@ -43,7 +41,6 @@ import jakarta.servlet.ServletContext;
  * A configuration class for customizing the {@link EndpointController} class.
  */
 @Configuration
-@Import(HotSwapConfiguration.class)
 public class EndpointControllerConfiguration {
     private final EndpointProperties endpointProperties;
 

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/EndpointHotSwapListener.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/EndpointHotSwapListener.java
@@ -21,13 +21,19 @@ import dev.hilla.engine.EngineConfiguration;
 import dev.hilla.engine.GeneratorProcessor;
 import dev.hilla.engine.ParserProcessor;
 import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static dev.hilla.internal.hotswap.HotSwapEvent.Type.OPEN_API_JSON;
 
 class EndpointHotSwapListener implements HotSwapListener {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(EndpointHotSwapListener.class);
 
     private final EndpointController endpointController;
 
@@ -48,6 +54,7 @@ class EndpointHotSwapListener implements HotSwapListener {
     public void onHotSwapEvent(HotSwapEvent event) {
         if (OPEN_API_JSON == event.type()) {
             this.endpointController.registerEndpoints();
+            reload(event);
         } else {
             Path buildDir = event.classesDir().getParent();
             EngineConfiguration engineConfiguration;
@@ -64,6 +71,16 @@ class EndpointHotSwapListener implements HotSwapListener {
                     engineConfiguration, "node");
             generator.process();
         }
+    }
+
+    private void reload(HotSwapEvent event) {
+
+        Optional.ofNullable(event.browserLiveReload())
+                .ifPresent(browserLiveReload -> {
+                    LOGGER.debug(
+                            "Reloading the browser after endpoint(s) changes...");
+                    browserLiveReload.reload();
+                });
     }
 
 }

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/EndpointHotSwapListener.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/EndpointHotSwapListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package dev.hilla.internal.hotswap;
+
+import dev.hilla.EndpointController;
+import dev.hilla.engine.EngineConfiguration;
+import dev.hilla.engine.GeneratorProcessor;
+import dev.hilla.engine.ParserProcessor;
+import jakarta.annotation.PostConstruct;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static dev.hilla.internal.hotswap.HotSwapEvent.Type.OPEN_API_JSON;
+
+class EndpointHotSwapListener implements HotSwapListener {
+
+    private final EndpointController endpointController;
+
+    private final HotSwapWatchService hotSwapWatchService;
+
+    public EndpointHotSwapListener(EndpointController endpointController,
+            HotSwapWatchService hotSwapWatchService) {
+        this.endpointController = endpointController;
+        this.hotSwapWatchService = hotSwapWatchService;
+    }
+
+    @PostConstruct
+    private void registerForHotSwapChanges() {
+        hotSwapWatchService.addHotSwapListener(this);
+    }
+
+    @Override
+    public void onHotSwapEvent(HotSwapEvent event) {
+        if (OPEN_API_JSON == event.type()) {
+            this.endpointController.registerEndpoints();
+        } else {
+            Path buildDir = event.classesDir().getParent();
+            EngineConfiguration engineConfiguration;
+            try {
+                engineConfiguration = EngineConfiguration
+                        .loadDirectory(buildDir);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            ParserProcessor parser = new ParserProcessor(engineConfiguration,
+                    this.getClass().getClassLoader());
+            parser.process();
+            GeneratorProcessor generator = new GeneratorProcessor(
+                    engineConfiguration, "node");
+            generator.process();
+        }
+    }
+
+}

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapConfiguration.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package dev.hilla.internal.hotswap;
+
+import dev.hilla.EndpointController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class HotSwapConfiguration {
+
+    @Bean
+    @Scope("singleton")
+    HotSwapWatchService hotSwapWatchService() {
+        return new HotSwapWatchService();
+    }
+
+    @Bean
+    @Scope("singleton")
+    HotSwapServiceInitializer hotSwapServiceInitializer(
+            @Autowired HotSwapWatchService hotSwapWatchService) {
+        return new HotSwapServiceInitializer(hotSwapWatchService);
+    }
+
+    @Bean
+    @Scope("singleton")
+    EndpointHotSwapListener endpointHotSwapListener(
+            @Autowired HotSwapWatchService hotSwapWatchService,
+            @Autowired EndpointController endpointController) {
+        return new EndpointHotSwapListener(endpointController,
+                hotSwapWatchService);
+    }
+}

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapConfiguration.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapConfiguration.java
@@ -20,26 +20,22 @@ import dev.hilla.EndpointController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 
 @Configuration
 public class HotSwapConfiguration {
 
     @Bean
-    @Scope("singleton")
     HotSwapWatchService hotSwapWatchService() {
         return new HotSwapWatchService();
     }
 
     @Bean
-    @Scope("singleton")
     HotSwapServiceInitializer hotSwapServiceInitializer(
             @Autowired HotSwapWatchService hotSwapWatchService) {
         return new HotSwapServiceInitializer(hotSwapWatchService);
     }
 
     @Bean
-    @Scope("singleton")
     EndpointHotSwapListener endpointHotSwapListener(
             @Autowired HotSwapWatchService hotSwapWatchService,
             @Autowired EndpointController endpointController) {

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapEvent.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapEvent.java
@@ -16,9 +16,11 @@
 
 package dev.hilla.internal.hotswap;
 
+import com.vaadin.flow.internal.BrowserLiveReload;
+
 import java.nio.file.Path;
 
-public record HotSwapEvent(Type type, Path classesDir) {
+public record HotSwapEvent(Type type, Path classesDir, BrowserLiveReload browserLiveReload) {
 
     public enum Type {
         CLASSES, OPEN_API_JSON

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapEvent.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package dev.hilla.internal.hotswap;
+
+import java.nio.file.Path;
+
+public record HotSwapEvent(Type type, Path classesDir) {
+
+    public enum Type {
+        CLASSES, OPEN_API_JSON
+    }
+
+}

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapListener.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package dev.hilla.internal.hotswap;
+
+public interface HotSwapListener {
+
+    void onHotSwapEvent(HotSwapEvent event);
+
+}

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapServiceInitializer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapServiceInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package dev.hilla.internal.hotswap;
+
+import com.vaadin.flow.internal.BrowserLiveReload;
+import com.vaadin.flow.internal.BrowserLiveReloadAccessor;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+import java.nio.file.Path;
+
+class HotSwapServiceInitializer implements VaadinServiceInitListener {
+
+    private final HotSwapWatchService hotSwapWatchService;
+
+    public HotSwapServiceInitializer(HotSwapWatchService hotSwapWatchService) {
+        this.hotSwapWatchService = hotSwapWatchService;
+    }
+
+    @Override
+    public void serviceInit(ServiceInitEvent serviceInitEvent) {
+        VaadinService vaadinService = serviceInitEvent.getSource();
+        BrowserLiveReloadAccessor.getLiveReloadFromService(vaadinService)
+                .ifPresent(browserLiveReload -> {
+                    if (BrowserLiveReload.Backend.SPRING_BOOT_DEVTOOLS != browserLiveReload
+                            .getBackend() && isHotSwapEnabled(vaadinService)) {
+                        hotSwapWatchService.watch(getClassesDir(vaadinService));
+                    }
+                });
+    }
+
+    private boolean isHotSwapEnabled(VaadinService vaadinService) {
+        return vaadinService.getDeploymentConfiguration()
+                .isDevModeLiveReloadEnabled();
+    }
+
+    private Path getClassesDir(VaadinService vaadinService) {
+        var deploymentConfig = vaadinService.getDeploymentConfiguration();
+        var projectFolder = deploymentConfig.getProjectFolder().toPath();
+        return projectFolder.resolve(deploymentConfig.getBuildFolder())
+                .resolve("classes");
+    }
+}

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapServiceInitializer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapServiceInitializer.java
@@ -39,7 +39,8 @@ class HotSwapServiceInitializer implements VaadinServiceInitListener {
                 .ifPresent(browserLiveReload -> {
                     if (BrowserLiveReload.Backend.SPRING_BOOT_DEVTOOLS != browserLiveReload
                             .getBackend() && isHotSwapEnabled(vaadinService)) {
-                        hotSwapWatchService.watch(getClassesDir(vaadinService));
+                        hotSwapWatchService.watch(getClassesDir(vaadinService),
+                                browserLiveReload);
                     }
                 });
     }

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapWatchService.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapWatchService.java
@@ -16,6 +16,7 @@
 
 package dev.hilla.internal.hotswap;
 
+import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.shared.Registration;
 import org.slf4j.Logger;
@@ -40,6 +41,8 @@ final class HotSwapWatchService {
     private final Map<WatchKey, Path> keys;
 
     private boolean trace;
+
+    private BrowserLiveReload browserLiveReload;
 
     private Path classesDir;
 
@@ -98,8 +101,8 @@ final class HotSwapWatchService {
     /**
      * Process all events for keys queued to the watcher
      */
-    void watch(Path classesDir) {
-
+    void watch(Path classesDir, BrowserLiveReload browserLiveReload) {
+        this.browserLiveReload = browserLiveReload;
         this.classesDir = classesDir;
         try {
             registerAll(classesDir);
@@ -200,7 +203,8 @@ final class HotSwapWatchService {
             var hotSwapType = isOpenApiJsonChanged
                     ? HotSwapEvent.Type.OPEN_API_JSON
                     : HotSwapEvent.Type.CLASSES;
-            var hotSwapEvent = new HotSwapEvent(hotSwapType, classesDir);
+            var hotSwapEvent = new HotSwapEvent(hotSwapType, classesDir,
+                    browserLiveReload);
             hotSwapListeners
                     .forEach(listener -> listener.onHotSwapEvent(hotSwapEvent));
         }

--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapWatchService.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapWatchService.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package dev.hilla.internal.hotswap;
+
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.shared.Registration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.concurrent.Executors;
+
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+import static java.nio.file.StandardWatchEventKinds.*;
+
+final class HotSwapWatchService {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(HotSwapWatchService.class);
+
+    private final WatchService watcher;
+
+    private final Map<WatchKey, Path> keys;
+
+    private boolean trace;
+
+    private Path classesDir;
+
+    private final Collection<HotSwapListener> hotSwapListeners = new ArrayList<>();
+
+    HotSwapWatchService() {
+
+        this.keys = new HashMap<>();
+        try {
+            this.watcher = FileSystems.getDefault().newWatchService();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Register the given directory, and all its sub-directories, with the
+     * WatchService.
+     */
+    private void registerAll(final Path start) throws IOException {
+
+        Files.walkFileTree(start, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir,
+                    BasicFileAttributes attrs) throws IOException {
+                register(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    /**
+     * Register the given directory with the WatchService
+     */
+    private void register(Path dir) throws IOException {
+        WatchKey key = dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE,
+                ENTRY_MODIFY);
+        if (trace) {
+            Path prev = keys.get(key);
+            if (prev == null) {
+                debug("registering: %s %n", dir);
+            } else {
+                if (!dir.equals(prev)) {
+                    debug("update: %s -> %s\n", prev, dir);
+                }
+            }
+        }
+        keys.put(key, dir);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> WatchEvent<T> cast(WatchEvent<?> event) {
+        return (WatchEvent<T>) event;
+    }
+
+    /**
+     * Process all events for keys queued to the watcher
+     */
+    void watch(Path classesDir) {
+
+        this.classesDir = classesDir;
+        try {
+            registerAll(classesDir);
+            // enable trace after initial registration
+            trace = true;
+        } catch (IOException e) {
+            error(String.format("Could not register the Watcher Service to %s",
+                    classesDir.toString()));
+            throw new RuntimeException(e);
+        }
+
+        Executors.newSingleThreadExecutor().execute(getWatchLoopRunnable());
+    }
+
+    private Runnable getWatchLoopRunnable() {
+        return () -> {
+            for (;;) {
+                // wait for key to be signalled
+                WatchKey key;
+                try {
+                    key = watcher.take();
+                } catch (InterruptedException x) {
+                    return;
+                }
+
+                Path dir = keys.get(key);
+                if (dir == null) {
+                    error("WatchKey not recognized!!");
+                    continue;
+                }
+
+                var changedFiles = new HashSet<String>();
+
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    WatchEvent.Kind<?> kind = event.kind();
+
+                    if (kind == OVERFLOW) {
+                        continue;
+                    }
+
+                    // Context for directory entry event is the path of the
+                    // entry
+                    WatchEvent<Path> ev = cast(event);
+                    Path file = ev.context();
+                    Path child = dir.resolve(file);
+
+                    // if directory is created, then register it as well as its
+                    // sub-directories
+                    if (kind == ENTRY_CREATE) {
+                        try {
+                            if (Files.isDirectory(child, NOFOLLOW_LINKS)) {
+                                registerAll(child);
+                            }
+                        } catch (IOException e) {
+                            error(String.format(
+                                    "Could not register for the changes to the newly added files in %s"
+                                            + " - Please restart the application to make sure all the classes are in sync.",
+                                    child));
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    String fileName = child.toString();
+
+                    if (fileName.endsWith("openapi.json") || changedFiles
+                            .stream().noneMatch(fileName::startsWith)) {
+                        debug("%s: %s\n", event.kind().name(), child);
+                        changedFiles.add(fileName);
+                    }
+                }
+
+                try {
+                    fireHotSwapEvent(changedFiles);
+                } catch (ExecutionFailedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // reset key and remove from set if directory no longer
+                // accessible
+                boolean valid = key.reset();
+                if (!valid) {
+                    keys.remove(key);
+
+                    // all directories are inaccessible
+                    if (keys.isEmpty()) {
+                        break;
+                    }
+                }
+            }
+        };
+    }
+
+    private void fireHotSwapEvent(Collection<String> changedFiles)
+            throws ExecutionFailedException {
+        if (changedFiles.size() > 0) {
+            boolean isOpenApiJsonChanged = changedFiles.stream()
+                    .anyMatch(file -> file.endsWith("openapi.json"));
+            var hotSwapType = isOpenApiJsonChanged
+                    ? HotSwapEvent.Type.OPEN_API_JSON
+                    : HotSwapEvent.Type.CLASSES;
+            var hotSwapEvent = new HotSwapEvent(hotSwapType, classesDir);
+            hotSwapListeners
+                    .forEach(listener -> listener.onHotSwapEvent(hotSwapEvent));
+        }
+    }
+
+    Registration addHotSwapListener(HotSwapListener listener) {
+        return Registration.addAndRemove(this.hotSwapListeners, listener);
+    }
+
+    private void debug(String format, Object... params) {
+        debug(String.format(format, params));
+    }
+
+    private void debug(String message) {
+        LOGGER.debug("### Hilla classes Watch service > " + message);
+    }
+
+    private void error(String message) {
+        LOGGER.error("### Hilla classes Watch service > " + message);
+    }
+}

--- a/packages/java/endpoint/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/packages/java/endpoint/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 dev.hilla.EndpointController
 dev.hilla.push.PushConfigurer
+dev.hilla.internal.hotswap.HotSwapConfiguration


### PR DESCRIPTION
## Description

This feature is based on having either HotSwap Agent or JRebel set in the development environment for
reloading classes so that Parser and Generator can re-generate the needed ts files based on the latest compiled classes.

In this approach, a filesystem WatchService will start monitoring the classes directory (in a separate thread) for changes if:

- Application is running in Dev mode, and
- Dev mode live reload is enabled, and
- The backend support for live reload is not Spring Boot DevTools

When a change in the classes is detected, the Parser and then Generator will update the openapi.json, and since this file reside under classes itself, then its changes also detected which will trigger the re-registration of the Endpoints, without a need to restart the application.

**Limitations**:
The limitations are dictated by the limitations of JRebel or HotSwapAgent to redefining the classes at runtime. Some preliminary local tests shows that HotSwapAgent is working much smoother than JRebel. For example, JRebel sometimes fails to redefine the method renames in the memory, although, Hilla is reloading the change based on the latest changes completely fine. HowSwapAgent shows a faster reload as well compared to JRebel.

If Only Spring Boot DevTools is in use in an application, the watch service will not register for changes, so the developer experience will not change.

Developer, do not need to do any setup or changes to their project in order to enable this feature, other than setting up the HotSwapAgent or JRebel in their development environment.

Fixes #863 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
