### PR TITLE
chore: disable esbuild minification to avoid broken source maps

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,7 +19,6 @@ await build({
   },
   entryPoints: srcFiles.map((file) => new URL(file, root)).map(fileURLToPath),
   format: 'esm',
-  minify: true,
   outdir: fileURLToPath(root),
   packages: 'external',
   sourcemap: 'linked',


### PR DESCRIPTION
Trying to use packages minified by `esbuild` I found that source maps are broken. If the minification is disabled, everything works as expected. The problem is somewhere inside Vite remapping: it incorrectly remaps existing source maps during the build preparation.