### PR TITLE
chore: relax error level in backbone and model plugins

### DIFF
--- a/packages/ts/generator-typescript-plugin-backbone/src/EntityProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EntityProcessor.ts
@@ -78,12 +78,12 @@ export class EntityProcessor {
     const { logger } = this.#owner;
 
     if (!isObjectSchema(schema)) {
-      logger.error(schema, `Component is not an object: '${this.#fullyQualifiedName}'`);
+      logger.debug(schema, `Component is not an object: '${this.#fullyQualifiedName}'`);
       return undefined;
     }
 
     if (isEmptyObject(schema)) {
-      logger.warn(`Component has no properties:' ${this.#fullyQualifiedName}'`);
+      logger.debug(`Component has no properties:' ${this.#fullyQualifiedName}'`);
     }
 
     return ts.factory.createInterfaceDeclaration(
@@ -110,14 +110,17 @@ export class EntityProcessor {
       const decomposed = decomposeSchema(schema);
 
       if (decomposed.length > 2) {
-        logger.error(schema, `Schema for '${this.#fullyQualifiedName}' class component is broken.`);
+        logger.debug(
+          schema,
+          `Schema for '${this.#fullyQualifiedName}' has more than two components. This plugin will ignore it.`,
+        );
         return undefined;
       }
 
       const [parent, child] = decomposed;
 
       if (!isReferenceSchema(parent)) {
-        logger.error(parent, 'Only reference schema allowed for parent class');
+        logger.debug(parent, 'Only reference schema allowed for parent class');
         return undefined;
       }
 

--- a/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/EntityModelProcessor.ts
@@ -130,14 +130,19 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
       const decomposed = decomposeSchema(this.#component);
 
       if (decomposed.length > 2) {
-        logger.error(this.#component, `The schema for a class component ${this.#fullyQualifiedName} is broken.`);
+        logger.debug(
+          this.#component,
+          `The schema for a class component ${
+            this.#fullyQualifiedName
+          } has more than two components. This plugin will ignore it.`,
+        );
         return undefined;
       }
 
       const [parentSchema, childSchema] = decomposed;
 
       if (!isReferenceSchema(parentSchema)) {
-        logger.error(parentSchema, 'Only reference schema allowed for parent class');
+        logger.debug(parentSchema, 'Only reference schema allowed for parent class');
         return undefined;
       }
 
@@ -184,7 +189,7 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
     const { logger } = this.#context.owner;
 
     if (!isObjectSchema(schema)) {
-      logger.error(schema, `Component is not an object: ${this.#fullyQualifiedName}`);
+      logger.debug(schema, `Component is not an object: ${this.#fullyQualifiedName}`);
       return undefined;
     }
 


### PR DESCRIPTION
Some OpenAPI definitions are not compatible with those plugins, yet they should not trigger an error. Another plugin can deal with, like the subtypes one.

Closes #1350.