### PR TITLE
fix(parser-jvm-plugin-backbone): Properly expand generic types

### DIFF
--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointExposedPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/EndpointExposedPlugin.java
@@ -11,6 +11,7 @@ import dev.hilla.parser.core.NodePath;
 import dev.hilla.parser.models.AnnotationInfoModel;
 import dev.hilla.parser.models.ClassInfoModel;
 import dev.hilla.parser.models.ClassRefSignatureModel;
+import dev.hilla.parser.models.MethodInfoModel;
 import dev.hilla.parser.models.SignatureModel;
 import dev.hilla.parser.models.TypeArgumentModel;
 import dev.hilla.parser.models.TypeParameterModel;
@@ -19,6 +20,7 @@ import dev.hilla.parser.plugins.backbone.nodes.EndpointExposedNode;
 import dev.hilla.parser.plugins.backbone.nodes.EndpointNode;
 import dev.hilla.parser.plugins.backbone.nodes.EndpointNonExposedNode;
 import dev.hilla.parser.plugins.backbone.nodes.EndpointSignatureNode;
+import dev.hilla.parser.plugins.backbone.nodes.MethodNode;
 import dev.hilla.parser.plugins.backbone.nodes.TypeSignatureNode;
 
 public final class EndpointExposedPlugin
@@ -35,6 +37,10 @@ public final class EndpointExposedPlugin
     @Override
     public Node<?, ?> resolve(@Nonnull Node<?, ?> node,
             @Nonnull NodePath<?> parentPath) {
+        if (node instanceof MethodNode
+                && parentPath.getNode() instanceof EndpointExposedNode) {
+            return MethodNode.of(((MethodNode) node).getSource());
+        }
         if (!(node instanceof TypeSignatureNode)) {
             return node;
         }

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/MethodPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/MethodPlugin.java
@@ -38,6 +38,9 @@ public final class MethodPlugin
 
         var endpointNode = (EndpointNode) endpointParent.get();
 
+        if (methodNode.getTarget().getPost() != null) {
+            throw new IllegalStateException("Post for method "+methodNode+" in endpoint "+endpointNode+" is already set");
+        }
         methodNode.getTarget().post(createOperation(endpointNode, methodNode));
     }
 

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/MethodPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/MethodPlugin.java
@@ -39,7 +39,8 @@ public final class MethodPlugin
         var endpointNode = (EndpointNode) endpointParent.get();
 
         if (methodNode.getTarget().getPost() != null) {
-            throw new IllegalStateException("Post for method "+methodNode+" in endpoint "+endpointNode+" is already set");
+            throw new IllegalStateException("Post for method " + methodNode
+                    + " in endpoint " + endpointNode + " is already set");
         }
         methodNode.getTarget().post(createOperation(endpointNode, methodNode));
     }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/Endpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/Endpoint.java
@@ -1,0 +1,11 @@
+package dev.hilla.parser.plugins.backbone.genericsuperclassmethods;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Endpoint {
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/EndpointExposed.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/EndpointExposed.java
@@ -1,0 +1,11 @@
+package dev.hilla.parser.plugins.backbone.genericsuperclassmethods;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EndpointExposed {
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClass.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClass.java
@@ -1,0 +1,10 @@
+package dev.hilla.parser.plugins.backbone.genericsuperclassmethods;
+
+@EndpointExposed
+public class GenericSuperClass<T> {
+
+    public T genericMethod(T param) {
+        return null;
+    }
+
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClassLong.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClassLong.java
@@ -1,0 +1,6 @@
+package dev.hilla.parser.plugins.backbone.genericsuperclassmethods;
+
+@Endpoint
+public class GenericSuperClassLong extends GenericSuperClass<Long> {
+
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClassMethodsTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClassMethodsTest.java
@@ -1,0 +1,26 @@
+package dev.hilla.parser.plugins.backbone.genericsuperclassmethods;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+import dev.hilla.parser.core.Parser;
+import dev.hilla.parser.plugins.backbone.BackbonePlugin;
+import dev.hilla.parser.plugins.backbone.test.helpers.TestHelper;
+import org.junit.jupiter.api.Test;
+
+public class GenericSuperClassMethodsTest {
+    private final TestHelper helper = new TestHelper(getClass());
+
+    @Test
+    public void should_CorrectlyHandleSuperClassMethods()
+            throws IOException, URISyntaxException {
+        var openAPI = new Parser().classLoader(getClass().getClassLoader())
+                .classPath(Set.of(helper.getTargetDir().toString()))
+                .endpointAnnotation(Endpoint.class.getName())
+                .endpointExposedAnnotation(EndpointExposed.class.getName())
+                .addPlugin(new BackbonePlugin()).execute();
+
+        helper.executeParserWithConfig(openAPI);
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClassString.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/GenericSuperClassString.java
@@ -1,0 +1,6 @@
+package dev.hilla.parser.plugins.backbone.genericsuperclassmethods;
+
+@Endpoint
+public class GenericSuperClassString extends GenericSuperClass<String> {
+
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/genericsuperclassmethods/openapi.json
@@ -1,0 +1,100 @@
+{
+    "openapi" : "3.0.1",
+    "info" : {
+      "title" : "Hilla Application",
+      "version" : "1.0.0"
+    },
+    "servers" : [
+      {
+        "url" : "http://localhost:8080/connect",
+        "description" : "Hilla Backend"
+      }
+    ],
+    "tags" : [
+      {
+        "name" : "GenericSuperClassLong",
+        "x-class-name" : "dev.hilla.parser.plugins.backbone.genericsuperclassmethods.GenericSuperClassLong"
+      },
+      {
+        "name" : "GenericSuperClassString",
+        "x-class-name" : "dev.hilla.parser.plugins.backbone.genericsuperclassmethods.GenericSuperClassString"
+      }
+    ],
+    "paths" : {
+      "/GenericSuperClassLong/genericMethod" : {
+        "post" : {
+          "tags" : [
+  
+            "GenericSuperClassLong"
+          ],
+          "operationId" : "GenericSuperClassLong_genericMethod_POST",
+          "requestBody" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "param" : {
+                      "type" : "integer",
+                      "format" : "int64",
+                      "nullable" : true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "responses" : {
+            "200" : {
+              "description" : "",
+              "content" : {
+                "application/json" : {
+                  "schema" : {
+                    "type" : "integer",
+                    "format" : "int64",
+                    "nullable" : true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/GenericSuperClassString/genericMethod" : {
+        "post" : {
+          "tags" : [
+            "GenericSuperClassString"
+          ],
+          "operationId" : "GenericSuperClassString_genericMethod_POST",
+          "requestBody" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object",
+                  "properties" : {
+                    "param" : {
+                      "type" : "string",
+                      "nullable" : true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "responses" : {
+            "200" : {
+              "description" : "",
+              "content" : {
+                "application/json" : {
+                  "schema" : {
+                    "type" : "string",
+                    "nullable" : true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
When a method is defined in the super class, the definition needs to be duplicated for each implementing class so that generics can be set separately for each instance

Fixes #1214
