### PR TITLE
feat(react-auth): allow customizing user type

### DIFF
--- a/packages/ts/react-auth/src/ProtectedRoute.tsx
+++ b/packages/ts/react-auth/src/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
+import { useContext } from 'react';
 import type { RouteObject } from 'react-router-dom';
 import { type IndexRouteObject, Navigate, type NonIndexRouteObject, useLocation } from 'react-router-dom';
-import { type AccessProps, useAuth } from './useAuth.js';
+import { type AccessProps, AuthContext } from './useAuth.js';
 
 type CustomMetadata = Record<string, any>;
 
@@ -27,7 +28,7 @@ function ProtectedRoute({ redirectPath, access, element }: ProtectedRouteProps):
   const {
     state: { initializing, loading, user },
     hasAccess,
-  } = useAuth();
+  } = useContext(AuthContext);
 
   const location = useLocation();
 

--- a/packages/ts/react-auth/src/ProtectedRoute.tsx
+++ b/packages/ts/react-auth/src/ProtectedRoute.tsx
@@ -1,7 +1,6 @@
-import { useContext } from 'react';
 import type { RouteObject } from 'react-router-dom';
 import { type IndexRouteObject, Navigate, type NonIndexRouteObject, useLocation } from 'react-router-dom';
-import { type AccessProps, AuthContext } from './useAuth.js';
+import { type AccessProps, useAuth } from './useAuth.js';
 
 type CustomMetadata = Record<string, any>;
 
@@ -28,7 +27,7 @@ function ProtectedRoute({ redirectPath, access, element }: ProtectedRouteProps):
   const {
     state: { initializing, loading, user },
     hasAccess,
-  } = useContext(AuthContext);
+  } = useAuth();
 
   const location = useLocation();
 

