### PR TITLE
fix: add support for proxied services as endpoints

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
@@ -38,6 +38,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cglib.proxy.Enhancer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
@@ -383,6 +384,12 @@ public class EndpointInvoker {
         var methodDeclaringClass = methodToInvoke.getDeclaringClass();
         var invokedEndpointClass = vaadinEndpointData.getEndpointObject()
                 .getClass();
+
+        // if the invoked endpoint is proxied, then take the original class:
+        // This is only to supports CGLIB proxies as Spring AOP proxies are.
+        if (Enhancer.isEnhanced(invokedEndpointClass)) {
+            invokedEndpointClass = invokedEndpointClass.getSuperclass();
+        }
 
         String checkError;
         if (methodDeclaringClass.equals(invokedEndpointClass)) {

--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
@@ -382,7 +382,7 @@ public class EndpointInvoker {
 
         var methodDeclaringClass = methodToInvoke.getDeclaringClass();
         var invokedEndpointClass = ClassUtils
-            .getUserClass(vaadinEndpointData.getEndpointObject());
+                .getUserClass(vaadinEndpointData.getEndpointObject());
 
         String checkError;
         if (methodDeclaringClass.equals(invokedEndpointClass)) {

--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointInvoker.java
@@ -38,7 +38,6 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cglib.proxy.Enhancer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
@@ -382,14 +381,8 @@ public class EndpointInvoker {
         EndpointAccessChecker accessChecker = getAccessChecker();
 
         var methodDeclaringClass = methodToInvoke.getDeclaringClass();
-        var invokedEndpointClass = vaadinEndpointData.getEndpointObject()
-                .getClass();
-
-        // if the invoked endpoint is proxied, then take the original class:
-        // This is only to supports CGLIB proxies as Spring AOP proxies are.
-        if (Enhancer.isEnhanced(invokedEndpointClass)) {
-            invokedEndpointClass = invokedEndpointClass.getSuperclass();
-        }
+        var invokedEndpointClass = ClassUtils
+            .getUserClass(vaadinEndpointData.getEndpointObject());
 
         String checkError;
         if (methodDeclaringClass.equals(invokedEndpointClass)) {

--- a/packages/java/endpoint/src/main/java/dev/hilla/EndpointUtil.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/EndpointUtil.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.server.PathContainer;
 import org.springframework.http.server.RequestPath;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ClassUtils;
 import org.springframework.web.util.pattern.PathPattern;
 
 import org.springframework.web.util.pattern.PathPatternParser;
@@ -80,16 +81,16 @@ public class EndpointUtil implements EndpointRequestUtil {
         if (endpointData.isEmpty()) {
             return false;
         }
-        var concreteEndpointClass = endpointData.get().endpointObject()
-                .getClass();
-        var methodWrappingClass = endpointData.get().method()
+        var invokedEndpointClass = ClassUtils
+                .getUserClass(endpointData.get().endpointObject());
+        var methodDeclaringClass = endpointData.get().method()
                 .getDeclaringClass();
-        if (concreteEndpointClass.equals(methodWrappingClass)) {
+        if (methodDeclaringClass.equals(invokedEndpointClass)) {
             return accessChecker.getAccessAnnotationChecker().hasAccess(
                     endpointData.get().method(), null, role -> false);
         } else {
             return accessChecker.getAccessAnnotationChecker()
-                    .hasAccess(concreteEndpointClass, null, role -> false);
+                    .hasAccess(invokedEndpointClass, null, role -> false);
         }
     }
 

--- a/packages/java/tests/spring/security/frontend/routes.ts
+++ b/packages/java/tests/spring/security/frontend/routes.ts
@@ -49,6 +49,14 @@ export const views: ViewRoute[] = [
       return undefined;
     },
   },
+  {
+    path: 'proxied-service',
+    component: 'proxied-service-test-view',
+    title: 'Proxied Service Test View',
+    action: async () => {
+      await import('./views/public/proxied-service-test-view');
+    },
+  },
 ];
 export const routes: ViewRoute[] = [
   {

--- a/packages/java/tests/spring/security/frontend/routes.ts
+++ b/packages/java/tests/spring/security/frontend/routes.ts
@@ -17,6 +17,14 @@ export const views: ViewRoute[] = [
     },
   },
   {
+    path: 'proxied-service',
+    component: 'proxied-service-test-view',
+    title: 'Proxied Service Test View',
+    action: async () => {
+      await import('./views/public/proxied-service-test-view');
+    },
+  },
+  {
     path: 'form',
     component: 'vaadin-elements-view',
     name: 'form',
@@ -47,14 +55,6 @@ export const views: ViewRoute[] = [
       }
       await import('./views/admin/admin-view');
       return undefined;
-    },
-  },
-  {
-    path: 'proxied-service',
-    component: 'proxied-service-test-view',
-    title: 'Proxied Service Test View',
-    action: async () => {
-      await import('./views/public/proxied-service-test-view');
     },
   },
 ];

--- a/packages/java/tests/spring/security/frontend/views/public/proxied-service-test-view.ts
+++ b/packages/java/tests/spring/security/frontend/views/public/proxied-service-test-view.ts
@@ -1,0 +1,25 @@
+import '@vaadin/button';
+import '@vaadin/text-field';
+import { GreetingService } from 'Frontend/generated/endpoints';
+import { html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { View } from '../view';
+import { Notification } from '@vaadin/notification';
+
+@customElement('proxied-service-test-view')
+export class ProxiedServiceTestView extends View {
+
+  async connectedCallback() {
+    super.connectedCallback();
+  }
+
+  render() {
+    return html`<div style="display:flex;flex-direction:column;height:100%">
+      <vaadin-button id="say-hello-btn" @click="${this.callSayHello}">Say Hello!</vaadin-button>
+    </div>`;
+  }
+
+  public async callSayHello() {
+    GreetingService.sayHello().then((response) => Notification.show(response));
+  }
+}

--- a/packages/java/tests/spring/security/frontend/views/public/proxied-service-test-view.ts
+++ b/packages/java/tests/spring/security/frontend/views/public/proxied-service-test-view.ts
@@ -15,7 +15,7 @@ export class ProxiedServiceTestView extends View {
 
   render() {
     return html`<div style="display:flex;flex-direction:column;height:100%">
-      <vaadin-button id="say-hello-btn" @click="${this.callSayHello}">Say Hello!</vaadin-button>
+      <vaadin-button id="say-hello-btn" @click="${() => this.callSayHello()}">Say Hello!</vaadin-button>
     </div>`;
   }
 

--- a/packages/java/tests/spring/security/src/main/java/com/vaadin/flow/spring/fusionsecurity/SecurityConfig.java
+++ b/packages/java/tests/spring/security/src/main/java/com/vaadin/flow/spring/fusionsecurity/SecurityConfig.java
@@ -61,6 +61,10 @@ public class SecurityConfig extends VaadinWebSecurity {
                 .requestMatchers(
                         new AntPathRequestMatcher(applyUrlMapping("/form")))
                 .permitAll();
+        http.authorizeHttpRequests().requestMatchers(
+                new AntPathRequestMatcher(applyUrlMapping("/proxied-service")))
+                .permitAll();
+
         // Admin only access
         http.authorizeHttpRequests()
                 .requestMatchers(new AntPathRequestMatcher("/admin-only/**"))

--- a/packages/java/tests/spring/security/src/main/java/com/vaadin/flow/spring/fusionsecurity/service/GreetingService.java
+++ b/packages/java/tests/spring/security/src/main/java/com/vaadin/flow/spring/fusionsecurity/service/GreetingService.java
@@ -1,0 +1,16 @@
+package com.vaadin.flow.spring.fusionsecurity.service;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import dev.hilla.BrowserCallable;
+import dev.hilla.Nonnull;
+import org.springframework.transaction.annotation.Transactional;
+
+@BrowserCallable
+@Transactional
+public class GreetingService {
+
+    @AnonymousAllowed
+    public @Nonnull String sayHello() {
+        return "Hello from GreetingService";
+    }
+}

--- a/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
+++ b/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
@@ -203,9 +203,8 @@ public class SecurityIT extends ChromeBrowserTest {
     @Test
     public void anonymously_allowed_method_from_not_annotated_proxied_endpoint_is_accessible() {
         open("proxied-service");
-        waitUntil(driver -> $("vaadin-button").attribute("id", "say-hello-btn")
-                .exists());
-        $(ButtonElement.class).id("say-hello-btn").click();
+        var view = $("proxied-service-test-view").waitForFirst();
+        view.$(ButtonElement.class).id("say-hello-btn").click();
         NotificationElement notification = $(NotificationElement.class).first();
         Assert.assertNotNull(notification);
         waitUntil(driver -> notification.isOpen());

--- a/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
+++ b/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
@@ -201,13 +201,12 @@ public class SecurityIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void anonymously_allowed_method_from_not_annotated_proxied_endpoint_is_accessible() {
+    public void when_endpoint_class_is_proxied_and_not_annotated_then_anonymously_allowed_method_is_accessible() {
         open("proxied-service");
         var view = $("proxied-service-test-view").waitForFirst();
         view.$(ButtonElement.class).id("say-hello-btn").click();
         NotificationElement notification = $(NotificationElement.class).first();
         Assert.assertNotNull(notification);
-        waitUntil(driver -> notification.isOpen());
         Assert.assertTrue(
                 notification.getText().contains("Hello from GreetingService"));
     }

--- a/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
+++ b/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
@@ -203,12 +203,14 @@ public class SecurityIT extends ChromeBrowserTest {
     @Test
     public void anonymously_allowed_method_from_not_annotated_proxied_endpoint_is_accessible() {
         open("proxied-service");
-        waitUntil(driver -> $("vaadin-button").attribute("id", "say-hello-btn").exists());
+        waitUntil(driver -> $("vaadin-button").attribute("id", "say-hello-btn")
+                .exists());
         $(ButtonElement.class).id("say-hello-btn").click();
         NotificationElement notification = $(NotificationElement.class).first();
         Assert.assertNotNull(notification);
         waitUntil(driver -> notification.isOpen());
-        Assert.assertTrue(notification.getText().contains("Hello from GreetingService"));
+        Assert.assertTrue(
+                notification.getText().contains("Hello from GreetingService"));
     }
 
     @Test

--- a/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
+++ b/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.notification.testbench.NotificationElement;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -197,6 +198,17 @@ public class SecurityIT extends ChromeBrowserTest {
         assertPrivatePageShown(USER_FULLNAME);
         refresh();
         assertPrivatePageShown(USER_FULLNAME);
+    }
+
+    @Test
+    public void anonymously_allowed_method_from_not_annotated_proxied_endpoint_is_accessible() {
+        open("proxied-service");
+        waitUntil(driver -> $("vaadin-button").attribute("id", "say-hello-btn").exists());
+        $(ButtonElement.class).id("say-hello-btn").click();
+        NotificationElement notification = $(NotificationElement.class).first();
+        Assert.assertNotNull(notification);
+        waitUntil(driver -> notification.isOpen());
+        Assert.assertTrue(notification.getText().contains("Hello from GreetingService"));
     }
 
     @Test


### PR DESCRIPTION
## Description
If a service class that is annotated with `@Endpoint` or `@BrowserCallable` is proxied at runtime e.g. by
annotating it by `@Transactional`, the invoked endpoint at runtime would be proxied subclass of the actual endpoint. In this case, resolving the target for access checking should consider resolving the original endpoint class not the runtime proxy object.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
