### PR TITLE
fix: add ApplicationContextProvider in springboot AutoConfiguration imports

### DIFF
--- a/packages/java/endpoint/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/packages/java/endpoint/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,5 @@
 dev.hilla.EndpointController
 dev.hilla.push.PushConfigurer
+dev.hilla.ApplicationContextProvider
 dev.hilla.internal.hotswap.HotSwapConfiguration
 dev.hilla.crud.CrudConfiguration


### PR DESCRIPTION
## Description

In order for the dev.hilla.ApplicationContextProvider to be loaded and initialized in Hilla applications from classpath, it should be listed in the imports of springboot auto-configurations. Otherwise, depending classes such as EndpointCodeGenerator will not function properly.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