--- a/packages/ts/react-auth/src/useAuth.tsx
+++ b/packages/ts/react-auth/src/useAuth.tsx
@@ -136,7 +136,7 @@ export type Authentication<TUser extends AuthUser> = Readonly<{
  * The hook that can be used to get the authentication state.
  * It returns the state of the authentication.
  */
-const AuthContext = createContext<Authentication<AuthUser>>({
+export const AuthContext = createContext<Authentication<AuthUser>>({
   state: initialState,
   async login() {
     throw new Error('AuthContext not initialized');

--- a/packages/ts/react-auth/src/useAuth.tsx
+++ b/packages/ts/react-auth/src/useAuth.tsx
@@ -1,5 +1,5 @@
-import { login as _login, logout as _logout, type LoginResult } from '@hilla/frontend';
-import { createContext, type Dispatch, type ReactNode, useContext, useEffect, useReducer } from 'react';
+import { login as _login, type LoginResult, logout as _logout } from '@hilla/frontend';
+import { createContext, type Dispatch, useContext, useEffect, useReducer } from 'react';
 
 type LoginFunction = (username: string, password: string) => Promise<LoginResult>;
 type LogoutFunction = () => Promise<void>;
@@ -10,23 +10,11 @@ const LOGIN_FAILURE = 'LOGIN_FAILURE';
 const LOGOUT = 'LOGOUT';
 
 /**
- * The user object returned from the authentication provider.
- * The properties are the same as the ones returned from the
- * {@link https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims | OpenID Connect Standard Claims}
- * specification, with the addition of the `roles` property.
- *
- * The user is not required to comply with this format. This is just for convenience.
- */
-export type AuthUser = Readonly<{
-  roles: string[];
-}>;
-
-/**
  * The type of the function that is used to get the authenticated user.
  */
-export type GetUserFn<TUser extends AuthUser> = () => Promise<TUser | undefined>;
+export type GetUserFn<TUser> = () => Promise<TUser | undefined>;
 
-type AuthState<TUser extends AuthUser> = Readonly<{
+type AuthState<TUser> = Readonly<{
   initializing: boolean;
   loading: boolean;
   user?: TUser;
@@ -39,7 +27,7 @@ type LoginFetchAction = Readonly<{
 }>;
 
 type LoginSuccessAction = Readonly<{
-  user: AuthUser;
+  user: unknown;
   type: typeof LOGIN_SUCCESS;
 }>;
 
@@ -54,7 +42,7 @@ type LogoutAction = Readonly<{
   type: typeof LOGOUT;
 }>;
 
-function createAuthenticateThunk(dispatch: Dispatch<LoginActions>, getAuthenticatedUser: GetUserFn<AuthUser>) {
+function createAuthenticateThunk<TUser>(dispatch: Dispatch<LoginActions>, getAuthenticatedUser: GetUserFn<TUser>) {
   async function authenticate() {
     dispatch({ type: LOGIN_FETCH });
 
@@ -82,12 +70,12 @@ function createUnauthenticateThunk(dispatch: Dispatch<LogoutAction>) {
   };
 }
 
-const initialState: AuthState<never> = {
+const initialState: AuthState<unknown> = {
   initializing: true,
   loading: false,
 };
 
-function reducer(state: AuthState<AuthUser>, action: LoginActions | LogoutAction) {
+function reducer(state: AuthState<unknown>, action: LoginActions | LogoutAction) {
   switch (action.type) {
     case LOGIN_FETCH:
       return {
@@ -125,7 +113,7 @@ export type AccessProps = Readonly<{
 /**
  * The type of the authentication hook.
  */
-export type Authentication<TUser extends AuthUser> = Readonly<{
+export type Authentication<TUser> = Readonly<{
   state: AuthState<TUser>;
   login: LoginFunction;
   logout: LogoutFunction;
@@ -136,7 +124,7 @@ export type Authentication<TUser extends AuthUser> = Readonly<{
  * The hook that can be used to get the authentication state.
  * It returns the state of the authentication.
  */
-export const AuthContext = createContext<Authentication<AuthUser>>({
+export const AuthContext = createContext<Authentication<unknown>>({
   state: initialState,
   async login() {
     throw new Error('AuthContext not initialized');
@@ -149,11 +137,25 @@ export const AuthContext = createContext<Authentication<AuthUser>>({
   },
 });
 
-interface AuthProviderProps<TUser extends AuthUser> extends React.PropsWithChildren {
-  getAuthenticatedUser: GetUserFn<TUser>;
+interface AuthConfig<TUser> {
+  getRoles?(user: TUser): readonly string[];
 }
 
-function AuthProvider<TUser extends AuthUser>({ children, getAuthenticatedUser }: AuthProviderProps<TUser>) {
+interface AuthProviderProps<TUser> extends React.PropsWithChildren {
+  getAuthenticatedUser: GetUserFn<TUser>;
+  config?: AuthConfig<TUser>;
+}
+
+interface UserWithRoles {
+  roles?: any;
+}
+
+const getDefaultRoles = (user: unknown) => {
+  const userWithRoles = user as UserWithRoles;
+  return Array.isArray(userWithRoles.roles) ? userWithRoles.roles : [];
+};
+
+function AuthProvider<TUser>({ children, getAuthenticatedUser, config }: AuthProviderProps<TUser>) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const authenticate = createAuthenticateThunk(dispatch, getAuthenticatedUser);
   const unauthenticate = createUnauthenticateThunk(dispatch);
@@ -184,7 +186,8 @@ function AuthProvider<TUser extends AuthUser>({ children, getAuthenticatedUser }
     }
 
     if (accessProps.rolesAllowed) {
-      return accessProps.rolesAllowed.some((allowedRole) => state.user?.roles.includes(allowedRole));
+      const userRoles = config?.getRoles ? config.getRoles(state.user as TUser) : getDefaultRoles(state.user);
+      return accessProps.rolesAllowed.some((allowedRole) => userRoles.includes(allowedRole));
     }
 
     return true;
@@ -206,25 +209,32 @@ function AuthProvider<TUser extends AuthUser>({ children, getAuthenticatedUser }
   return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
 }
 
-export type AuthHook<TUser extends AuthUser> = () => Authentication<TUser>;
+export type AuthHook<TUser> = () => Authentication<TUser>;
 
 /**
  * The hook that can be used to authenticate the user.
  * It returns the state of the authentication and the functions
  * to authenticate and unauthenticate the user.
  */
-function useAuth(): Authentication<AuthUser> {
-  return useContext(AuthContext);
+function useAuth<TUser>(): Authentication<TUser> {
+  return useContext(AuthContext) as Authentication<TUser>;
 }
 
-interface AuthModule<TUser extends AuthUser> {
+interface AuthModule<TUser> {
   AuthProvider: React.FC<React.PropsWithChildren>;
   useAuth: AuthHook<TUser>;
 }
 
-export function configureAuth<TUser extends AuthUser>(getAuthenticatedUser: GetUserFn<TUser>): AuthModule<TUser> {
+export function configureAuth<TUser>(
+  getAuthenticatedUser: GetUserFn<TUser>,
+  config?: AuthConfig<TUser>,
+): AuthModule<TUser> {
   function PreconfiguredAuthProvider({ children }: React.PropsWithChildren) {
-    return <AuthProvider<TUser> getAuthenticatedUser={getAuthenticatedUser}>{children}</AuthProvider>;
+    return (
+      <AuthProvider<TUser> getAuthenticatedUser={getAuthenticatedUser} config={config}>
+        {children}
+      </AuthProvider>
+    );
   }
 
   return {

--- a/packages/ts/react-auth/test/ProtectedRoute.spec.tsx
+++ b/packages/ts/react-auth/test/ProtectedRoute.spec.tsx
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { render, waitFor } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { AuthContext, type AuthUser, protectRoutes, type RouteObjectWithAuth, useAuth } from '../src';
+import { type AuthUser, configureAuth, protectRoutes, type RouteObjectWithAuth } from '../src';
 
 function TestView({ route }: { route: string }) {
   return <div>{`route: ${route}`}</div>;
@@ -56,16 +56,16 @@ const testRoutes: RouteObjectWithAuth[] = [
 ];
 
 function TestApp({ user, initialRoute }: { user?: AuthUser; initialRoute: string }) {
-  const auth = useAuth(async () => Promise.resolve(user));
+  const { AuthProvider } = configureAuth(async () => Promise.resolve(user));
   const protectedRoutes = protectRoutes(testRoutes);
   const router = createMemoryRouter(protectedRoutes, {
     initialEntries: [initialRoute],
   });
 
   return (
-    <AuthContext.Provider value={auth}>
+    <AuthProvider>
       <RouterProvider router={router} />
-    </AuthContext.Provider>
+    </AuthProvider>
   );
 }
 
@@ -88,7 +88,7 @@ describe('@hilla/react-auth', () => {
     });
 
     it('should protect routes when user without roles is authenticated', async () => {
-      const user = { name: 'John' };
+      const user = { name: 'John', roles: [] };
       await testRoute('/public', user, true);
       await testRoute('/protected/login', user, true);
       await testRoute('/protected/role/user', user, false);

--- a/packages/ts/react-auth/test/ProtectedRoute.spec.tsx
+++ b/packages/ts/react-auth/test/ProtectedRoute.spec.tsx
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { render, waitFor } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { type AuthUser, configureAuth, protectRoutes, type RouteObjectWithAuth } from '../src';
+import { configureAuth, protectRoutes, type RouteObjectWithAuth } from '../src';
 
 function TestView({ route }: { route: string }) {
   return <div>{`route: ${route}`}</div>;
@@ -55,8 +55,12 @@ const testRoutes: RouteObjectWithAuth[] = [
   },
 ];
 
-function TestApp({ user, initialRoute }: { user?: AuthUser; initialRoute: string }) {
-  const { AuthProvider } = configureAuth(async () => Promise.resolve(user));
+interface User {
+  roles: string[];
+}
+
+function TestApp({ user, initialRoute }: { user?: User; initialRoute: string }) {
+  const { AuthProvider, useAuth } = configureAuth(async () => Promise.resolve(user));
   const protectedRoutes = protectRoutes(testRoutes);
   const router = createMemoryRouter(protectedRoutes, {
     initialEntries: [initialRoute],
@@ -71,7 +75,7 @@ function TestApp({ user, initialRoute }: { user?: AuthUser; initialRoute: string
 
 describe('@hilla/react-auth', () => {
   describe('protectRoutes', () => {
-    async function testRoute(route: string, user: AuthUser | undefined, canAccess: boolean) {
+    async function testRoute(route: string, user: User | undefined, canAccess: boolean) {
       const result = render(<TestApp initialRoute={route} user={user} />);
       const expectedText = canAccess ? `route: ${route}` : 'route: /login';
       await waitFor(() => expect(result.getByText(expectedText)).to.exist);

--- a/packages/ts/react-auth/test/useAuth.spec.tsx
+++ b/packages/ts/react-auth/test/useAuth.spec.tsx
@@ -1,40 +1,61 @@
 import { expect } from '@esm-bundle/chai';
-import { render, waitFor } from '@testing-library/react';
-import { type AuthUser, configureAuth } from '../src';
-
-interface CustomUser extends AuthUser {
-  name: string;
-}
-
-let user: CustomUser | undefined;
-const getAuthenticatedUser = async () => Promise.resolve(user);
-const { AuthProvider, useAuth } = configureAuth(getAuthenticatedUser);
-
-function TestComponent() {
-  const auth = useAuth();
-  return <div>{auth.state.user ? auth.state.user.name : 'Not logged in'}</div>;
-}
-
-function TestApp() {
-  return (
-    <AuthProvider>
-      <TestComponent />
-    </AuthProvider>
-  );
-}
+import { renderHook, waitFor } from '@testing-library/react';
+import { configureAuth } from '../src';
 
 describe('@hilla/react-auth', () => {
   describe('useAuth', () => {
-    it('should be able to access user information after login', async () => {
-      user = { name: 'John', roles: ['admin'] };
-      const { getByText } = render(<TestApp />);
-      await waitFor(() => expect(getByText('John')).to.exist);
+    it('should provide user in state', async () => {
+      const user = { customRoles: ['admin'] };
+      const { AuthProvider, useAuth } = configureAuth(async () => Promise.resolve(user));
+      const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+      await waitFor(() => expect(result.current.state.user).to.equal(user));
     });
 
-    it('should not be able to access user information after login', async () => {
-      user = undefined;
-      const { getByText } = render(<TestApp />);
-      await waitFor(() => expect(getByText('Not logged in')).to.exist);
+    describe('hasAccess', () => {
+      it('should not give access if user has no roles', async () => {
+        const user = {};
+        const { AuthProvider, useAuth } = configureAuth(async () => Promise.resolve(user));
+
+        const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+        await waitFor(() => expect(result.current.state.user).to.equal(user));
+        expect(result.current.hasAccess({ rolesAllowed: ['admin'] })).to.be.false;
+        expect(result.current.hasAccess({ rolesAllowed: ['superadmin'] })).to.be.false;
+      });
+
+      it('should handle incompatible roles property', async () => {
+        const user = { roles: 'admin' };
+        const { AuthProvider, useAuth } = configureAuth(async () => Promise.resolve(user));
+
+        const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+        await waitFor(() => expect(result.current.state.user).to.equal(user));
+        expect(result.current.hasAccess({ rolesAllowed: ['admin'] })).to.be.false;
+        expect(result.current.hasAccess({ rolesAllowed: ['superadmin'] })).to.be.false;
+      });
+
+      it('should use roles property by convention', async () => {
+        const user = { roles: ['admin'] };
+        const { AuthProvider, useAuth } = configureAuth(async () => Promise.resolve(user));
+        const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+        await waitFor(() => expect(result.current.state.user).to.equal(user));
+        expect(result.current.hasAccess({ rolesAllowed: ['admin'] })).to.be.true;
+        expect(result.current.hasAccess({ rolesAllowed: ['superadmin'] })).to.be.false;
+      });
+
+      it('should use custom roles accessor when configured', async () => {
+        const user = { roles: ['superadmin'], customRoles: ['admin'] };
+        const { AuthProvider, useAuth } = configureAuth(async () => Promise.resolve(user), {
+          getRoles: (authenticatedUser) => authenticatedUser.customRoles,
+        });
+        const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+        await waitFor(() => expect(result.current.state.user).to.equal(user));
+        expect(result.current.hasAccess({ rolesAllowed: ['admin'] })).to.be.true;
+        expect(result.current.hasAccess({ rolesAllowed: ['superadmin'] })).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Working on updating the starters it was rather odd that the auth state contains a user object with two dozen properties that might exist, but you can't really be sure unless you double check in the backend. This proposes an alternative that would allow providing a custom user type to the auth module. It also does some minor improvements to how the context works, so that the auth provider doesn't require passing a value, and the `useAuth` hook is actually the hook that devs can call to get the auth state from the context.

To start with, apps would have some module like `frontend/util/auth.ts` that configures the auth module to use a specific user type:
```ts
import { configureAuth } from "@hilla/react-auth";
import { UserEndpoint } from "Frontend/generated/endpoints";

// Configure auth to use `UserEndpoint.getAuthenticatedUser`
const auth = configureAuth(UserEndpoint.getAuthenticatedUser);

// Export auth provider and useAuth hook, which are automatically typed to the result of `UserEndpoint.getAuthenticatedUser`
export const useAuth = auth.useAuth;
export const AuthProvider = auth.AuthProvider;
```

Adding the auth provider to the app then becomes:
```diff
import router from 'Frontend/routes.js';
- import { AuthContext, useAuth } from 'Frontend/useAuth.js';
+ import { AuthProvider } from 'Frontend/utils/auth';
import { RouterProvider } from 'react-router-dom';

export default function App() {
-   const auth = useAuth();
  return (
-     <AuthContext.Provider value={auth}>
+     <AuthProvider>
      <RouterProvider router={router} />
-     </AuthContext.Provider>
+    </ AuthProvider>
  );
}
```

And accessing the auth state then becomes:
```diff
- import { useContext } from 'react';
- import { AuthContext } from '@hilla/react-auth';
+ import { useAuth } from 'frontend/utils/auth';

- const { state } = useContext(AuthContext);
+ const { state } = useAuth();

// state.user is now the same type as return type from UserEndpoint.getAuthenticatedUser
```
