### PR TITLE
feat: add annotations to schema

### DIFF
--- a/packages/java/parser-jvm-plugin-model/pom.xml
+++ b/packages/java/parser-jvm-plugin-model/pom.xml
@@ -59,5 +59,10 @@
       <artifactId>jakarta.validation-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/Annotation.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/Annotation.java
@@ -1,0 +1,23 @@
+package dev.hilla.parser.plugins.model;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+public final class Annotation {
+    private final Map<String, Object> attributes;
+    private final String name;
+
+    public Annotation(@Nonnull String name, Map<String, Object> attributes) {
+        this.name = name;
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Nonnull
+    public String getName() {
+        return name;
+    }
+}

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -2,6 +2,7 @@ package dev.hilla.parser.plugins.model;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -12,24 +13,31 @@ import dev.hilla.parser.core.NodeDependencies;
 import dev.hilla.parser.core.NodePath;
 import dev.hilla.parser.core.Plugin;
 import dev.hilla.parser.core.PluginConfiguration;
+import dev.hilla.parser.models.AnnotatedModel;
 import dev.hilla.parser.models.AnnotationInfoModel;
 import dev.hilla.parser.models.AnnotationParameterModel;
 import dev.hilla.parser.models.SignatureModel;
 import dev.hilla.parser.plugins.backbone.BackbonePlugin;
 import dev.hilla.parser.plugins.backbone.nodes.AnnotatedNode;
+import dev.hilla.parser.plugins.backbone.nodes.PropertyNode;
 import dev.hilla.parser.plugins.backbone.nodes.TypedNode;
 
 import io.swagger.v3.oas.models.media.Schema;
 
 public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
     private static final String VALIDATION_CONSTRAINTS_KEY = "x-validation-constraints";
+    private static final String ANNOTATIONS_KEY = "x-annotations";
     private static final String VALIDATION_CONSTRAINTS_PACKAGE_NAME = "jakarta.validation.constraints";
+
+    // Include-list of annotations that should be added to the schema
+    private static final Set<String> INCLUDED_ANNOTATIONS = Set
+            .of("jakarta.persistence.Id", "jakarta.persistence.Version");
 
     public ModelPlugin() {
         super();
     }
 
-    private static ValidationConstraint convertAnnotation(
+    private static ValidationConstraint convertValidationConstraintAnnotation(
             AnnotationInfoModel annotation) {
         var simpleName = extractSimpleName(annotation.getName());
 
@@ -39,6 +47,17 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
                         AnnotationParameterModel::getValue));
 
         return new ValidationConstraint(simpleName,
+                !attributes.isEmpty() ? attributes : null);
+    }
+
+    private static Annotation convertAnnotation(
+            AnnotationInfoModel annotation) {
+        var attributes = annotation.getParameters().stream()
+                .filter(Predicate.not(AnnotationParameterModel::isDefault))
+                .collect(Collectors.toMap(AnnotationParameterModel::getName,
+                        AnnotationParameterModel::getValue));
+
+        return new Annotation(annotation.getName(),
                 !attributes.isEmpty() ? attributes : null);
     }
 
@@ -53,20 +72,31 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
                 .startsWith(VALIDATION_CONSTRAINTS_PACKAGE_NAME);
     }
 
