### PR TITLE
test: Do not run endpoint tests in parallel

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -291,5 +291,15 @@
 
 
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <parallel>none</parallel>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M7</version>
+        <version>3.1.2</version>
         <configuration>
           <useModulePath>false</useModulePath>
           <parallel>all</parallel>


### PR DESCRIPTION
Tests that use the static instance variable of EndpointCodeGenerator cannot run in parallel with any other test. It seems that annotating these tests with @NotThreadSafe does not help as the setup part is still run in parallel and this is the problematic part.
