### PR TITLE
fix(react-form): force initialize optional models when binding to field

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,13 +2,13 @@
   "extends": [
     "vaadin/typescript-requiring-type-checking",
     "vaadin/imports-typescript",
-    "vaadin/sort",
     "vaadin/testing",
     "vaadin/prettier"
   ],
   "ignorePatterns": ["packages/ts/*/test/**/*.snap.ts"],
   "plugins": ["tsdoc"],
   "rules": {
+    "@typescript-eslint/member-ordering": "off",
     "class-methods-use-this": "off",
     "import/no-duplicates": "off",
     "import/prefer-default-export": "off",

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -306,31 +306,6 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
     arrayNode.value = (arrayNode.value ?? []).filter((_, i) => i !== itemIndex);
   }
 
-  [_initializeValue](forceInitialize = false): void {
-    // First, make sure parents have value initialized
-    if (this.parent && (this.parent.value === undefined || (this.parent.defaultValue as T | undefined) === undefined)) {
-      this.parent[_initializeValue](true);
-    }
-
-    const key = this.model[_key];
-    let value: T | undefined = this.parent
-      ? (this.parent.value as { readonly [key in typeof key]: T })[this.model[_key]]
-      : undefined;
-
-    if (value === undefined) {
-      // Initialize value if this is the root level node, or it is enforced
-      if (forceInitialize || !this.parent) {
-        value = this.model.constructor.createEmptyValue() as T;
-        this.setValueState(value, this.defaultValue === undefined);
-      } else if (
-        this.parent.model instanceof ObjectModel &&
-        !(key in ((this.parent.value || {}) as { readonly [key in typeof key]?: T }))
-      ) {
-        this.setValueState(undefined, this.defaultValue === undefined);
-      }
-    }
-  }
-
   protected clearValidation(): boolean {
     if (this[_visited]) {
       this[_visited] = false;
@@ -437,6 +412,31 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
       ],
       [],
     );
+  }
+
+  [_initializeValue](forceInitialize = false): void {
+    // First, make sure parents have value initialized
+    if (this.parent && (this.parent.value === undefined || (this.parent.defaultValue as T | undefined) === undefined)) {
+      this.parent[_initializeValue](true);
+    }
+
+    const key = this.model[_key];
+    let value: T | undefined = this.parent
+      ? (this.parent.value as { readonly [key in typeof key]: T })[this.model[_key]]
+      : undefined;
+
+    if (value === undefined) {
+      // Initialize value if this is the root level node, or it is enforced
+      if (forceInitialize || !this.parent) {
+        value = this.model.constructor.createEmptyValue() as T;
+        this.setValueState(value, this.defaultValue === undefined);
+      } else if (
+        this.parent.model instanceof ObjectModel &&
+        !(key in ((this.parent.value || {}) as { readonly [key in typeof key]?: T }))
+      ) {
+        this.setValueState(undefined, this.defaultValue === undefined);
+      }
+    }
   }
 
   private requestValidationWithAncestors(): ReadonlyArray<Promise<ReadonlyArray<ValueError<any>>>> {

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -414,6 +414,10 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
     );
   }
 
+  private requestValidationWithAncestors(): ReadonlyArray<Promise<ReadonlyArray<ValueError<any>>>> {
+    return [...this.runOwnValidators(), ...(this.parent ? this.parent.requestValidationWithAncestors() : [])];
+  }
+
   [_initializeValue](forceInitialize = false): void {
     // First, make sure parents have value initialized
     if (this.parent && (this.parent.value === undefined || (this.parent.defaultValue as T | undefined) === undefined)) {
@@ -437,10 +441,6 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
         this.setValueState(undefined, this.defaultValue === undefined);
       }
     }
