### PR TITLE
chore: Do not wait for unit tests before running ITs

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -151,8 +151,6 @@ jobs:
   test-it:
     needs:
       - init
-      - test-java
-      - test-typescript
     name: ITs
     timeout-minutes: 25
     strategy:


### PR DESCRIPTION
Should speed up the build by 6 minutes
