### PR TITLE
chore: fix regexp to allow dots in artifactId

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -50,7 +50,8 @@ jobs:
               -Dexec.args='${project.groupId}:${project.artifactId}' \
               -Dexec.skip='${maven.deploy.skip}' \
               exec:exec \
-            | tr '.:' '/' \
+            | perl -pe 's/\.(?=.*:)/\//g' \
+            | sed -e 's/:/\//' \
             | sed -e 's/^/.m2\/repository\//' \
           )
           find packages/java -type d -name target -print0 | xargs -0 tar rf workspace.tar


### PR DESCRIPTION
It allows that we can have dots in artifactId so as we can add `dev.hilla.gradle.plugin` in #1087
This should be merged before #1087 
