### PR TITLE
feat: add java type to parser

### DIFF
--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -154,7 +154,8 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
         } else if (signature instanceof ClassRefSignatureModel classRefSignatureModel) {
             typeName = classRefSignatureModel.getName();
         } else if (signature instanceof ArraySignatureModel arraySignatureModel) {
-            AnnotatedArrayType o = (AnnotatedArrayType) arraySignatureModel.get();
+            AnnotatedArrayType o = (AnnotatedArrayType) arraySignatureModel
+                    .get();
             typeName = o.toString();
         }
 

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -1,5 +1,6 @@
 package dev.hilla.parser.plugins.model;
 
+import java.lang.reflect.AnnotatedArrayType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -16,6 +17,7 @@ import dev.hilla.parser.core.PluginConfiguration;
 import dev.hilla.parser.models.AnnotatedModel;
 import dev.hilla.parser.models.AnnotationInfoModel;
 import dev.hilla.parser.models.AnnotationParameterModel;
+import dev.hilla.parser.models.ArraySignatureModel;
 import dev.hilla.parser.models.BaseSignatureModel;
 import dev.hilla.parser.models.ClassRefSignatureModel;
 import dev.hilla.parser.models.SignatureModel;
@@ -93,6 +95,7 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
 
         var schema = typedNode.getTarget();
         addConstraintsToSchema(typedNode, schema);
+        addJavaTypeToSchema(typedNode, schema);
 
         // Add annotations from parent property model to schema
         if (nodePath.getParentPath() != null && nodePath.getParentPath()
@@ -100,14 +103,6 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
             var propertyModel = propertyNode.getSource();
             addAnnotationsToSchema(propertyModel, schema);
         }
-        if (signature instanceof BaseSignatureModel) {
-            schema.addExtension(JAVA_TYPE_KEY,
-                    ((BaseSignatureModel) signature).getType().getName());
-        } else if (signature instanceof ClassRefSignatureModel) {
-            schema.addExtension(JAVA_TYPE_KEY,
-                    ((ClassRefSignatureModel) signature).getName());
-        }
-        addConstraintsToSchema((AnnotatedNode) typedNode, schema);
     }
 
     @Override
@@ -148,5 +143,50 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
         if (!annotations.isEmpty()) {
             schema.addExtension(ANNOTATIONS_KEY, annotations);
         }
+    }
+
+    private void addJavaTypeToSchema(TypedNode typedNode, Schema<?> schema) {
+        var signature = (SignatureModel) typedNode.getType();
+        String typeName = null;
+
+        if (signature instanceof BaseSignatureModel baseSignatureModel) {
+            typeName = baseSignatureModel.getType().getName();
+        } else if (signature instanceof ClassRefSignatureModel classRefSignatureModel) {
+            typeName = classRefSignatureModel.getName();
+        } else if (signature instanceof ArraySignatureModel arraySignatureModel) {
+            AnnotatedArrayType o = (AnnotatedArrayType) arraySignatureModel.get();
+            typeName = o.toString();
+        }
+
+        if (includeJavaType(typeName)) {
+            schema.addExtension(JAVA_TYPE_KEY, typeName);
+        }
+    }
+
+    private boolean includeJavaType(String typeName) {
+        if (typeName == null) {
+            return false;
+        }
+
+        // Handle array types just the same
+        if (typeName.endsWith("[]")) {
+            typeName = typeName.substring(0, typeName.length() - 2);
+        }
+
+        // Include all primitive types
+        if (typeName.equals("boolean") || typeName.equals("byte")
+                || typeName.equals("char") || typeName.equals("double")
+                || typeName.equals("float") || typeName.equals("int")
+                || typeName.equals("long") || typeName.equals("short")) {
+            return true;
+        }
+
+        // Include all types from java package
+        if (typeName.startsWith("java.")) {
+            return true;
+        }
+
+        // Otherwise don't include
+        return false;
     }
 }

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -16,6 +16,8 @@ import dev.hilla.parser.core.PluginConfiguration;
 import dev.hilla.parser.models.AnnotatedModel;
 import dev.hilla.parser.models.AnnotationInfoModel;
 import dev.hilla.parser.models.AnnotationParameterModel;
+import dev.hilla.parser.models.BaseSignatureModel;
+import dev.hilla.parser.models.ClassRefSignatureModel;
 import dev.hilla.parser.models.SignatureModel;
 import dev.hilla.parser.plugins.backbone.BackbonePlugin;
 import dev.hilla.parser.plugins.backbone.nodes.AnnotatedNode;
