### PR TITLE
refactor: use annotations for excluding properties

### DIFF
--- a/packages/ts/react-grid/src/autogrid.tsx
+++ b/packages/ts/react-grid/src/autogrid.tsx
@@ -21,12 +21,14 @@ import type Filter from './types/dev/hilla/crud/filter/Filter';
 import type PropertyStringFilter from './types/dev/hilla/crud/filter/PropertyStringFilter';
 import type Sort from './types/dev/hilla/mappedtypes/Sort';
 import Direction from './types/org/springframework/data/domain/Sort/Direction';
-import { getProperties, type PropertyInfo } from './utils.js';
+import { getProperties, hasAnnotation, type PropertyInfo } from './utils.js';
 
-function includeColumn(propertyId: string): unknown {
-  // Exclude id and version columns
-  // Currently based on name until https://github.com/vaadin/hilla/issues/1266
-  if (propertyId === 'id' || propertyId === 'version') {
+function includeProperty(propertyInfo: PropertyInfo): unknown {
+  // Exclude properties annotated with id and version
+  if (
+    hasAnnotation(propertyInfo, 'jakarta.persistence.Id') ||
+    hasAnnotation(propertyInfo, 'jakarta.persistence.Version')
+  ) {
     return false;
   }
   return true;
@@ -106,7 +108,7 @@ function useColumns(
   options: { visibleColumns?: string[]; headerFilters?: boolean },
 ) {
   const properties = getProperties(model);
-  const effectiveColumns = options.visibleColumns ?? properties.map((p) => p.name).filter((p) => includeColumn(p));
+  const effectiveColumns = options.visibleColumns ?? properties.filter(includeProperty).map((p) => p.name);
   const effectiveProperties = effectiveColumns
     .map((name) => properties.find((prop) => prop.name === name))
     .filter(Boolean) as PropertyInfo[];

--- a/packages/ts/react-grid/src/utils.ts
+++ b/packages/ts/react-grid/src/utils.ts
@@ -1,15 +1,22 @@
 import {
+  _meta,
   createDetachedModel,
   StringModel,
   type AbstractModel,
   type DetachedModelConstructor,
   NumberModel,
+  type ModelMetadata,
 } from '@hilla/form';
 
 export interface PropertyInfo {
   name: string;
   humanReadableName: string;
   modelType: 'number' | 'string' | undefined;
+  meta: ModelMetadata;
+}
+
+export function hasAnnotation(propertyInfo: PropertyInfo, annotationName: string): boolean {
+  return propertyInfo.meta.annotations?.some((annotation) => annotation.name === annotationName) ?? false;
 }
 
 // This is from vaadin-grid-column.js, should be used from there maybe. At least we must be 100% sure to match grid and fields
@@ -28,7 +35,9 @@ export const getProperties = (model: DetachedModelConstructor<AbstractModel>): P
   const modelInstance: any = createDetachedModel(model);
   return properties.map((name) => {
     // eslint-disable-next-line
-    const propertyModel = modelInstance[name];
+    const propertyModel = modelInstance[name] as AbstractModel;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const meta = propertyModel[_meta];
     const humanReadableName = _generateHeader(name);
     const { constructor } = propertyModel;
     const modelType = constructor === StringModel ? 'string' : constructor === NumberModel ? 'number' : undefined;
@@ -36,6 +45,7 @@ export const getProperties = (model: DetachedModelConstructor<AbstractModel>): P
       name,
       humanReadableName,
       modelType,
+      meta,
     };
   });
 };

--- a/packages/ts/react-grid/test/autogrid.spec.tsx
+++ b/packages/ts/react-grid/test/autogrid.spec.tsx
@@ -40,6 +40,7 @@ describe('@hilla/react-grid', () => {
   function TestAutoGrid(customProps: Partial<AutoGridProps<Person>>) {
     return <AutoGrid service={personService()} model={PersonModel} {...customProps}></AutoGrid>;
   }
+
   describe('Auto grid', () => {
     it('creates columns based on model', async () => {
       const result: RenderResult = render(<TestAutoGrid />);
@@ -313,6 +314,11 @@ describe('@hilla/react-grid', () => {
     it('should only show configured columns in specified order', async () => {
       const result = render(<TestAutoGrid visibleColumns={['email', 'firstName']} />);
       await assertColumns(result, 'email', 'firstName');
+    });
+
+    it('should show columns that would be excluded by default', async () => {
+      const result = render(<TestAutoGrid visibleColumns={['id', 'version']} />);
+      await assertColumns(result, 'id', 'version');
     });
 
     it('should ignore unknown columns', async () => {

--- a/packages/ts/react-grid/test/test-models-and-services.ts
+++ b/packages/ts/react-grid/test/test-models-and-services.ts
@@ -18,6 +18,7 @@ export interface Company {
   name: string;
   foundedDate: string;
 }
+
 export interface Person {
   id: number;
   version: number;
@@ -32,11 +33,19 @@ export class PersonModel<T extends Person = Person> extends ObjectModel<T> {
   static override createEmptyValue = makeObjectEmptyValueCreator(PersonModel);
 
   get id(): NumberModel {
-    return this[_getPropertyModel]('id', (parent, key) => new NumberModel(parent, key, false));
+    return this[_getPropertyModel](
+      'id',
+      (parent, key) =>
+        new NumberModel(parent, key, false, { meta: { annotations: [{ name: 'jakarta.persistence.Id' }] } }),
+    );
   }
 
   get version(): NumberModel {
-    return this[_getPropertyModel]('version', (parent, key) => new NumberModel(parent, key, false));
+    return this[_getPropertyModel](
+      'version',
+      (parent, key) =>
+        new NumberModel(parent, key, false, { meta: { annotations: [{ name: 'jakarta.persistence.Version' }] } }),
+    );
   }
 
   get firstName(): StringModel {
@@ -64,11 +73,19 @@ export class CompanyModel<T extends Company = Company> extends ObjectModel<T> {
   declare static createEmptyValue: () => Company;
 
   get id(): NumberModel {
-    return this[_getPropertyModel]('id', (parent, key) => new NumberModel(parent, key, false));
+    return this[_getPropertyModel](
+      'id',
+      (parent, key) =>
+        new NumberModel(parent, key, false, { meta: { annotations: [{ name: 'jakarta.persistence.Id' }] } }),
+    );
   }
 
   get version(): NumberModel {
-    return this[_getPropertyModel]('version', (parent, key) => new NumberModel(parent, key, false));
+    return this[_getPropertyModel](
+      'version',
+      (parent, key) =>
+        new NumberModel(parent, key, false, { meta: { annotations: [{ name: 'jakarta.persistence.Version' }] } }),
+    );
   }
 
   get name(): StringModel {
@@ -138,7 +155,9 @@ export const companyData: Company[] = [
   { id: 1, version: 1, name: 'Vaadin Ltd', foundedDate: '2000-05-06' },
   { id: 2, version: 1, name: 'Google', foundedDate: '1998-09-04' },
 ];
-export type HasLastFilter = { lastFilter: Filter | undefined };
+export type HasLastFilter = {
+  lastFilter: Filter | undefined;
+};
 
 export const personService = (): CrudService<Person> & HasLastFilter => createService(personData);
 export const companyService = (): CrudService<Company> & HasLastFilter => createService(companyData);


### PR DESCRIPTION
Use Java annotations instead of property names for determining which columns to exclude.

Closes https://github.com/vaadin/hilla/issues/1266