### PR TITLE
fix: accept entities with no properties

### DIFF
--- a/packages/ts/generator-typescript-plugin-backbone/src/EntityProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EntityProcessor.ts
@@ -13,7 +13,7 @@ import {
   isNullableSchema,
   isObjectSchema,
   isReferenceSchema,
-  type NonEmptyObjectSchema,
+  type ObjectSchema,
 } from '@hilla/generator-typescript-core/Schema.js';
 import {
   convertFullyQualifiedNameToRelativePath,
@@ -91,7 +91,7 @@ export class EntityProcessor {
       this.#id,
       undefined,
       undefined,
-      this.#processTypeElements(schema as NonEmptyObjectSchema),
+      this.#processTypeElements(schema as ObjectSchema),
     );
   }
 
@@ -153,8 +153,8 @@ export class EntityProcessor {
     return imports.default.add(path, specifier, true);
   }
 
-  #processTypeElements({ properties }: NonEmptyObjectSchema): readonly TypeElement[] {
-    return Object.entries(properties).map(([name, schema]) => {
+  #processTypeElements({ properties }: ObjectSchema): readonly TypeElement[] {
+    return Object.entries(properties ?? {}).map(([name, schema]) => {
       const [type] = new TypeSchemaProcessor(schema, this.#dependencies).process();
 
       return ts.factory.createPropertySignature(

--- a/packages/ts/generator-typescript-plugin-backbone/test/no-properties/NoProperties.json
+++ b/packages/ts/generator-typescript-plugin-backbone/test/no-properties/NoProperties.json
@@ -1,0 +1,82 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Hilla Application",
+    "version" : "1.0.0"
+  },
+  "servers" : [
+    {
+      "url" : "http://localhost:8080/connect",
+      "description" : "Hilla Backend"
+    }
+  ],
+  "tags" : [
+    {
+      "name" : "NoPropertiesEndpoint"
+    }
+  ],
+  "paths" : {
+    "/NoPropertiesEndpoint/sayHello" : {
+      "post" : {
+        "tags" : [
+          "NoPropertiesEndpoint"
+        ],
+        "operationId" : "NoPropertiesEndpoint_sayHello_POST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "id" : {
+                    "anyOf" : [
+                      {
+                        "$ref" : "#/components/schemas/com.example.application.entities.ExampleEntity"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "com.example.application.entities.ExampleEntity" : {
+        "anyOf" : [
+          {
+            "$ref" : "#/components/schemas/com.example.application.entities.CoreEntity"
+          },
+          {
+            "type" : "object",
+            "properties" : {
+              "id" : {
+                "type" : "integer",
+                "format" : "int64",
+                "nullable" : true
+              }
+            }
+          }
+        ]
+      },
+      "com.example.application.entities.CoreEntity" : {
+        "type" : "object"
+      }
+    }
+  }
+}

--- a/packages/ts/generator-typescript-plugin-backbone/test/no-properties/NoProperties.spec.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/no-properties/NoProperties.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import snapshotMatcher from '@hilla/generator-typescript-utils/testing/snapshotMatcher.js';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import BackbonePlugin from '../../src/index.js';
+import { createGenerator, loadInput } from '../utils/common.js';
+
+use(sinonChai);
+use(snapshotMatcher);
+
+describe('BackbonePlugin', () => {
+  context('when an entity with no properties is processed', () => {
+    const sectionName = 'NoProperties';
+
+    it('creates an empty TS interface without errors', async () => {
+      const generator = createGenerator([BackbonePlugin]);
+      const input = await loadInput(sectionName, import.meta.url);
+      const files = await generator.process(input);
+      expect(files.length).to.equal(3);
+
+      const [endpointFile, entity1, entity2] = files;
+
+      await expect(await endpointFile.text()).toMatchSnapshot(`${sectionName}Endpoint`, import.meta.url);
+      expect(endpointFile.name).to.equal(`${sectionName}Endpoint.ts`);
+
+      await expect(await entity1.text()).toMatchSnapshot(`ExampleEntity`, import.meta.url);
+      expect(entity1.name).to.equal(`com/example/application/entities/ExampleEntity.ts`);
+
+      await expect(await entity2.text()).toMatchSnapshot(`CoreEntity`, import.meta.url);
+      expect(entity2.name).to.equal(`com/example/application/entities/CoreEntity.ts`);
+    });
+  });
+});

--- a/packages/ts/generator-typescript-plugin-backbone/test/no-properties/fixtures/CoreEntity.snap.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/no-properties/fixtures/CoreEntity.snap.ts
@@ -1,0 +1,3 @@
+interface CoreEntity {
+}
+export default CoreEntity;

--- a/packages/ts/generator-typescript-plugin-backbone/test/no-properties/fixtures/ExampleEntity.snap.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/no-properties/fixtures/ExampleEntity.snap.ts
@@ -1,0 +1,5 @@
+import type CoreEntity_1 from "./CoreEntity.js";
+interface ExampleEntity extends CoreEntity_1 {
+    id?: number;
+}
+export default ExampleEntity;

--- a/packages/ts/generator-typescript-plugin-backbone/test/no-properties/fixtures/NoPropertiesEndpoint.snap.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/test/no-properties/fixtures/NoPropertiesEndpoint.snap.ts
@@ -1,0 +1,5 @@
+import { EndpointRequestInit as EndpointRequestInit_1 } from "@hilla/frontend";
+import type ExampleEntity_1 from "./com/example/application/entities/ExampleEntity.js";
+import client_1 from "./connect-client.default.js";
+async function sayHello_1(id: ExampleEntity_1, init?: EndpointRequestInit_1): Promise<string> { return client_1.call("NoPropertiesEndpoint", "sayHello", { id }, init); }
+export { sayHello_1 as sayHello };


### PR DESCRIPTION
While it's unlikely to want to use entities with no properties in endpoints, they can exist up in the class hierarchy as supertypes and the generator wants to deal with them.

This PR adds a simple fix to generate empty entities.

Fixes #1105