@@ -27,6 +29,7 @@ import io.swagger.v3.oas.models.media.Schema;
 public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
     private static final String VALIDATION_CONSTRAINTS_KEY = "x-validation-constraints";
     private static final String ANNOTATIONS_KEY = "x-annotations";
+    private static final String JAVA_TYPE_KEY = "x-java-type";
     private static final String VALIDATION_CONSTRAINTS_PACKAGE_NAME = "jakarta.validation.constraints";
 
     // Include-list of annotations that should be added to the schema
@@ -97,6 +100,12 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
             var propertyModel = propertyNode.getSource();
             addAnnotationsToSchema(propertyModel, schema);
         }
+        if (signature instanceof BaseSignatureModel) {
+            schema.addExtension(JAVA_TYPE_KEY, ((BaseSignatureModel) signature).getType().getName());
+        } else if (signature instanceof ClassRefSignatureModel) {
+            schema.addExtension(JAVA_TYPE_KEY, ((ClassRefSignatureModel) signature).getName());
+        }
+        addConstraintsToSchema((AnnotatedNode) typedNode, schema);
     }
 
     @Override

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -101,9 +101,11 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
             addAnnotationsToSchema(propertyModel, schema);
         }
         if (signature instanceof BaseSignatureModel) {
-            schema.addExtension(JAVA_TYPE_KEY, ((BaseSignatureModel) signature).getType().getName());
+            schema.addExtension(JAVA_TYPE_KEY,
+                    ((BaseSignatureModel) signature).getType().getName());
         } else if (signature instanceof ClassRefSignatureModel) {
-            schema.addExtension(JAVA_TYPE_KEY, ((ClassRefSignatureModel) signature).getName());
+            schema.addExtension(JAVA_TYPE_KEY,
+                    ((ClassRefSignatureModel) signature).getName());
         }
         addConstraintsToSchema((AnnotatedNode) typedNode, schema);
     }

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/javatypes/JavaTypeEndpoint.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/javatypes/JavaTypeEndpoint.java
@@ -1,0 +1,58 @@
+package dev.hilla.parser.plugins.model.javatypes;
+
+import dev.hilla.parser.plugins.model.Endpoint;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Version;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.List;
+
+@Endpoint
+public class JavaTypeEndpoint {
+    public JavaTypeTestEntity getTestEntity() {
+        return new JavaTypeTestEntity();
+    }
+
+    public static class CustomEntity {
+        public String value;
+    }
+
+    public static class JavaTypeTestEntity {
+        public boolean aBoolean;
+        public Boolean aNullableBoolean;
+        public byte aByte;
+        public Byte aNullableByte;
+        public char aChar;
+        public Character aNullableChar;
+        public double aDouble;
+        public Double aNullableDouble;
+        public float aFloat;
+        public Float aNullableFloat;
+        public int aInt;
+        public Integer aNullableInt;
+        public long aLong;
+        public Long aNullableLong;
+        public short aShort;
+        public Short aNullableShort;
+
+        public String aString;
+        public Date aDate;
+        public LocalDate aLocalDate;
+        public LocalTime aLocalTime;
+        public LocalDateTime aLocalDateTime;
+
+        public String[] aStringArray;
+        public byte[] aByteArray;
+
+        public List<String> aStringList;
+
+        public CustomEntity aCustomEntity;
+    }
+}

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/javatypes/JavaTypeTest.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/javatypes/JavaTypeTest.java
@@ -1,0 +1,32 @@
+package dev.hilla.parser.plugins.model.javatypes;
+
+import dev.hilla.parser.core.Parser;
+import dev.hilla.parser.model.test.helpers.TestHelper;
+import dev.hilla.parser.plugins.backbone.BackbonePlugin;
+import dev.hilla.parser.plugins.model.Endpoint;
+import dev.hilla.parser.plugins.model.EndpointExposed;
+import dev.hilla.parser.plugins.model.ModelPlugin;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+public class JavaTypeTest {
+    private final TestHelper helper = new TestHelper(getClass());
+
+    @Test
+    public void should_GenerateAnnotations()
+            throws IOException, URISyntaxException {
+        var openAPI = new Parser().classLoader(getClass().getClassLoader())
+                .exposedPackages(
+                        Set.of("dev.hilla.parser.plugins.model.javatypes"))
+                .classPath(Set.of(helper.getTargetDir().toString()))
+                .endpointAnnotation(Endpoint.class.getName())
+                .endpointExposedAnnotation(EndpointExposed.class.getName())
+                .addPlugin(new BackbonePlugin()).addPlugin(new ModelPlugin())
+                .execute();
+
+        helper.executeParserWithConfig(openAPI);
+    }
+}

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
@@ -52,6 +52,7 @@
             "type" : "integer",
             "format" : "int64",
             "nullable" : true,