+    private static boolean isIncludedAnnotation(
+            AnnotationInfoModel annotation) {
+        return INCLUDED_ANNOTATIONS.contains(annotation.getName());
+    }
+
     @Override
     public void enter(NodePath<?> nodePath) {
-        if (!(nodePath.getNode() instanceof TypedNode)) {
+        if (!(nodePath.getNode()instanceof TypedNode typedNode)) {
             return;
         }
 
-        var typedNode = (TypedNode) nodePath.getNode();
         var signature = (SignatureModel) typedNode.getType();
         if (signature.isTypeArgument() || signature.isTypeParameter()) {
             return;
         }
 
         var schema = typedNode.getTarget();
-        addConstraintsToSchema((AnnotatedNode) typedNode, schema);
+        addConstraintsToSchema(typedNode, schema);
+
+        // Add annotations from parent property model to schema
+        if (nodePath.getParentPath() != null && nodePath.getParentPath()
+                .getNode()instanceof PropertyNode propertyNode) {
+            var propertyModel = propertyNode.getSource();
+            addAnnotationsToSchema(propertyModel, schema);
+        }
     }
 
     @Override
@@ -89,11 +119,23 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
             Schema<?> schema) {
         var constraints = annotatedNode.getAnnotations().stream()
                 .filter(ModelPlugin::isValidationConstraintAnnotation)
-                .map(ModelPlugin::convertAnnotation)
+                .map(ModelPlugin::convertValidationConstraintAnnotation)
                 .collect(Collectors.toList());
 
         if (!constraints.isEmpty()) {
             schema.addExtension(VALIDATION_CONSTRAINTS_KEY, constraints);
+        }
+    }
+
+    private void addAnnotationsToSchema(AnnotatedModel annotatedModel,
+            Schema<?> schema) {
+        var annotations = annotatedModel.getAnnotations().stream()
+                .filter(ModelPlugin::isIncludedAnnotation)
+                .map(ModelPlugin::convertAnnotation)
+                .collect(Collectors.toList());
+
+        if (!annotations.isEmpty()) {
+            schema.addExtension(ANNOTATIONS_KEY, annotations);
         }
     }
 }

