### PR TITLE
fix: set atmosphere's default broadcaster back to default

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/push/PushConfigurer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/push/PushConfigurer.java
@@ -57,7 +57,6 @@ public class PushConfigurer {
                 new TrackMessageSizeInterceptor(),
                 new SuspendTrackerInterceptor());
         AtmosphereFramework fw = atmosphereServlet.framework();
-        fw.setDefaultBroadcasterClassName(SimpleBroadcaster.class.getName());
         fw.addAtmosphereHandler(HILLA_PUSH_PATH, pushEndpoint, interceptors);
 
         // Override the global mapping set by Flow


### PR DESCRIPTION
## Description

This is a partial revert for the change in #1103
to just let the DefaultBroadcaster be used since
it is able to broadcast asynchronously by using
an ExecutorService to broadcast the messages to
the suspended responses while SimpleBroadcaster
is blocked by the current thread.