+            "x-java-type" : "java.lang.Long",
             "x-annotations" : [
               {
                 "name" : "jakarta.persistence.Id"
@@ -61,6 +62,7 @@
           "version" : {
             "type" : "integer",
             "format" : "int32",
+            "x-java-type" : "int",
             "x-annotations" : [
               {
                 "name" : "jakarta.persistence.Version"
@@ -69,7 +71,8 @@
           },
           "name" : {
             "type" : "string",
-            "nullable" : true
+            "nullable" : true,
+            "x-java-type" : "java.lang.String"
           }
         }
       }

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/javatypes/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/javatypes/openapi.json
@@ -1,0 +1,216 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Hilla Application",
+    "version" : "1.0.0"
+  },
+  "servers" : [
+    {
+      "url" : "http://localhost:8080/connect",
+      "description" : "Hilla Backend"
+    }
+  ],
+  "tags" : [
+    {
+      "name" : "JavaTypeEndpoint",
+      "x-class-name" : "dev.hilla.parser.plugins.model.javatypes.JavaTypeEndpoint"
+    }
+  ],
+  "paths" : {
+    "/JavaTypeEndpoint/getTestEntity" : {
+      "post" : {
+        "tags" : [
+          "JavaTypeEndpoint"
+        ],
+        "operationId" : "JavaTypeEndpoint_getTestEntity_POST",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "nullable" : true,
+                  "anyOf" : [
+                    {
+                      "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.javatypes.JavaTypeEndpoint$JavaTypeTestEntity"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "dev.hilla.parser.plugins.model.javatypes.JavaTypeEndpoint$JavaTypeTestEntity" : {
+        "type" : "object",
+        "properties" : {
+          "aBoolean" : {
+            "type" : "boolean",
+            "x-java-type" : "boolean"
+          },
+          "aNullableBoolean" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Boolean"
+          },
+          "aByte" : {
+            "type" : "integer",
+            "format" : "int32",
+            "x-java-type" : "byte"
+          },
+          "aNullableByte" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Byte"
+          },
+          "aChar" : {
+            "type" : "string",
+            "x-java-type" : "char"
+          },
+          "aNullableChar" : {
+            "type" : "string",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Character"
+          },
+          "aDouble" : {
+            "type" : "number",
+            "format" : "double",
+            "x-java-type" : "double"
+          },
+          "aNullableDouble" : {
+            "type" : "number",
+            "format" : "double",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Double"
+          },
+          "aFloat" : {
+            "type" : "number",
+            "format" : "float",
+            "x-java-type" : "float"
+          },
+          "aNullableFloat" : {
+            "type" : "number",
+            "format" : "float",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Float"
+          },
+          "aInt" : {
+            "type" : "integer",
+            "format" : "int32",
+            "x-java-type" : "int"
+          },
+          "aNullableInt" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Integer"
+          },
+          "aLong" : {
+            "type" : "integer",
+            "format" : "int64",
+            "x-java-type" : "long"
+          },
+          "aNullableLong" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Long"
+          },
+          "aShort" : {
+            "type" : "integer",
+            "format" : "int32",
+            "x-java-type" : "short"
+          },
+          "aNullableShort" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true,
+            "x-java-type" : "java.lang.Short"
+          },
+          "aString" : {
+            "type" : "string",
+            "nullable" : true,
+            "x-java-type" : "java.lang.String"
+          },
+          "aDate" : {
+            "type" : "string",
+            "format" : "date",
+            "nullable" : true,
+            "x-java-type" : "java.util.Date"
+          },
+          "aLocalDate" : {
+            "type" : "string",
+            "format" : "date",
+            "nullable" : true,
+            "x-java-type" : "java.time.LocalDate"
+          },
+          "aLocalTime" : {
+            "type" : "string",
+            "format" : "date-time",
+            "nullable" : true,
+            "x-java-type" : "java.time.LocalTime"
+          },
+          "aLocalDateTime" : {
+            "type" : "string",
+            "format" : "date-time",
+            "nullable" : true,
+            "x-java-type" : "java.time.LocalDateTime"
+          },
+          "aStringArray" : {
+            "type" : "array",
+            "nullable" : true,
+            "items" : {
+              "type" : "string",
+              "nullable" : true,
+              "x-java-type" : "java.lang.String"
+            },
+            "x-java-type" : "java.lang.String[]"
+          },
+          "aByteArray" : {
+            "type" : "array",
+            "nullable" : true,
+            "items" : {
+              "type" : "integer",
+              "format" : "int32",
+              "x-java-type" : "byte"
+            },
+            "x-java-type" : "byte[]"
+          },
+          "aStringList" : {
+            "type" : "array",
+            "nullable" : true,
+            "items" : {
+              "type" : "string",
+              "nullable" : true,
+              "x-java-type" : "java.lang.String"
+            },
+            "x-java-type" : "java.util.List"
+          },
+          "aCustomEntity" : {
+            "nullable" : true,
+            "anyOf" : [
+              {
+                "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.javatypes.JavaTypeEndpoint$CustomEntity"
+              }
+            ]
+          }
+        }
+      },
+      "dev.hilla.parser.plugins.model.javatypes.JavaTypeEndpoint$CustomEntity" : {
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "type" : "string",
+            "nullable" : true,
+            "x-java-type" : "java.lang.String"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/validation/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/validation/openapi.json
@@ -32,8 +32,7 @@
                     {
                       "$ref": "#/components/schemas/dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData"
                     }
-                  ],
-                  "x-java-type": "dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData"
+                  ]
                 }
               }
             }
