### PR TITLE
fix(parser-jvm-core): Filter synthetic methods

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -217,6 +217,7 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     @Override
     protected List<MethodInfoModel> prepareMethods() {
         return Arrays.stream(origin.getDeclaredMethods())
+                .filter(method -> !method.isSynthetic())
                 .map(MethodInfoModel::of).sorted(MethodInfoModel.METHOD_ORDER)
                 .collect(Collectors.toList());
     }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/generics/ConcreteType.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/generics/ConcreteType.java
@@ -1,0 +1,4 @@
+package dev.hilla.parser.plugins.backbone.generics;
+
+public class ConcreteType {
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/generics/GenericInterface.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/generics/GenericInterface.java
@@ -1,0 +1,7 @@
+package dev.hilla.parser.plugins.backbone.generics;
+
+public interface GenericInterface<T> {
+    T dealWithGenericType(T object);
+
+    T dealWithItAgain(T object);
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/generics/ImplementInterfaceEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/dev/hilla/parser/plugins/backbone/generics/ImplementInterfaceEndpoint.java
@@ -1,0 +1,22 @@
+package dev.hilla.parser.plugins.backbone.generics;
+
+import java.lang.reflect.Modifier;
+
+@Endpoint
+public class ImplementInterfaceEndpoint
+        implements GenericInterface<ConcreteType> {
+
+    @Override
+    public ConcreteType dealWithGenericType(ConcreteType object) {
+        return object;
+    }
+
+    @Override
+    public ConcreteType dealWithItAgain(ConcreteType object) {
+        return object;
+    }
+
+    public ConcreteType dealWithConcreteType(ConcreteType object) {
+        return object;
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/generics/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/dev/hilla/parser/plugins/backbone/generics/openapi.json
@@ -26,6 +26,10 @@
     {
       "name": "GenericsRefEndpoint",
       "x-class-name": "dev.hilla.parser.plugins.backbone.generics.GenericsRefEndpoint"
+    },
+    {
+      "name": "ImplementInterfaceEndpoint",
+      "x-class-name": "dev.hilla.parser.plugins.backbone.generics.ImplementInterfaceEndpoint"
     }
   ],
   "paths": {
@@ -300,6 +304,132 @@
           }
         }
       }
+    },
+    "/ImplementInterfaceEndpoint/dealWithConcreteType": {
+      "post": {
+        "tags": ["ImplementInterfaceEndpoint"],
+        "operationId": "ImplementInterfaceEndpoint_dealWithConcreteType_POST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "object": {
+                    "nullable": true,
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.generics.ConcreteType"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.generics.ConcreteType"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ImplementInterfaceEndpoint/dealWithGenericType": {
+      "post": {
+        "tags": ["ImplementInterfaceEndpoint"],
+        "operationId": "ImplementInterfaceEndpoint_dealWithGenericType_POST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "object": {
+                    "nullable": true,
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.generics.ConcreteType"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.generics.ConcreteType"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ImplementInterfaceEndpoint/dealWithItAgain": {
+      "post": {
+        "tags": ["ImplementInterfaceEndpoint"],
+        "operationId": "ImplementInterfaceEndpoint_dealWithItAgain_POST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "object": {
+                    "nullable": true,
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.generics.ConcreteType"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/dev.hilla.parser.plugins.backbone.generics.ConcreteType"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -324,6 +454,9 @@
             ]
           }
         }
+      },
+      "dev.hilla.parser.plugins.backbone.generics.ConcreteType" : {
+        "type": "object"
       }
     }
   }


### PR DESCRIPTION
When implementing a generic interface, compliant methods are generated as synthetic ones.

This PR filters them out, otherwise those methods are randomly picked as choices when parsing.

Fixes #1210