-  }
-
-  private requestValidationWithAncestors(): ReadonlyArray<Promise<ReadonlyArray<ValueError<any>>>> {
-    return [...this.runOwnValidators(), ...(this.parent ? this.parent.requestValidationWithAncestors() : [])];
   }
 
   private setValueState(value: T | undefined, keepPristine = false): void {

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -34,7 +34,6 @@ import { _validity } from './Validity.js';
 
 const _ownErrors = Symbol('ownErrorsSymbol');
 const _visited = Symbol('visited');
-export const _initializeValue = Symbol('initializeValue');
 
 function getErrorPropertyName(valueError: ValueError<any>): string {
   return typeof valueError.property === 'string' ? valueError.property : getBinderNode(valueError.property).name;
@@ -92,7 +91,7 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
     this.model = model;
     model[_binderNode] = this;
     this.validityStateValidator = new ValidityStateValidator<T>();
-    this[_initializeValue]();
+    this.initializeValue();
     this[_validators] = model[_validators];
   }
 
@@ -131,7 +130,7 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
    */
   get value(): T | undefined {
     if (this.parent!.value === undefined) {
-      this.parent![_initializeValue](true);
+      this.parent!.initializeValue(true);
     }
     const key = this.model[_key];
     return (this.parent!.value as { readonly [key in typeof key]: T })[key];
@@ -418,10 +417,10 @@ export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
     return [...this.runOwnValidators(), ...(this.parent ? this.parent.requestValidationWithAncestors() : [])];
   }
 
-  [_initializeValue](forceInitialize = false): void {
+  initializeValue(forceInitialize = false): void {
     // First, make sure parents have value initialized
     if (this.parent && (this.parent.value === undefined || (this.parent.defaultValue as T | undefined) === undefined)) {
-      this.parent[_initializeValue](true);
+      this.parent.initializeValue(true);
     }
 
     const key = this.model[_key];

--- a/packages/ts/react-form/src/index.ts
+++ b/packages/ts/react-form/src/index.ts
@@ -16,6 +16,7 @@ import {
   type FieldStrategy,
 } from '@hilla/form';
 import type { BinderNode } from '@hilla/form/BinderNode.js';
+import { _initializeValue } from '@hilla/form/BinderNode.js';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 
 function useUpdate() {
@@ -113,6 +114,7 @@ function useFields<T, M extends AbstractModel<T>>(node: BinderNode<T, M>): Field
 
     return ((model: AbstractModel<any>) => {
       const n = getBinderNode(model);
+      n[_initializeValue](true);
 
       const fieldState: FieldState<unknown> = registry.get(model) ?? {
         element: undefined,

--- a/packages/ts/react-form/src/index.ts
+++ b/packages/ts/react-form/src/index.ts
@@ -16,7 +16,6 @@ import {
   type FieldStrategy,
 } from '@hilla/form';
 import type { BinderNode } from '@hilla/form/BinderNode.js';
-import { _initializeValue } from '@hilla/form/BinderNode.js';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 
 function useUpdate() {
@@ -114,7 +113,7 @@ function useFields<T, M extends AbstractModel<T>>(node: BinderNode<T, M>): Field
 
     return ((model: AbstractModel<any>) => {
       const n = getBinderNode(model);
-      n[_initializeValue](true);
+      n.initializeValue(true);
 
       const fieldState: FieldState<unknown> = registry.get(model) ?? {
         element: undefined,

--- a/packages/ts/react-form/test/models.ts
+++ b/packages/ts/react-form/test/models.ts
@@ -16,6 +16,7 @@ export interface User {
   id: number;
   name: string;
   password: string;
+  passwordHint?: string;
 }
 
 export class UserModel<T extends User = User> extends ObjectModel<T> {
@@ -31,6 +32,10 @@ export class UserModel<T extends User = User> extends ObjectModel<T> {
 
   get password(): StringModel {
     return this[_getPropertyModel]('password', StringModel, [false, new Required(), new Size({ min: 6 })]);
+  }
+
+  get passwordHint(): StringModel {
+    return this[_getPropertyModel]('passwordHint', StringModel, [true /* should be optional */]);
   }
 }
 

--- a/packages/ts/react-form/test/useForm.spec.tsx
+++ b/packages/ts/react-form/test/useForm.spec.tsx
@@ -1,10 +1,10 @@
 import { expect, use } from '@esm-bundle/chai';
-import { act, render } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { useForm as _useForm, useFormPart } from '../src/index.js';
-import { type Login, LoginModel, type User, type UserModel } from './models.js';
+import { type Login, LoginModel, UserModel } from './models.js';
 
 use(sinonChai);
 
@@ -204,6 +204,20 @@ describe('@hilla/react-form', () => {
         await user.keyboard('a');
 
         expect(onChange).to.have.been.calledOnce;
+      });
+    });
+
+    describe('model initialization', () => {
+      it('should initialize optional string model when it is bound to a field', () => {
+        const { rerender, result } = renderHook(() => useForm(UserModel));
+
+        expect(result.current.value.passwordHint).to.be.undefined;
+
+        // Call field directive to simulate binding the model to a field
+        result.current.field(result.current.model.passwordHint);
+        rerender();
+
+        expect(result.current.value.passwordHint).to.equal('');
       });
     });
   });


### PR DESCRIPTION
## Description

Currently optional models have a value of `undefined` when being bound to a field. This can cause validators such as `Size` to fail, as they expect a string value. 
This change enforces initialization of models as soon as they are bound to a field, so that a `StringModel` for example gets a value of an empty string as soon as it is bound to a field.

Fixes https://github.com/vaadin/hilla/issues/1197

## Type of change

- Bugfix