@@ -50,27 +49,26 @@
           "assertFalse": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "AssertFalse"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "assertTrue": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "AssertTrue"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "decimalMax": {
             "type": "number",
             "format": "double",
-            "x-java-type": "double",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -79,12 +77,12 @@
                 },
                 "simpleName": "DecimalMax"
               }
-            ]
+            ],
+            "x-java-type": "double"
           },
           "decimalMin": {
             "type": "number",
             "format": "double",
-            "x-java-type": "double",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -92,12 +90,12 @@
                 },
                 "simpleName": "DecimalMin"
               }
-            ]
+            ],
+            "x-java-type": "double"
           },
           "digits": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -106,12 +104,12 @@
                 },
                 "simpleName": "Digits"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "email": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -119,28 +117,29 @@
                 },
                 "simpleName": "Email"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "future": {
             "type": "string",
             "format": "date",
             "nullable": true,
-            "x-java-type": "java.time.LocalDate",
             "x-validation-constraints": [
               {
                 "simpleName": "Future"
               }
-            ]
+            ],
+            "x-java-type": "java.time.LocalDate"
           },
           "isNull": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "Null"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "list": {
             "type": "array",
@@ -150,18 +149,17 @@
               "nullable": true,
               "x-java-type": "java.lang.String"
             },
-            "x-java-type": "java.util.List",
             "x-validation-constraints": [
               {
                 "simpleName": "NotEmpty"
               }
-            ]
+            ],
+            "x-java-type": "java.util.List"
           },
           "max": {
             "type": "integer",
             "format": "int32",
             "nullable": true,
-            "x-java-type": "java.lang.Integer",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -169,13 +167,13 @@
                 },
                 "simpleName": "Max"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.Integer"
           },
           "min": {
             "type": "integer",
             "format": "int32",
             "nullable": true,
-            "x-java-type": "java.lang.Integer",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -184,42 +182,42 @@
                 },
                 "simpleName": "Min"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.Integer"
           },
           "negative": {
             "type": "integer",
             "format": "int32",
-            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "Negative"
               }
-            ]
+            ],
+            "x-java-type": "int"
           },
           "negativeOrZero": {
             "type": "integer",
             "format": "int32",
-            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "NegativeOrZero"
               }
-            ]
+            ],
+            "x-java-type": "int"
           },
           "notBlank": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotBlank"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "notEmpty": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -227,17 +225,18 @@
               {
                 "simpleName": "NotEmpty"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "notNull": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "notNullEntity": {
             "nullable": true,
@@ -246,7 +245,6 @@
                 "$ref": "#/components/schemas/dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData"
               }
             ],
-            "x-java-type": "dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -257,17 +255,16 @@
             "type": "string",
             "format": "date",
             "nullable": true,
-            "x-java-type": "java.time.LocalDate",
             "x-validation-constraints": [
               {
                 "simpleName": "Past"
               }
-            ]
+            ],
+            "x-java-type": "java.time.LocalDate"
           },
           "pattern": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -275,42 +272,42 @@
                 },
                 "simpleName": "Pattern"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "positive": {
             "type": "integer",
             "format": "int32",
-            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "Positive"
               }
