### PR TITLE
fix: make NonNullApi only work on own package

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoModel.java
@@ -32,6 +32,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
     private List<ClassInfoModel> innerClasses;
     private List<ClassRefSignatureModel> interfaces;
     private List<MethodInfoModel> methods;
+    private PackageInfoModel pkg;
     private List<PackageInfoModel> ancestors;
     private Optional<ClassRefSignatureModel> superClass;
     private List<TypeParameterModel> typeParameters;
@@ -299,20 +300,12 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
         return methods;
     }
 
-    /**
-     * Tries to find all packages that are ancestors of this class. From the
-     * list of all possible ancestor packages, only those whose existence is
-     * confirmed are returned. This is a "best effort" to find them as, even if
-     * they exist, there is no guarantee that they have already been loaded.
-     *
-     * @return a list of packages that are ancestors of this class
-     */
-    public List<PackageInfoModel> findAncestors() {
-        if (ancestors == null) {
-            ancestors = prepareAncestors();
+    public PackageInfoModel getPackage() {
+        if (pkg == null) {
+            pkg = preparePackage();
         }
 
-        return ancestors;
+        return pkg;
     }
 
     public abstract String getSimpleName();
@@ -441,7 +434,7 @@ public abstract class ClassInfoModel extends AnnotatedAbstractModel
 
     protected abstract List<MethodInfoModel> prepareMethods();
 
-    protected abstract List<PackageInfoModel> prepareAncestors();
+    protected abstract PackageInfoModel preparePackage();
 
     protected abstract ClassRefSignatureModel prepareSuperClass();
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -222,26 +222,8 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     }
 
     @Override
-    protected List<PackageInfoModel> prepareAncestors() {
-        var classLoader = origin.getClassLoader();
-
-        return getAllAncestorPackageNames(origin.getPackageName())
-                .map(classLoader::getDefinedPackage).filter(Objects::nonNull)
-                .map(PackageInfoModel::of).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns a stream of all ancestor package names, starting with the package
-     * itself.
-     *
-     * @param packageName
-     *            the package packageName
-     * @return the stream of all ancestor package names
-     */
-    private static Stream<String> getAllAncestorPackageNames(
-            String packageName) {
-        return Stream.iterate(packageName, n -> n.contains("."),
-                n -> n.substring(0, n.lastIndexOf('.')));
+    protected PackageInfoModel preparePackage() {
+        return PackageInfoModel.of(origin.getPackage());
     }
 
     @Override

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
@@ -220,13 +220,10 @@ final class ClassInfoSourceModel extends ClassInfoModel implements SourceModel {
     }
 
     @Override
-    protected List<PackageInfoModel> prepareAncestors() {
-        // This is just a dummy implementation, as source models are no longer
-        // used. It only returns the package of the class.
-        return List.of(PackageInfoModel.of(origin.getPackageInfo()));
+    protected PackageInfoModel preparePackage() {
+        return PackageInfoModel.of(origin.getPackageInfo());
     }
 
-    @Override
     protected ClassRefSignatureModel prepareSuperClass() {
         var superClass = origin.getTypeSignatureOrTypeDescriptor()
                 .getSuperclassSignature();

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
@@ -344,23 +344,6 @@ public class ClassInfoModelTests {
         }
     }
 
-    @DisplayName("It should return all valid ancestors packages")
-    @Test
-    public void should_ReturnAllValidAncestorsPackages() {
-        // Load the `dev.hilla` package
-        var dummy = new dev.hilla.Dummy();
-        var model = ClassInfoModel.of(ctx.getReflectionOrigin());
-        var ancestors = model.findAncestors();
-        var ancestorNames = ancestors.stream().map(PackageInfoModel::getName)
-                .sorted().collect(Collectors.toList());
-
-        // `findAncestors()` returns only valid packages, so the result of this
-        // test could vary if some class is added to, or removed from, any
-        // ancestor package
-        assertEquals(List.of("dev.hilla", "dev.hilla.parser.models"),
-                ancestorNames);
-    }
-
     static final class Characteristics {
         enum Enum {
         }

--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/dev/hilla/parser/plugins/nonnull/NonnullPlugin.java
@@ -112,13 +112,17 @@ public final class NonnullPlugin extends AbstractPlugin<NonnullPluginConfig> {
                 .map(node -> (ClassInfoModel) node.getSource()).findFirst();
     }
 
+    private Optional<PackageInfoModel> findClosestPackage(
+            NodePath<?> nodePath) {
+        return nodePath.stream().map(NodePath::getNode)
+                .filter(node -> node.getSource() instanceof ClassInfoModel)
+                .map(node -> (ClassInfoModel) node.getSource()).findFirst()
+                .map(ClassInfoModel::getPackage);
+    }
+
     private Stream<AnnotationInfoModel> getPackageAnnotationsStream(
             NodePath<?> nodePath) {
-        return findClosestClass(nodePath)
-                // Find all available ancestor packages
-                .map(ClassInfoModel::findAncestors).map(Collection::stream)
-                .orElseGet(Stream::empty)
-                // Get all annotations from packages
+        return findClosestPackage(nodePath).stream()
                 .map(PackageInfoModel::getAnnotations)
                 .flatMap(Collection::stream);
     }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/NonNullApiEndpoint.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/NonNullApiEndpoint.java
@@ -32,7 +32,7 @@ public class NonNullApiEndpoint {
         return null;
     }
 
-    static class Dependency {
+    public static class Dependency {
         public String defaultField;
         @NullableField
         public String nullableField;

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/subpackage/SubPackageDependency.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/dev/hilla/parser/plugins/nonnull/nonnullapi/subpackage/SubPackageDependency.java
@@ -1,5 +1,6 @@
 package dev.hilla.parser.plugins.nonnull.nonnullapi.subpackage;
 
 public class SubPackageDependency {
+    // this is nullable, as @NonNullApi does not apply to subpackages
     public String defaultField;
 }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/resources/dev/hilla/parser/plugins/nonnull/nonnullapi/openapi.json
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/resources/dev/hilla/parser/plugins/nonnull/nonnullapi/openapi.json
@@ -327,7 +327,8 @@
         "type": "object",
         "properties": {
           "defaultField": {
-            "type": "string"
+            "type": "string",
+            "nullable" : true
           }
         }
       }


### PR DESCRIPTION
Fixes #921

Applying NonNullApi on subpackages is convenient, but it proved to be not reliable due to how packages work in Java.

We found contradictory indications in the Spring documentation, but it looks reasonable to conform to the general Java rule.