--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -79,7 +79,7 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
 
     @Override
     public void enter(NodePath<?> nodePath) {
-        if (!(nodePath.getNode()instanceof TypedNode typedNode)) {
+        if (!(nodePath.getNode() instanceof TypedNode typedNode)) {
             return;
         }
 
@@ -93,7 +93,7 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
 
         // Add annotations from parent property model to schema
         if (nodePath.getParentPath() != null && nodePath.getParentPath()
-                .getNode()instanceof PropertyNode propertyNode) {
+                .getNode() instanceof PropertyNode propertyNode) {
             var propertyModel = propertyNode.getSource();
             addAnnotationsToSchema(propertyModel, schema);
         }

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/model/test/helpers/TestHelper.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/model/test/helpers/TestHelper.java
@@ -27,9 +27,9 @@ public final class TestHelper {
         }
     }
 
-    public void executeParserWithConfig(OpenAPI openAPI)
+    public void executeParserWithConfig(OpenAPI openAPI, String snapshotName)
             throws IOException, URISyntaxException {
-        var expected = mapper.readValue(resourceLoader.find("openapi.json"),
+        var expected = mapper.readValue(resourceLoader.find(snapshotName),
                 OpenAPI.class);
 
         assertEquals(expected, openAPI);

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/model/test/helpers/TestHelper.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/model/test/helpers/TestHelper.java
@@ -27,9 +27,9 @@ public final class TestHelper {
         }
     }
 
-    public void executeParserWithConfig(OpenAPI openAPI, String snapshotName)
+    public void executeParserWithConfig(OpenAPI openAPI)
             throws IOException, URISyntaxException {
-        var expected = mapper.readValue(resourceLoader.find(snapshotName),
+        var expected = mapper.readValue(resourceLoader.find("openapi.json"),
                 OpenAPI.class);
 
         assertEquals(expected, openAPI);

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/Endpoint.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/Endpoint.java
@@ -1,4 +1,4 @@
-package dev.hilla.parser.plugins.model.validation;
+package dev.hilla.parser.plugins.model;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface EndpointExposed {
+public @interface Endpoint {
 }

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/EndpointExposed.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/EndpointExposed.java
@@ -1,4 +1,4 @@
-package dev.hilla.parser.plugins.model.validation;
+package dev.hilla.parser.plugins.model;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface Endpoint {
+public @interface EndpointExposed {
 }

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsEndpoint.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsEndpoint.java
@@ -1,0 +1,37 @@
+package dev.hilla.parser.plugins.model.annotations;
+
+import dev.hilla.parser.plugins.model.Endpoint;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Version;
+
+@Endpoint
+public class AnnotationsEndpoint {
+    public AnnotationTestEntity getTestEntity() {
+        return new AnnotationTestEntity();
+    }
+
+    public static class AnnotationTestEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "idgenerator")
+        @SequenceGenerator(name = "idgenerator", initialValue = 1000)
+        public Long id;
+
+        private int version;
+
+        @Column(name = "test_column")
+        public String name;
+
+        @Version
+        public int getVersion() {
+            return version;
+        }
+
+        public void setVersion(int version) {
+            this.version = version;
+        }
+    }
+}

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsTest.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsTest.java
@@ -1,27 +1,26 @@
-package dev.hilla.parser.plugins.model.validation;
+package dev.hilla.parser.plugins.model.annotations;
+
+import dev.hilla.parser.core.Parser;
+import dev.hilla.parser.model.test.helpers.TestHelper;
+import dev.hilla.parser.plugins.backbone.BackbonePlugin;
+import dev.hilla.parser.plugins.model.Endpoint;
+import dev.hilla.parser.plugins.model.EndpointExposed;
+import dev.hilla.parser.plugins.model.ModelPlugin;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Set;
 
-import dev.hilla.parser.plugins.model.Endpoint;
-import dev.hilla.parser.plugins.model.EndpointExposed;
-import org.junit.jupiter.api.Test;
-
-import dev.hilla.parser.core.Parser;
-import dev.hilla.parser.model.test.helpers.TestHelper;
-import dev.hilla.parser.plugins.backbone.BackbonePlugin;
-import dev.hilla.parser.plugins.model.ModelPlugin;
-
-public class ValidationTest {
+public class AnnotationsTest {
     private final TestHelper helper = new TestHelper(getClass());
 
     @Test
-    public void should_GenerateValidations()
+    public void should_GenerateAnnotations()
             throws IOException, URISyntaxException {
         var openAPI = new Parser().classLoader(getClass().getClassLoader())
                 .exposedPackages(
-                        Set.of("dev.hilla.parser.plugins.model.validation"))
+                        Set.of("dev.hilla.parser.plugins.model.annotations"))
                 .classPath(Set.of(helper.getTargetDir().toString()))
                 .endpointAnnotation(Endpoint.class.getName())
                 .endpointExposedAnnotation(EndpointExposed.class.getName())

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsTest.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsTest.java
@@ -27,6 +27,6 @@ public class AnnotationsTest {
                 .addPlugin(new BackbonePlugin()).addPlugin(new ModelPlugin())
                 .execute();
 
-        helper.executeParserWithConfig(openAPI, "openapi.json");
+        helper.executeParserWithConfig(openAPI);
     }
 }

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/validation/ValidationEndpoint.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/validation/ValidationEndpoint.java
@@ -3,6 +3,7 @@ package dev.hilla.parser.plugins.model.validation;
 import java.time.LocalDate;
 import java.util.List;
 
+import dev.hilla.parser.plugins.model.Endpoint;
 import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/validation/ValidationTest.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/validation/ValidationTest.java
@@ -28,6 +28,6 @@ public class ValidationTest {
                 .addPlugin(new BackbonePlugin()).addPlugin(new ModelPlugin())
                 .execute();
 
-        helper.executeParserWithConfig(openAPI, "openapi.json");
+        helper.executeParserWithConfig(openAPI);
     }
 }

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
@@ -1,0 +1,78 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Hilla Application",
+    "version" : "1.0.0"
+  },
+  "servers" : [
+    {
+      "url" : "http://localhost:8080/connect",
+      "description" : "Hilla Backend"
+    }
+  ],
+  "tags" : [
+    {
+      "name" : "AnnotationsEndpoint",
+      "x-class-name" : "dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint"
+    }
+  ],
+  "paths" : {
+    "/AnnotationsEndpoint/getTestEntity" : {
+      "post" : {
+        "tags" : [
+          "AnnotationsEndpoint"
+        ],
+        "operationId" : "AnnotationsEndpoint_getTestEntity_POST",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "nullable" : true,
+                  "anyOf" : [
+                    {
+                      "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$AnnotationTestEntity"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$AnnotationTestEntity" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "integer",
+            "format" : "int64",
+            "nullable" : true,
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.Id"
+              }
+            ]
+          },
+          "version" : {
+            "type" : "integer",
+            "format" : "int32",
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.Version"
+              }
+            ]
+          },
+          "name" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds annotations for properties to the schema. The annotations are filtered by an include list, which currently only includes `jakarta.persistence.Id` and `jakarta.persistence.Version`.

Part of https://github.com/vaadin/hilla/issues/1266
