### PR TITLE
refactor(parser-jvm): move synthetic method filtering to BackbonePlugin

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/models/ClassInfoReflectionModel.java
@@ -217,7 +217,6 @@ final class ClassInfoReflectionModel extends ClassInfoModel
     @Override
     protected List<MethodInfoModel> prepareMethods() {
         return Arrays.stream(origin.getDeclaredMethods())
-                .filter(method -> !method.isSynthetic())
                 .map(MethodInfoModel::of).sorted(MethodInfoModel.METHOD_ORDER)
                 .collect(Collectors.toList());
     }

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/MethodPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/dev/hilla/parser/plugins/backbone/MethodPlugin.java
@@ -77,6 +77,7 @@ public final class MethodPlugin
             var endpointCls = (ClassInfoModel) node.getSource();
             var methodNodes = endpointCls.getMethods().stream()
                     .filter(MethodInfoModel::isPublic)
+                    .filter(method -> !method.isSynthetic())
                     .<Node<?, ?>> map(MethodNode::of);
             return nodeDependencies.appendChildNodes(methodNodes);
         }


### PR DESCRIPTION
This PR is a small fix for #1217.

I moved filtering of synthetics methods from the model to `BackbonePlugin` because the design idea of the model is to provide the fullest info about the reflection item. Filtering synthetic methods breaks this idea, so I believe that the best place for this filtering is in the `BackbonePlugin`.