### PR TITLE
fix: Use "*" also for generator-typescript-plugin-model form dependency

### DIFF
--- a/packages/ts/generator-typescript-plugin-model/package.json
+++ b/packages/ts/generator-typescript-plugin-model/package.json
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@hilla/form": "^2.2.0-beta1",
+    "@hilla/form": "*",
     "@hilla/generator-typescript-core": "^2.2.0-beta1",
     "@hilla/generator-typescript-plugin-backbone": "^2.2.0-beta1"
   },


### PR DESCRIPTION
Without this you get a lot of warnings when updating the project version with "npm version"
