### PR TITLE
fix(form): gracefully handle validator throwing an error

### DIFF
--- a/packages/ts/form/src/Validation.ts
+++ b/packages/ts/form/src/Validation.ts
@@ -97,28 +97,33 @@ export async function runValidator<T>(
   if (!binderNode.required && !new Required().validate(value) && !(model instanceof NumberModel)) {
     return [];
   }
-  return (async () => validator.validate(value, binderNode.binder))().then((result) => {
-    if (result === false) {
-      return [{ message: interpolateMessage(validator.message), property: binderNode.name, validator, value }];
-    }
-    if (result === true || (Array.isArray(result) && result.length === 0)) {
-      return [];
-    }
-    if (Array.isArray(result)) {
-      return result.map((result2) => ({
-        message: interpolateMessage(validator.message),
-        ...setPropertyAbsolutePath(binderNode.name, result2),
-        validator,
-        value,
-      }));
-    }
-    return [
-      {
-        message: interpolateMessage(validator.message),
-        ...setPropertyAbsolutePath(binderNode.name, result as ValidationResult),
-        validator,
-        value,
-      },
-    ];
-  });
+  return (async () => validator.validate(value, binderNode.binder))()
+    .catch((error) => {
+      console.error(`${binderNode.name} - Validator ${validator.constructor.name} threw an error:`, error);
+      return true;
+    })
+    .then((result) => {
+      if (result === false) {
+        return [{ message: interpolateMessage(validator.message), property: binderNode.name, validator, value }];
+      }
+      if (result === true || (Array.isArray(result) && result.length === 0)) {
+        return [];
+      }
+      if (Array.isArray(result)) {
+        return result.map((result2) => ({
+          message: interpolateMessage(validator.message),
+          ...setPropertyAbsolutePath(binderNode.name, result2),
+          validator,
+          value,
+        }));
+      }
+      return [
+        {
+          message: interpolateMessage(validator.message),
+          ...setPropertyAbsolutePath(binderNode.name, result as ValidationResult),
+          validator,
+          value,
+        },
+      ];
+    });
 }

--- a/packages/ts/form/src/Validation.ts
+++ b/packages/ts/form/src/Validation.ts
@@ -100,7 +100,7 @@ export async function runValidator<T>(
   return (async () => validator.validate(value, binderNode.binder))()
     .catch((error) => {
       console.error(`${binderNode.name} - Validator ${validator.constructor.name} threw an error:`, error);
-      return true;
+      return [{ message: 'Validator threw an error', property: binderNode.name, validator, value }];
     })
     .then((result) => {
       if (result === false) {

--- a/packages/ts/form/test/Validation.test.ts
+++ b/packages/ts/form/test/Validation.test.ts
@@ -869,13 +869,16 @@ describe('@hilla/form', () => {
         expect(errors).to.have.lengthOf.at.least(1);
       });
 
-      it('should not report thrown exception as validation error', async () => {
+      it('should report thrown exception as validation error', async () => {
         let errors = await binder.validate();
-        const expectedErrors = errors.length;
+        const initialErrors = errors.length;
 
         binder.addValidator(new BrokenValidator());
         errors = await binder.validate();
-        expect(errors).to.have.lengthOf(expectedErrors);
+        expect(errors).to.have.lengthOf(initialErrors + 1);
+
+        const error = errors.find((e) => e.validator instanceof BrokenValidator);
+        expect(error?.message ?? '').to.include('Validator threw an error');
       });
 
       it('should log error if a validator unexpectedly throws an error', async () => {


### PR DESCRIPTION
## Description

Adds error handling to validator executions, so that binder validation and update can still complete in case a validator unexpectedly throw an error.

## Type of change

- Bugfix
