### PR TITLE
fix!: use explicit `Response` type in Middleware

### DIFF
--- a/packages/ts/hilla-frontend/src/Authentication.ts
+++ b/packages/ts/hilla-frontend/src/Authentication.ts
@@ -184,7 +184,7 @@ export class InvalidSessionMiddleware implements MiddlewareClass {
   async invoke(context: MiddlewareContext, next: MiddlewareNext): Promise<Response> {
     const clonedContext = { ...context };
     clonedContext.request = context.request.clone();
-    const response = (await next(context)) as Response;
+    const response = await next(context);
     if (response.status === 401) {
       const loginResult = await this.onInvalidSessionCallback();
       if (loginResult.token) {

--- a/packages/ts/hilla-frontend/src/Connect.ts
+++ b/packages/ts/hilla-frontend/src/Connect.ts
@@ -138,7 +138,7 @@ export interface MiddlewareContext extends EndpointCallMetaInfo {
  * or makes the actual request.
  * @param context - The information about the call and request
  */
-export type MiddlewareNext = (context: MiddlewareContext) => MaybePromise<unknown>;
+export type MiddlewareNext = (context: MiddlewareContext) => MaybePromise<Response>;
 
 /**
  * An interface that allows defining a middleware as a class.
@@ -148,14 +148,14 @@ export interface MiddlewareClass {
    * @param context - The information about the call and request
    * @param next - Invokes the next in the call chain
    */
-  invoke(context: MiddlewareContext, next: MiddlewareNext): MaybePromise<unknown>;
+  invoke(context: MiddlewareContext, next: MiddlewareNext): MaybePromise<Response>;
 }
 
 /**
  * An async callback function that can intercept the request and response
  * of a call.
  */
-export type MiddlewareFunction = (context: MiddlewareContext, next: MiddlewareNext) => MaybePromise<unknown>;
+export type MiddlewareFunction = (context: MiddlewareContext, next: MiddlewareNext) => MaybePromise<Response>;
 
 /**
  * An async callback that can intercept the request and response
@@ -299,8 +299,8 @@ export class ConnectClient {
     // response handling should come last after the other middlewares are done
     // with processing the response. That is why this middleware is first
     // in the final middlewares array.
-    async function responseHandlerMiddleware(context: MiddlewareContext, next: MiddlewareNext): Promise<unknown> {
-      const response = (await next(context)) as Response;
+    async function responseHandlerMiddleware(context: MiddlewareContext, next: MiddlewareNext): Promise<Response> {
+      const response = await next(context);
       await assertResponseIsOk(response);
       const text = await response.text();
       return JSON.parse(text, (_, value: any) => (value === null ? undefined : value));

--- a/packages/ts/hilla-frontend/test/Connect.test.ts
+++ b/packages/ts/hilla-frontend/test/Connect.test.ts
@@ -478,19 +478,19 @@ describe('@hilla/frontend', () => {
 
       describe('middleware invocation', () => {
         it('should not invoke middleware before call', async () => {
-          const spyMiddleware = sinon.spy(async (context: MiddlewareContext, next?: MiddlewareNext) => next?.(context));
+          const spyMiddleware = sinon.spy(async (context: MiddlewareContext, next: MiddlewareNext) => next(context));
           client.middlewares = [spyMiddleware];
 
           expect(spyMiddleware).to.not.be.called;
         });
 
         it('should invoke middleware during call', async () => {
-          const spyMiddleware = sinon.spy(async (context: MiddlewareContext, next?: MiddlewareNext) => {
+          const spyMiddleware = sinon.spy(async (context: MiddlewareContext, next: MiddlewareNext) => {
             expect(context.endpoint).to.equal('FooEndpoint');
             expect(context.method).to.equal('fooMethod');
             expect(context.params).to.deep.equal({ fooParam: 'foo' });
             expect(context.request).to.be.instanceOf(Request);
-            return next?.(context);
+            return next(context);
           });
           client.middlewares = [spyMiddleware];
 
@@ -532,18 +532,18 @@ describe('@hilla/frontend', () => {
         });
 
         it('should invoke middlewares in order', async () => {
-          const firstMiddleware = sinon.spy(async (context: MiddlewareContext, next?: MiddlewareNext) => {
+          const firstMiddleware = sinon.spy(async (context: MiddlewareContext, next: MiddlewareNext) => {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             expect(secondMiddleware).to.not.be.called;
-            const response = await next?.(context);
+            const response = await next(context);
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             expect(secondMiddleware).to.be.calledOnce;
             return response;
           });
 
-          const secondMiddleware = sinon.spy(async (context: MiddlewareContext, next?: MiddlewareNext) => {
+          const secondMiddleware = sinon.spy(async (context: MiddlewareContext, next: MiddlewareNext) => {
             expect(firstMiddleware).to.be.calledOnce;
-            return next?.(context);
+            return next(context);
           });
 
           client.middlewares = [firstMiddleware, secondMiddleware];
@@ -563,15 +563,15 @@ describe('@hilla/frontend', () => {
           const myResponse = new Response('{}');
           const myContext = { endpoint: 'Bar', foo: 'bar', method: 'bar', request: myRequest };
 
-          const firstMiddleware = async (_: MiddlewareContext, next?: MiddlewareNext) => {
+          const firstMiddleware = async (_: MiddlewareContext, next: MiddlewareNext) => {
             // Pass modified context
-            const response = await next?.(myContext);
+            const response = await next(myContext);
             // Expect modified response
             expect(response).to.equal(myResponse);
             return response;
           };
 
-          const secondMiddleware = async (context: MiddlewareContext, _?: MiddlewareNext) => {
+          const secondMiddleware = async (context: MiddlewareContext, _: MiddlewareNext) => {
             // Expect modified context
             expect(context).to.equal(myContext);
             // Pass modified response


### PR DESCRIPTION
Fixes #1154.

There is a small API change since now the `Response` type is expected in middleware, but this shouldn't break any existing code since that's the only type that the middleware could deal with anyway.