### PR TITLE
feat: add react-routing helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1137,6 +1137,10 @@
       "resolved": "packages/ts/react-form",
       "link": true
     },
+    "node_modules/@hilla/react-routing": {
+      "resolved": "packages/ts/react-routing",
+      "link": true
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -2591,6 +2595,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.8.0.tgz",
+      "integrity": "sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@sigstore/bundle": {
@@ -15398,7 +15411,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -15413,6 +15425,38 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/react-router": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.15.0.tgz",
+      "integrity": "sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==",
+      "peer": true,
+      "dependencies": {
+        "@remix-run/router": "1.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.15.0.tgz",
+      "integrity": "sha512-aR42t0fs7brintwBGAv2+mGlCtgtFQeOzK0BM1/OiqEzRejOZtpMZepvgkscpMUnKb8YO84G7s3LsHnnDNonbQ==",
+      "peer": true,
+      "dependencies": {
+        "@remix-run/router": "1.8.0",
+        "react-router": "6.15.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/read": {
       "version": "2.1.0",
@@ -16158,7 +16202,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19071,6 +19114,32 @@
       },
       "peerDependencies": {
         "react": "^18"
+      }
+    },
+    "packages/ts/react-routing": {
+      "version": "2.2.0-beta1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/react": "^18.2.20"
+      },
+      "devDependencies": {
+        "@esm-bundle/chai": "^4.3.4-fix.0",
+        "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.4.3",
+        "@types/chai": "^4.3.5",
+        "@types/chai-dom": "^1.11.0",
+        "@types/mocha": "^10.0.1",
+        "@types/sinon": "^10.0.16",
+        "@types/sinon-chai": "^3.2.9",
+        "@types/validator": "^13.11.1",
+        "chai-dom": "^1.11.0",
+        "sinon": "^15.2.0",
+        "sinon-chai": "^3.7.0",
+        "typescript": "^5.1.6"
+      },
+      "peerDependencies": {
+        "react": "^18",
+        "react-router-dom": "^6"
       }
     }
   }

--- a/packages/java/hilla-react/src/main/java/dev/hilla/HillaReactRouting.java
+++ b/packages/java/hilla-react/src/main/java/dev/hilla/HillaReactRouting.java
@@ -1,0 +1,10 @@
+package dev.hilla;
+
+import com.vaadin.flow.component.dependency.NpmPackage;
+
+/**
+ * Empty class that adds <code>@hilla/react-routing</code> npm package dependency.
+ */
+@NpmPackage(value = "@hilla/react-routing", version = "2.2.0-beta1")
+public class HillaReactRouting {
+}

--- a/packages/ts/react-routing/.eslintrc
+++ b/packages/ts/react-routing/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  }
+}

--- a/packages/ts/react-routing/.lintstagedrc.js
+++ b/packages/ts/react-routing/.lintstagedrc.js
@@ -1,0 +1,9 @@
+import { commands } from '../../../.lintstagedrc.js';
+
+// TODO: Remove when project is updated to the new eslint rules.
+const [, prettier] = commands;
+
+export default {
+  'src/**/*.{js,ts}': prettier,
+  'test/**/*.{js,ts}': prettier,
+};

--- a/packages/ts/react-routing/LICENSE
+++ b/packages/ts/react-routing/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ts/react-routing/README.md
+++ b/packages/ts/react-routing/README.md
@@ -1,0 +1,22 @@
+# Hilla React Routing
+
+A set of utilities for integrating react-router-dom in Hilla applications.
+
+A part of the Hilla project.
+
+## Installation
+
+```bash
+$ npm install @hilla/react-routing
+```
+
+## Contribution
+
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing-docs/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+
+## License
+
+Apache License 2.0
+
+Vaadin collects development time usage statistics to improve this product.
+For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistics.