-            ]
+            ],
+            "x-java-type": "int"
           },
           "positiveOrZero": {
             "type": "integer",
             "format": "int32",
-            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "PositiveOrZero"
               }
-            ]
+            ],
+            "x-java-type": "int"
           },
           "size": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "Size"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "size1": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -318,12 +315,12 @@
                 },
                 "simpleName": "Size"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "withConstraintsOnSetter": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -334,22 +331,22 @@
               {
                 "simpleName": "Email"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "withGetter": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotBlank"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           },
           "withSetter": {
             "type": "string",
             "nullable": true,
-            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "Email"
@@ -357,7 +354,8 @@
               {
                 "simpleName": "NotBlank"
               }
-            ]
+            ],
+            "x-java-type": "java.lang.String"
           }
         }
       }

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/validation/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/validation/openapi.json
@@ -32,7 +32,8 @@
                     {
                       "$ref": "#/components/schemas/dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData"
                     }
-                  ]
+                  ],
+                  "x-java-type": "dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData"
                 }
               }
             }
@@ -49,6 +50,7 @@
           "assertFalse": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "AssertFalse"
@@ -58,6 +60,7 @@
           "assertTrue": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "AssertTrue"
@@ -67,6 +70,7 @@
           "decimalMax": {
             "type": "number",
             "format": "double",
+            "x-java-type": "double",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -80,6 +84,7 @@
           "decimalMin": {
             "type": "number",
             "format": "double",
+            "x-java-type": "double",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -92,6 +97,7 @@
           "digits": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -105,6 +111,7 @@
           "email": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -118,6 +125,7 @@
             "type": "string",
             "format": "date",
             "nullable": true,
+            "x-java-type": "java.time.LocalDate",
             "x-validation-constraints": [
               {
                 "simpleName": "Future"
@@ -127,6 +135,7 @@
           "isNull": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "Null"
@@ -138,8 +147,10 @@
             "nullable": true,
             "items": {
               "type": "string",
-              "nullable": true
+              "nullable": true,
+              "x-java-type": "java.lang.String"
             },
+            "x-java-type": "java.util.List",
             "x-validation-constraints": [
               {
                 "simpleName": "NotEmpty"
@@ -150,6 +161,7 @@
             "type": "integer",
             "format": "int32",
             "nullable": true,
+            "x-java-type": "java.lang.Integer",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -163,6 +175,7 @@
             "type": "integer",
             "format": "int32",
             "nullable": true,
+            "x-java-type": "java.lang.Integer",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -176,6 +189,7 @@
           "negative": {
             "type": "integer",
             "format": "int32",
+            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "Negative"
@@ -185,6 +199,7 @@
           "negativeOrZero": {
             "type": "integer",
             "format": "int32",
+            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "NegativeOrZero"
@@ -194,6 +209,7 @@
           "notBlank": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotBlank"
@@ -203,6 +219,7 @@
           "notEmpty": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -215,6 +232,7 @@
           "notNull": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -228,6 +246,7 @@
                 "$ref": "#/components/schemas/dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData"
               }
             ],
+            "x-java-type": "dev.hilla.parser.plugins.model.validation.ValidationEndpoint$ValidationData",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -238,6 +257,7 @@
             "type": "string",
             "format": "date",
             "nullable": true,
+            "x-java-type": "java.time.LocalDate",
             "x-validation-constraints": [
               {
                 "simpleName": "Past"
@@ -247,6 +267,7 @@
           "pattern": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -259,6 +280,7 @@
           "positive": {
             "type": "integer",
             "format": "int32",
+            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "Positive"
@@ -268,6 +290,7 @@
           "positiveOrZero": {
             "type": "integer",
             "format": "int32",
+            "x-java-type": "int",
             "x-validation-constraints": [
               {
                 "simpleName": "PositiveOrZero"
@@ -277,6 +300,7 @@
           "size": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "Size"
@@ -286,6 +310,7 @@
           "size1": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "attributes": {
@@ -298,6 +323,7 @@
           "withConstraintsOnSetter": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotNull"
@@ -313,6 +339,7 @@
           "withGetter": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "NotBlank"
@@ -322,6 +349,7 @@
           "withSetter": {
             "type": "string",
             "nullable": true,
+            "x-java-type": "java.lang.String",
             "x-validation-constraints": [
               {
                 "simpleName": "Email"


### PR DESCRIPTION
## Description

Adds the fully qualified Java type name to the generated `openapi.json`. This is part of getting the Java type information into the generated models in order to use them for CRUD features like choosing a proper column renderer or form field type.

Part of https://github.com/vaadin/hilla/issues/1271