### PR TITLE
chore: Fix build

### DIFF
--- a/packages/java/hilla-react/pom.xml
+++ b/packages/java/hilla-react/pom.xml
@@ -126,6 +126,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>

--- a/packages/java/hilla-react/pom.xml
+++ b/packages/java/hilla-react/pom.xml
@@ -125,25 +125,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <tasks>
-                                <replace token= "{{version}}" value="${project.parent.version}" dir="target/classes">
-                                    <include name="vaadin-core-versions.json"/>
-                                </replace>
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>
                     <execution>

--- a/packages/java/hilla/pom.xml
+++ b/packages/java/hilla/pom.xml
@@ -120,6 +120,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>

--- a/packages/java/hilla/pom.xml
+++ b/packages/java/hilla/pom.xml
@@ -119,25 +119,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <tasks>
-                                <replace token= "{{version}}" value="${project.parent.version}" dir="target/classes">
-                                    <include name="vaadin-core-versions.json"/>
-                                </replace>
-                            </tasks>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
If a newer antrun plugin is available, the build fails with "You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site"

<!-- PLEASE READ AND FOLLO