--- a/packages/ts/react-routing/package.json
+++ b/packages/ts/react-routing/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@hilla/react-routing",
+  "version": "2.2.0-beta1",
+  "description": "Hilla routing utils for React",
+  "main": "index.js",
+  "module": "index.js",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vaadin/hilla.git",
+    "directory": "packages/ts/react-routing"
+  },
+  "keywords": [
+    "Hilla",
+    "Routing",
+    "React"
+  ],
+  "scripts": {
+    "build": "tsc --isolatedModules -p tsconfig.build.json",
+    "lint": "echo \"Skipping\"",
+    "test": "karma start ../../../karma.config.cjs --port 9877",
+    "test:coverage": "echo \"Skipping\"",
+    "test:watch": "npm run test -- --watch",
+    "typecheck": "tsc --noEmit",
+    "version": "node ../../../scripts/bump/package-update.js"
+  },
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  },
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/vaadin/hilla/issues"
+  },
+  "homepage": "https://hilla.dev",
+  "files": [
+    "*.{d.ts.map,d.ts,js.map,js}"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@types/react": "^18.2.20"
+  },
+  "peerDependencies": {
+    "react": "^18",
+    "react-router-dom": "^6"
+  },
+  "devDependencies": {
+    "@esm-bundle/chai": "^4.3.4-fix.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/chai": "^4.3.5",
+    "@types/chai-dom": "^1.11.0",
+    "@types/mocha": "^10.0.1",
+    "@types/sinon": "^10.0.16",
+    "@types/sinon-chai": "^3.2.9",
+    "@types/validator": "^13.11.1",
+    "chai-dom": "^1.11.0",
+    "sinon": "^15.2.0",
+    "sinon-chai": "^3.7.0",
+    "typescript": "^5.1.6"
+  }
+}

--- a/packages/ts/react-routing/src/index.tsx
+++ b/packages/ts/react-routing/src/index.tsx
@@ -10,21 +10,23 @@ export type AccessProps = Readonly<{
   rolesAllowed?: readonly string[];
 }>;
 
-export type ViewMeta = Readonly<{ handle?: AccessProps & MenuProps }>;
+export type RouteMetadata = AccessProps & MenuProps;
+
+type HandleWithMetadata = { handle?: RouteMetadata };
 
 type Override<T, E> = E & Omit<T, keyof E>;
 
-export type IndexHillaRouteObject = Override<IndexRouteObject, ViewMeta>;
-export type NonIndexHillaRouteObject = Override<
-  Override<NonIndexRouteObject, ViewMeta>,
+export type IndexRouteObjectWithMetadata = Override<IndexRouteObject, HandleWithMetadata>;
+export type NonIndexRouteObjectWithMetadata = Override<
+  Override<NonIndexRouteObject, HandleWithMetadata>,
   {
-    children?: HillaRouteObject[];
+    children?: RouteObjectWithMetadata[];
   }
 >;
-export type HillaRouteObject = IndexHillaRouteObject | NonIndexHillaRouteObject;
+export type RouteObjectWithMetadata = IndexRouteObjectWithMetadata | NonIndexRouteObjectWithMetadata;
 
-type RouteMatch = ReturnType<typeof useMatches> extends Array<infer T> ? T : never;
-
-export type HillaRouteMatch = Readonly<Override<RouteMatch, ViewMeta>>;
-
-export const useHillaMatches = useMatches as () => readonly HillaRouteMatch[];
+export function useRouteMetadata(): RouteMetadata | undefined {
+  const matches = useMatches();
+  const match = [...matches].reverse().find((m) => m.handle);
+  return match?.handle as RouteMetadata | undefined;
+}

--- a/packages/ts/react-routing/src/index.tsx
+++ b/packages/ts/react-routing/src/index.tsx
@@ -1,0 +1,30 @@
+import { type IndexRouteObject, type NonIndexRouteObject, useMatches } from 'react-router-dom';
+
+export type MenuProps = Readonly<{
+  icon?: string;
+  title?: string;
+}>;
+
+export type AccessProps = Readonly<{
+  requireAuthentication?: boolean;
+  rolesAllowed?: readonly string[];
+}>;
+
+export type ViewMeta = Readonly<{ handle?: AccessProps & MenuProps }>;
+
+type Override<T, E> = E & Omit<T, keyof E>;
+
+export type IndexHillaRouteObject = Override<IndexRouteObject, ViewMeta>;
+export type NonIndexHillaRouteObject = Override<
+  Override<NonIndexRouteObject, ViewMeta>,
+  {
+    children?: HillaRouteObject[];
+  }
+>;
+export type HillaRouteObject = IndexHillaRouteObject | NonIndexHillaRouteObject;
+
+type RouteMatch = ReturnType<typeof useMatches> extends Array<infer T> ? T : never;
+
+export type HillaRouteMatch = Readonly<Override<RouteMatch, ViewMeta>>;
+
+export const useHillaMatches = useMatches as () => readonly HillaRouteMatch[];

