### PR TITLE
fix: hotswap should not get enabled when liveReloadBackend is null

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapServiceInitializer.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/internal/hotswap/HotSwapServiceInitializer.java
@@ -47,8 +47,9 @@ class HotSwapServiceInitializer implements VaadinServiceInitListener {
         VaadinService vaadinService = serviceInitEvent.getSource();
         BrowserLiveReloadAccessor.getLiveReloadFromService(vaadinService)
                 .ifPresent(browserLiveReload -> {
-                    if (BrowserLiveReload.Backend.SPRING_BOOT_DEVTOOLS != browserLiveReload
-                            .getBackend()
+                    if (browserLiveReload.getBackend() != null
+                            && BrowserLiveReload.Backend.SPRING_BOOT_DEVTOOLS != browserLiveReload
+                                    .getBackend()
                             && isDevModeLiveReloadEnabled(vaadinService)) {
                         if (isEndpointHotReloadEnabled()) {
                             endpointHotSwapService.monitorChanges(

--- a/packages/java/endpoint/src/test/java/dev/hilla/internal/hotswap/HotSwapServiceInitializerTest.java
+++ b/packages/java/endpoint/src/test/java/dev/hilla/internal/hotswap/HotSwapServiceInitializerTest.java
@@ -134,15 +134,34 @@ public class HotSwapServiceInitializerTest {
     }
 
     @Test
-    public void liveReloadBackendIsNull_monitorChangesFromHotSwapServiceDoesNotGetCalled() {
+    public void liveReloadIsNull_monitorChangesFromHotSwapServiceDoesNotGetCalled() {
         try (var browserLiveReloadAccessorMockedStatic = Mockito
                 .mockStatic(BrowserLiveReloadAccessor.class)) {
             browserLiveReloadAccessorMockedStatic
                     .when(() -> BrowserLiveReloadAccessor
                             .getLiveReloadFromService(vaadinService))
                     .thenReturn(Optional.empty());
-            Mockito.when(mockedBrowserLiveReload.getBackend())
-                    .thenReturn(BrowserLiveReload.Backend.HOTSWAP_AGENT);
+
+            Mockito.when(deploymentConfiguration.isDevModeLiveReloadEnabled())
+                    .thenReturn(Boolean.TRUE);
+
+            hotSwapServiceInitializer.serviceInit(serviceInitEvent);
+
+            Mockito.verify(spyEndpointHotSwapService, Mockito.never())
+                    .monitorChanges(Mockito.any(), Mockito.any());
+        }
+    }
+
+    @Test
+    public void liveReloadBackendIsNull_monitorChangesFromHotSwapServiceDoesNotGetCalled() {
+        try (var browserLiveReloadAccessorMockedStatic = Mockito
+                .mockStatic(BrowserLiveReloadAccessor.class)) {
+            browserLiveReloadAccessorMockedStatic
+                    .when(() -> BrowserLiveReloadAccessor
+                            .getLiveReloadFromService(vaadinService))
+                    .thenReturn(Optional.of(mockedBrowserLiveReload));
+
+            Mockito.when(mockedBrowserLiveReload.getBackend()).thenReturn(null);
             Mockito.when(deploymentConfiguration.isDevModeLiveReloadEnabled())
                     .thenReturn(Boolean.TRUE);
 


### PR DESCRIPTION
## Description
If the liveReload is not null, but none
of the backends (SpringBootDevTools,
JRebel, or HotSwapAgent) was not
configured, the endpoint hotswap service
should not be enabled.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
