### PR TITLE
chore: Run validation on 2.2 instead of 2.0

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,7 +6,7 @@ defaults:
 
 on:
   push:
-    branches: [ main, '2.1', '2.0', '1.3' ]
+    branches: [ main, '2.2', '2.1', '1.3' ]
     paths-ignore:
       - 'hilla-logo.svg'
       - 'README.md'


### PR DESCRIPTION
2.0 is end of life