--- a/packages/ts/react-routing/test/useRouteMetadata.spec.tsx
+++ b/packages/ts/react-routing/test/useRouteMetadata.spec.tsx
@@ -1,0 +1,94 @@
+import { expect } from '@esm-bundle/chai';
+import { render } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { type RouteObjectWithMetadata, useRouteMetadata, type RouteMetadata } from '../src';
+
+let metadata: RouteMetadata | undefined;
+
+const CaptureMetadata = () => {
+  metadata = useRouteMetadata();
+  return <div />;
+};
+
+const mainMetadata = {
+  title: 'Main route',
+  icon: 'main',
+  requireAuthentication: true,
+  rolesAllowed: ['ROLE_MAIN'],
+};
+const nestedMetadata = {
+  title: 'Nested route',
+  icon: 'nested',
+  requireAuthentication: true,
+  rolesAllowed: ['ROLE_NESTED'],
+};
+
+const routes: RouteObjectWithMetadata[] = [
+  {
+    path: '/main',
+    element: <CaptureMetadata />,
+    handle: mainMetadata,
+    children: [
+      {
+        path: '/main/with-meta',
+        element: <CaptureMetadata />,
+        handle: nestedMetadata,
+      },
+      {
+        path: '/main/without-meta',
+        element: <CaptureMetadata />,
+      },
+    ],
+  },
+  {
+    path: '/without-meta',
+    element: <CaptureMetadata />,
+  },
+];
+
+describe('@hilla/react-routing', () => {
+  describe('useRouteMetadata', () => {
+    it('should return route metadata', () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ['/main'],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      expect(metadata).to.exist;
+      expect(metadata).to.deep.equal(mainMetadata);
+    });
+
+    it('should return undefined if route has no metadata', () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ['/without-meta'],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      expect(metadata).to.be.undefined;
+    });
+
+    it('should return metadata from nested route', () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ['/main/with-meta'],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      expect(metadata).to.exist;
+      expect(metadata).to.deep.equal(nestedMetadata);
+    });
+
+    it('should return parent metadata if nested route has no metadata', () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ['/main/without-meta'],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      expect(metadata).to.exist;
+      expect(metadata).to.deep.equal(mainMetadata);
+    });
+  });
+});

--- a/packages/ts/react-routing/tsconfig.build.json
+++ b/packages/ts/react-routing/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "."
+  },
+  "include": ["src"]
+}

--- a/packages/ts/react-routing/tsconfig.json
+++ b/packages/ts/react-routing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "experimentalDecorators": true,
+    "target": "es2022"
+  },
+  "include": ["src", "test"],
+  "exclude": ["test/**/*.snap.ts"]
+}


### PR DESCRIPTION
## Description

Extracts routing types and hooks from the starter into a new `@hilla/react-routing` package. The main features are:
- A `RouteObjectWithMetadata` type that extends the `react-router-dom` route type with metadata for menu icon and title, as well as for whether the route requires authentication and which roles are allowed to access the route. Specifically the type overrides the `handle` property, which should be used for custom application-specific data, with metadata currently used by the starter.
- A `useRouteMetadata` hook that returns the metadata for the current route. The hook will return the metadata for the current route if it has metadata, or the nearest parent route that has metadata. Otherwise returns `undefined`.

Changes compared to the starter:
- This duplicates the `AccessProps` type as there currently is none in the Hilla codebase that could be imported. Not a blocker IMO and can be cleaned up when auth-related helpers are extracted.
- The role type has been changed to use a `string`, whereas the starter uses an application-specific `Role` enum.

## Type of change

- Feature
