### PR TITLE
fix: Do not sort class fields

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -6,10 +6,8 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 final class ClassInfoReflectionModel extends ClassInfoModel
         implements ReflectionModel {

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -197,7 +197,6 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     @Override
     protected List<FieldInfoModel> prepareFields() {
         return Arrays.stream(origin.getDeclaredFields()).map(FieldInfoModel::of)
-                .sorted(FieldInfoModel.FIELD_ORDER)
                 .collect(Collectors.toList());
     }
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoSourceModel.java
@@ -195,7 +195,6 @@ final class ClassInfoSourceModel extends ClassInfoModel implements SourceModel {
     @Override
     protected List<FieldInfoModel> prepareFields() {
         return origin.getDeclaredFieldInfo().stream().map(FieldInfoModel::of)
-                .sorted(FieldInfoModel.FIELD_ORDER)
                 .collect(Collectors.toList());
     }
 

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/FieldInfoModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/FieldInfoModel.java
@@ -1,17 +1,14 @@
 package dev.hilla.parser.models;
 
-import java.lang.reflect.Field;
-import java.util.Comparator;
-import java.util.Objects;
-
 import javax.annotation.Nonnull;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
 
 import io.github.classgraph.FieldInfo;
 
 public abstract class FieldInfoModel extends AnnotatedAbstractModel
         implements ClassMemberModel {
-    static final Comparator<FieldInfoModel> FIELD_ORDER = Comparator
-            .comparing(FieldInfoModel::getName);
     private ClassInfoModel owner;
     private SignatureModel type;
 

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/dependency/DependencyTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/dependency/DependencyTests.java
@@ -1,17 +1,18 @@
 package dev.hilla.parser.core.dependency;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import java.util.Set;
 
 import dev.hilla.parser.core.Parser;
 import dev.hilla.parser.testutils.ResourceLoader;
-
 import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DependencyTests {
     private static final List<String> classPath;
@@ -61,12 +62,12 @@ public class DependencyTests {
 
     @Test
     public void should_ResolveDependencyMembersCorrectly() {
-        var expected = List.of("bar", "dependencyEntityThree", "foo", "foo2",
+        var expected = Set.of("bar", "dependencyEntityThree", "foo", "foo2",
                 "foo3");
 
-        var actual = openApi.getExtensions()
+        Collection<String> actual = (Collection<String>) openApi.getExtensions()
                 .get(DependencyPlugin.DEPS_MEMBERS_STORAGE_KEY);
 
-        assertEquals(expected, actual);
+        assertEquals(expected, new HashSet<>(actual));
     }
 }

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
@@ -236,8 +236,7 @@ public class ClassInfoModelTests {
     @ArgumentsSource(ModelProvider.class)
     public void should_GetClassFields(ClassInfoModel model, ModelKind kind) {
         var expected = getDeclaredFields(Dependency.Sample.class)
-                .map(FieldInfoModel::of)
-                .collect(Collectors.toList());
+                .map(FieldInfoModel::of).collect(Collectors.toList());
         var actual = model.getFields();
 
         assertEquals(expected, actual);

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/ClassInfoModelTests.java
@@ -236,7 +236,7 @@ public class ClassInfoModelTests {
     @ArgumentsSource(ModelProvider.class)
     public void should_GetClassFields(ClassInfoModel model, ModelKind kind) {
         var expected = getDeclaredFields(Dependency.Sample.class)
-                .map(FieldInfoModel::of).sorted(FieldInfoModel.FIELD_ORDER)
+                .map(FieldInfoModel::of)
                 .collect(Collectors.toList());
         var actual = model.getFields();
 

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/jackson/JacksonPropertyModelTests.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/models/jackson/JacksonPropertyModelTests.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -47,10 +48,11 @@ public class JacksonPropertyModelTests {
     @ArgumentsSource(ModelProvider.class)
     public void should_HaveCorrectType(JacksonPropertyModel model,
             String name) {
-        var expectedTypes = JacksonPropertySharedTests.stringifiedTypes
-                .get(name);
-        assertEquals(expectedTypes, model.getAssociatedTypes().stream()
-                .map(Model::get).map(Object::toString).toList());
+        var expectedTypes = new HashSet<>(
+                JacksonPropertySharedTests.stringifiedTypes.get(name));
+        assertEquals(expectedTypes,
+                model.getAssociatedTypes().stream().map(Model::get)
+                        .map(Object::toString).collect(Collectors.toSet()));
     }
 
     @DisplayName("It should pass equality check")
@@ -172,8 +174,9 @@ public class JacksonPropertyModelTests {
         var expected = switch (name) {
         case "propertyGetterOnly", "propertySetterOnly" -> new Expected(false,
                 Optional.empty());
-        default -> new Expected(true, Optional.of(FieldInfoModel
-                .of(getDeclaredField(JacksonPropertySharedTests.Sample.class, name))));
+        default -> new Expected(true,
+                Optional.of(FieldInfoModel.of(getDeclaredField(
+                        JacksonPropertySharedTests.Sample.class, name))));
         };
 
         assertEquals(expected.hasField(), model.hasField());
@@ -193,7 +196,8 @@ public class JacksonPropertyModelTests {
                 false, Optional.empty());
         default -> new Expected(true,
                 Optional.of(MethodInfoModel.of(getDeclaredMethod(
-                        JacksonPropertySharedTests.Sample.class, toGetterName(name)))));
+                        JacksonPropertySharedTests.Sample.class,
+                        toGetterName(name)))));
         };
 
         assertEquals(expected.hasGetter(), model.hasGetter());
@@ -210,7 +214,8 @@ public class JacksonPropertyModelTests {
 
         var expected = switch (name) {
         case "privatePropertyWithAccessors", "propertySetterOnly" -> new Expected(
-                true, getAnyDeclaredMethod(JacksonPropertySharedTests.Sample.class,
+                true,
+                getAnyDeclaredMethod(JacksonPropertySharedTests.Sample.class,
                         toSetterName(name)).map(MethodInfoModel::of));
         default -> new Expected(false, Optional.empty());
         };

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/PropertyPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/PropertyPlugin.java
@@ -27,8 +27,6 @@ import jakarta.annotation.Nonnull;
 
 public final class PropertyPlugin
         extends AbstractPlugin<BackbonePluginConfiguration> {
-    private static final Comparator<JacksonPropertyModel> sorter = Comparator
-            .comparing(JacksonPropertyModel::getName);
     private SerializationConfig serializationConfig = new JacksonObjectMapperFactory.Json()
             .build().getSerializationConfig();
 
@@ -87,7 +85,7 @@ public final class PropertyPlugin
                 .introspect(serializationConfig.constructType((Class<?>) cls));
 
         var processor = new PropertyProcessor(description);
-        return processor.stream().sorted(sorter);
+        return processor.stream();
     }
 
     private JacksonObjectMapperFactory loadJacksonObjectMapperFactory() {

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/jackson/JacksonTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/jackson/JacksonTest.java
@@ -1,14 +1,18 @@
 package dev.hilla.parser.plugins.backbone.jackson;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Set;
-
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
 
 import dev.hilla.parser.core.Parser;
 import dev.hilla.parser.plugins.backbone.BackbonePlugin;
+import dev.hilla.parser.plugins.backbone.jackson.JacksonEndpoint.Sample;
 import dev.hilla.parser.plugins.backbone.test.helpers.TestHelper;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 public class JacksonTest {
     private final TestHelper helper = new TestHelper(getClass());
@@ -16,11 +20,36 @@ public class JacksonTest {
     @Test
     public void should_CorrectlyIgnoreFieldsBasedOnJSONAnnotations()
             throws IOException, URISyntaxException {
+        // This test is only run on JDKs that return fields and methods in the
+        // order they are defined. Some JDKs like JetBrains Runtime does not
+        Assumptions.assumeTrue(fieldsReturnedInDefinedOrder(),
+                "This test is skipped on JDKs that do not return declared methods in the file order");
+
         var openAPI = new Parser().classLoader(getClass().getClassLoader())
                 .classPath(Set.of(helper.getTargetDir().toString()))
                 .endpointAnnotation(Endpoint.class.getName())
                 .addPlugin(new BackbonePlugin()).execute();
 
         helper.executeParserWithConfig(openAPI);
+    }
+
+    private boolean fieldsReturnedInDefinedOrder() {
+        List<String> methodsInClass = List.of("getPrivateProp",
+                "getPrivatePropWithJsonIgnore",
+                "getPrivatePropWithJsonIgnoreProperties",
+                "getPrivateTransientPropWithGetter", "getPropertyGetterOnly",
+                "setPropertyGetterOnly", "getPropertyWithDifferentField",
+                "setPropertyWithDifferentField", "getRenamedPrivateProp",
+                "setPropertySetterOnly");
+        List<String> declaredMethods = Stream
+                .of(Sample.class.getDeclaredMethods()).map(Method::getName)
+                .filter(name -> !name.equals("$jacocoInit")).toList();
+        if (declaredMethods.size() != methodsInClass.size()) {
+            throw new IllegalStateException(methodsInClass.size()
+                    + " methods defined, " + declaredMethods.size() + " found. "
+                    + "If you modify methods in the " + Sample.class.getName()
+                    + " you need to update this method");
+        }
+        return declaredMethods.equals(methodsInClass);
     }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/enumtype/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/enumtype/openapi.json
@@ -1,37 +1,57 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "Hilla Application",
-    "version": "1.0.0"
-  },
-  "servers": [
-    {
-      "url": "http://localhost:8080/connect",
-      "description": "Hilla Backend"
-    }
-  ],
-  "tags": [
-    {
-      "name": "EnumTypeEndpoint",
-      "x-class-name": "dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint"
-    }
-  ],
-  "paths": {
-    "/EnumTypeEndpoint/echoEnum": {
-      "post": {
-        "tags": ["EnumTypeEndpoint"],
-        "operationId": "EnumTypeEndpoint_echoEnum_POST",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "nullable": true,
-                    "anyOf": [
+    "openapi" : "3.0.1",
+    "info" : {
+      "title" : "Hilla Application",
+      "version" : "1.0.0"
+    },
+    "servers" : [
+      {
+        "url" : "http://localhost:8080/connect",
+        "description" : "Hilla Backend"
+      }
+    ],
+    "tags" : [
+      {
+        "name" : "EnumTypeEndpoint",
+        "x-class-name" : "dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint"
+      }
+    ],
+    "paths" : {
+      "/EnumTypeEndpoint/echoEnum" : {
+        "post" : {
+          "tags" : [
+            "EnumTypeEndpoint"
+          ],
+          "operationId" : "EnumTypeEndpoint_echoEnum_POST",
+          "requestBody" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "value" : {
+                      "nullable" : true,
+                      "anyOf" : [
+                        {
+                          "$ref" : "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "responses" : {
+            "200" : {
+              "description" : "",
+              "content" : {
+                "application/json" : {
+                  "schema" : {
+                    "nullable" : true,
+                    "anyOf" : [
                       {
-                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+                        "$ref" : "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
                       }
                     ]
                   }
@@ -39,44 +59,51 @@
               }
             }
           }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "nullable": true,
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+        }
+      },
+      "/EnumTypeEndpoint/echoListEnum" : {
+        "post" : {
+          "tags" : [
+            "EnumTypeEndpoint"
+          ],
+          "operationId" : "EnumTypeEndpoint_echoListEnum_POST",
+          "requestBody" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "enumList" : {
+                      "type" : "array",
+                      "nullable" : true,
+                      "items" : {
+                        "nullable" : true,
+                        "anyOf" : [
+                          {
+                            "$ref" : "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+                          }
+                        ]
+                      }
                     }
-                  ]
+                  }
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/EnumTypeEndpoint/echoListEnum": {
-      "post": {
-        "tags": ["EnumTypeEndpoint"],
-        "operationId": "EnumTypeEndpoint_echoListEnum_POST",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "enumList": {
-                    "type": "array",
-                    "nullable": true,
-                    "items": {
-                      "nullable": true,
-                      "anyOf": [
+          },
+          "responses" : {
+            "200" : {
+              "description" : "",
+              "content" : {
+                "application/json" : {
+                  "schema" : {
+                    "type" : "array",
+                    "nullable" : true,
+                    "items" : {
+                      "nullable" : true,
+                      "anyOf" : [
                         {
-                          "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+  
+                          "$ref" : "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
                         }
                       ]
                     }
@@ -85,20 +112,24 @@
               }
             }
           }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "nullable": true,
-                  "items": {
-                    "nullable": true,
-                    "anyOf": [
+        }
+      },
+      "/EnumTypeEndpoint/getEnum" : {
+        "post" : {
+          "tags" : [
+            "EnumTypeEndpoint"
+          ],
+          "operationId" : "EnumTypeEndpoint_getEnum_POST",
+          "responses" : {
+            "200" : {
+              "description" : "",
+              "content" : {
+                "application/json" : {
+                  "schema" : {
+                    "nullable" : true,
+                    "anyOf" : [
                       {
-                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+                        "$ref" : "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
                       }
                     ]
                   }
@@ -107,68 +138,53 @@
             }
           }
         }
-      }
-    },
-    "/EnumTypeEndpoint/getEnum": {
-      "post": {
-        "tags": ["EnumTypeEndpoint"],
-        "operationId": "EnumTypeEndpoint_getEnum_POST",
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "nullable": true,
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+      },
+      "/EnumTypeEndpoint/setEnum" : {
+        "post" : {
+          "tags" : [
+            "EnumTypeEndpoint"
+          ],
+          "operationId" : "EnumTypeEndpoint_setEnum_POST",
+          "requestBody" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "value" : {
+                      "nullable" : true,
+                      "anyOf" : [
+                        {
+                          "$ref" : "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
+            }
+          },
+          "responses" : {
+            "200" : {
+              "description" : ""
             }
           }
         }
       }
     },
-    "/EnumTypeEndpoint/setEnum": {
-      "post": {
-        "tags": ["EnumTypeEndpoint"],
-        "operationId": "EnumTypeEndpoint_setEnum_POST",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "value": {
-                    "nullable": true,
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
+    "components" : {
+      "schemas" : {
+        "dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity" : {
+          "type" : "string",
+          "enum" : [
+            "ENUM1",
+            "ENUM2",
+            "ENUM_2",
+            "HELLO_WORLD",
+            "_HELLO",
+            "MANY_MANY_WORDS"
+          ]
         }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "dev.hilla.parser.plugins.backbone.enumtype.EnumTypeEndpoint$EnumEntity": {
-        "type": "string",
-        "enum": ["ENUM1", "ENUM2", "ENUM_2", "HELLO_WORLD", "MANY_MANY_WORDS", "_HELLO"]
       }
     }
   }
-}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/jackson/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/jackson/openapi.json
@@ -51,6 +51,10 @@
           {
             "type": "object",
             "properties": {
+              "publicProp": {
+                "type": "string",
+                "nullable": true
+              },
               "privateProp": {
                 "type": "string",
                 "nullable": true
@@ -63,23 +67,19 @@
                 "type": "string",
                 "nullable": true
               },
-              "propertySetterOnly": {
-                "type": "string",
-                "nullable": true
-              },
               "propertyWithDifferentField": {
                 "type": "string",
                 "nullable": true
               },
-              "publicProp": {
-                "type": "string",
-                "nullable": true
-              },
-              "renamedPrivateProp0": {
+              "propertySetterOnly": {
                 "type": "string",
                 "nullable": true
               },
               "renamedPublicProp0": {
+                "type": "string",
+                "nullable": true
+              },
+              "renamedPrivateProp0": {
                 "type": "string",
                 "nullable": true
               }
@@ -90,11 +90,11 @@
       "dev.hilla.parser.plugins.backbone.jackson.JacksonEndpoint$SampleParent": {
         "type": "object",
         "properties": {
-          "privateParentProperty": {
+          "publicParentProperty": {
             "type": "string",
             "nullable": true
           },
-          "publicParentProperty": {
+          "privateParentProperty": {
             "type": "string",
             "nullable": true
           }

--- a/packages/java/parser-jvm-plugin-transfertypes/src/test/resources/dev/hilla/parser/plugins/transfertypes/pageable/bare/openapi.json
+++ b/packages/java/parser-jvm-plugin-transfertypes/src/test/resources/dev/hilla/parser/plugins/transfertypes/pageable/bare/openapi.json
@@ -71,6 +71,10 @@
               }
             ]
           },
+          "property": {
+            "type": "string",
+            "nullable": true
+          },
           "ignoreCase": {
             "type": "boolean"
           },
@@ -81,10 +85,6 @@
                 "$ref": "#/components/schemas/org.springframework.data.domain.Sort$NullHandling"
               }
             ]
-          },
-          "property": {
-            "type": "string",
-            "nullable": true
           }
         }
       },

--- a/packages/java/parser-jvm-plugin-transfertypes/src/test/resources/dev/hilla/parser/plugins/transfertypes/pageable/basic/openapi.json
+++ b/packages/java/parser-jvm-plugin-transfertypes/src/test/resources/dev/hilla/parser/plugins/transfertypes/pageable/basic/openapi.json
@@ -123,6 +123,10 @@
               }
             ]
           },
+          "property": {
+            "type": "string",
+            "nullable": true
+          },
           "ignoreCase": {
             "type": "boolean"
           },
@@ -133,10 +137,6 @@
                 "$ref": "#/components/schemas/org.springframework.data.domain.Sort$NullHandling"
               }
             ]
-          },
-          "property": {
-            "type": "string",
-            "nullable": true
           }
         }
       },


### PR DESCRIPTION
The natural order is... natural. This allows using the TS model to generate e.g. grid columns in the same order the properties are in the bean
