### PR TITLE
chore: ignore same files as eslint when prettifying

### DIFF
--- a/packages/ts/react-grid/.prettierignore
+++ b/packages/ts/react-grid/.prettierignore
@@ -1,0 +1,2 @@
+src/types/**
+test/grid-test-utils.js


### PR DESCRIPTION
Git commit hook prettifies files that are ignored by ESLint in `react-grid`. Let's create a similar config for Prettier.