### PR TITLE
feat: Allow clearing the form by reading undefined or null

### DIFF
--- a/packages/ts/form/src/BinderRoot.ts
+++ b/packages/ts/form/src/BinderRoot.ts
@@ -129,12 +129,15 @@ export class BinderRoot<T, M extends AbstractModel<T>> extends BinderNode<T, M> 
   }
 
   /**
-   * Read the given value into the form and clear validation errors
+   * Read the given value into the form and clear validation errors. Clears the form if the value is undefined.
    *
-   * @param value - Sets the argument as the new default
-   * value before resetting, otherwise the previous default is used.
+   * @param value - The value to read, or undefined to clear.
    */
-  read(value: T): void {
+  read(value: T | undefined): void {
+    if (value === undefined) {
+      this.clear();
+      return;
+    }
     this.defaultValue = value;
     if (
       // Skip when no value is set yet (e.g., invoked from constructor)

--- a/packages/ts/form/src/BinderRoot.ts
+++ b/packages/ts/form/src/BinderRoot.ts
@@ -133,8 +133,8 @@ export class BinderRoot<T, M extends AbstractModel<T>> extends BinderNode<T, M> 
    *
    * @param value - The value to read, or undefined to clear.
    */
-  read(value: T | undefined): void {
-    if (value === undefined) {
+  read(value: T | undefined | null): void {
+    if (value === undefined || value === null) {
       this.clear();
       return;
     }

--- a/packages/ts/form/src/BinderRoot.ts
+++ b/packages/ts/form/src/BinderRoot.ts
@@ -133,7 +133,7 @@ export class BinderRoot<T, M extends AbstractModel<T>> extends BinderNode<T, M> 
    *
    * @param value - The value to read, or undefined to clear.
    */
-  read(value: T | undefined | null): void {
+  read(value: T | null | undefined): void {
     if (value === undefined || value === null) {
       this.clear();
       return;

--- a/packages/ts/form/test/Binder.test.ts
+++ b/packages/ts/form/test/Binder.test.ts
@@ -191,6 +191,25 @@ describe('@hilla/form', () => {
         assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
         expect(requestUpdateStub).to.be.calledOnce;
       });
+      it('should clear value when setting an undefined value', () => {
+        binder.read({
+          ...expectedEmptyOrder,
+          notes: 'bar',
+          customer: {
+            ...expectedEmptyOrder.customer,
+            fullName: 'bar',
+          },
+        });
+        requestUpdateStub.reset();
+        assert.notDeepEqual(binder.value, expectedEmptyOrder);
+        assert.notDeepEqual(binder.defaultValue, expectedEmptyOrder);
+
+        binder.read(undefined);
+
+        assert.deepEqual(binder.value, expectedEmptyOrder);
+        assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
+        expect(requestUpdateStub).to.be.calledOnce;
+      });
 
       it('should update when clearing validation', async () => {
         binder.clear();

--- a/packages/ts/form/test/Binder.test.ts
+++ b/packages/ts/form/test/Binder.test.ts
@@ -210,6 +210,25 @@ describe('@hilla/form', () => {
         assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
         expect(requestUpdateStub).to.be.calledOnce;
       });
+      it('should clear value when setting a null value', () => {
+        binder.read({
+          ...expectedEmptyOrder,
+          notes: 'bar',
+          customer: {
+            ...expectedEmptyOrder.customer,
+            fullName: 'bar',
+          },
+        });
+        requestUpdateStub.reset();
+        assert.notDeepEqual(binder.value, expectedEmptyOrder);
+        assert.notDeepEqual(binder.defaultValue, expectedEmptyOrder);
+
+        binder.read(null);
+
+        assert.deepEqual(binder.value, expectedEmptyOrder);
+        assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
+        expect(requestUpdateStub).to.be.calledOnce;
+      });
 
       it('should update when clearing validation', async () => {
         binder.clear();

--- a/packages/ts/form/test/Binder.test.ts
+++ b/packages/ts/form/test/Binder.test.ts
@@ -82,6 +82,26 @@ describe('@hilla/form', () => {
         total: undefined,
       };
 
+      function testClear(doClear: () => void) {
+        binder.read({
+          ...expectedEmptyOrder,
+          notes: 'bar',
+          customer: {
+            ...expectedEmptyOrder.customer,
+            fullName: 'bar',
+          },
+        });
+        requestUpdateStub.reset();
+        assert.notDeepEqual(binder.value, expectedEmptyOrder);
+        assert.notDeepEqual(binder.defaultValue, expectedEmptyOrder);
+
+        doClear();
+
+        assert.deepEqual(binder.value, expectedEmptyOrder);
+        assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
+        expect(requestUpdateStub).to.be.calledOnce;
+      }
+
       beforeEach(() => {
         binder = new Binder(litOrderView, OrderModel);
         requestUpdateStub.reset();
@@ -173,61 +193,13 @@ describe('@hilla/form', () => {
       });
 
       it('should clear value and default value', () => {
-        binder.read({
-          ...expectedEmptyOrder,
-          notes: 'bar',
-          customer: {
-            ...expectedEmptyOrder.customer,
-            fullName: 'bar',
-          },
-        });
-        requestUpdateStub.reset();
-        assert.notDeepEqual(binder.value, expectedEmptyOrder);
-        assert.notDeepEqual(binder.defaultValue, expectedEmptyOrder);
-
-        binder.clear();
-
-        assert.deepEqual(binder.value, expectedEmptyOrder);
-        assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
-        expect(requestUpdateStub).to.be.calledOnce;
+        testClear(() => binder.clear());
       });
       it('should clear value when setting an undefined value', () => {
-        binder.read({
-          ...expectedEmptyOrder,
-          notes: 'bar',
-          customer: {
-            ...expectedEmptyOrder.customer,
-            fullName: 'bar',
-          },
-        });
-        requestUpdateStub.reset();
-        assert.notDeepEqual(binder.value, expectedEmptyOrder);
-        assert.notDeepEqual(binder.defaultValue, expectedEmptyOrder);
-
-        binder.read(undefined);
-
-        assert.deepEqual(binder.value, expectedEmptyOrder);
-        assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
-        expect(requestUpdateStub).to.be.calledOnce;
+        testClear(() => binder.read(undefined));
       });
       it('should clear value when setting a null value', () => {
-        binder.read({
-          ...expectedEmptyOrder,
-          notes: 'bar',
-          customer: {
-            ...expectedEmptyOrder.customer,
-            fullName: 'bar',
-          },
-        });
-        requestUpdateStub.reset();
-        assert.notDeepEqual(binder.value, expectedEmptyOrder);
-        assert.notDeepEqual(binder.defaultValue, expectedEmptyOrder);
-
-        binder.read(null);
-
-        assert.deepEqual(binder.value, expectedEmptyOrder);
-        assert.deepEqual(binder.defaultValue, expectedEmptyOrder);
-        expect(requestUpdateStub).to.be.calledOnce;
+        testClear(() => binder.read(null));
       });
 
       it('should update when clearing validation', async () => {

--- a/packages/ts/react-form/src/index.ts
+++ b/packages/ts/react-form/src/index.ts
@@ -60,7 +60,7 @@ export type UseFormResult<T, M extends AbstractModel<T>> = Readonly<{
   submit(): Promise<T | undefined>;
   reset(): void;
   clear(): void;
-  read(value: T | undefined): void;
+  read(value: T | undefined | null): void;
 }> &
   UseFormPartResult<T, M>;
 

--- a/packages/ts/react-form/src/index.ts
+++ b/packages/ts/react-form/src/index.ts
@@ -60,7 +60,7 @@ export type UseFormResult<T, M extends AbstractModel<T>> = Readonly<{
   submit(): Promise<T | undefined>;
   reset(): void;
   clear(): void;
-  read(value: T): void;
+  read(value: T | undefined): void;
 }> &
   UseFormPartResult<T, M>;
 


### PR DESCRIPTION
This is convenient as you can "bind" to a selection in grid - either a value or undefined if unselected