### PR TITLE
fix(jvm-parser): use gradle.exe as executable as well

### DIFF
--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
@@ -69,7 +69,7 @@ public class GradleRunner implements CommandRunner {
 
     @Override
     public List<String> executables() {
-        return IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat")
+        return IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat", "gradle")
                 : List.of("./gradlew", "gradle");
     }
 }


### PR DESCRIPTION
This PR fixes Gradle test failure on Windows