### PR TITLE
chore: use npm module version for generation script [skip ci]

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# use platform version  from the root pom.xml
-version=`mvn -N help:evaluate -Dexpression=project.version -q -DforceStdout | grep "^[0-9]"`
+# use hilla version from the root hilla npm modules package json
+# cannot use maven project.version here, as file generation happens before building maven
+version=`jq .version packages/ts/generator-typescript-core/package.json | cut -d '"' -f 2`
 # TODO: compute this number when we maintain multiple hilla branches
 branch=24.1
 


### PR DESCRIPTION
Json files generation happen before the version setting to maven modules, so using the `project.version` from root pom is not a ideal way here.  