### PR TITLE
fix(form): errors when defaultValue is set with array items

### DIFF
--- a/packages/ts/form/src/Validation.ts
+++ b/packages/ts/form/src/Validation.ts
@@ -53,7 +53,7 @@ export type InterpolateMessageCallback<T> = (
 ) => string;
 
 export interface Validator<T> {
-  validate: ValidationCallback<T>;
+  validate(...args: Parameters<ValidationCallback<T>>): ReturnType<ValidationCallback<T>>;
   message: string;
   impliesRequired?: boolean;
 }

--- a/packages/ts/form/test/Binder.test.ts
+++ b/packages/ts/form/test/Binder.test.ts
@@ -394,29 +394,40 @@ describe('@hilla/form', () => {
       });
     });
 
-    @customElement('lit-hierarchy-view')
-    class LitHierarchyView extends LitElement {
-      binder: Binder<Level1, Level1Model>;
-
-      constructor() {
-        super();
-        this.binder = new Binder(this, Level1Model);
-        const level1 = Level1Model.createEmptyValue();
-        const level2 = Level2Model.createEmptyValue();
-        level1.level2 = [level2];
-        this.binder.read(level1);
-      }
-    }
-
     describe('complex hierarchy', () => {
-      it('should create binder in complex hierarchy', async () => {
-        const litHierarchyView = document.createElement('lit-hierarchy-view') as LitHierarchyView;
+      @customElement('lit-hierarchy-view')
+      class LitHierarchyView extends LitElement {
+        binder: Binder<Level1, Level1Model>;
+
+        constructor() {
+          super();
+          this.binder = new Binder(this, Level1Model);
+          const level1 = Level1Model.createEmptyValue();
+          const level2 = Level2Model.createEmptyValue();
+          level1.level2 = [level2];
+          this.binder.read(level1);
+        }
+      }
+
+      let litHierarchyView: LitHierarchyView;
+
+      beforeEach(() => {
+        litHierarchyView = document.createElement('lit-hierarchy-view') as LitHierarchyView;
         document.body.appendChild(litHierarchyView);
+      });
+
+      afterEach(() => {
+        document.body.removeChild(litHierarchyView);
+      });
+
+      it('should create binder in complex hierarchy', async () => {
         const { binder } = litHierarchyView;
         await litHierarchyView.updateComplete;
-        for (const item of binder.model.level2) {
-          assert.isDefined(binder.for(item.model.level3.level4.name4).defaultValue);
-        }
+        const level3Nodes = [...binder.model.level2];
+        assert.lengthOf(level3Nodes, 1);
+        assert.isDefined(binder.for(level3Nodes[0].model.level3.level4.name4).parent?.defaultValue);
+        // Automatic node initialization should preserve pristine state
+        assert.isFalse(binder.dirty);
       });
     });
   });

--- a/packages/ts/form/test/Binder.test.ts
+++ b/packages/ts/form/test/Binder.test.ts
@@ -1,14 +1,22 @@
 /* eslint-disable sort-keys */
 import { assert, expect, use } from '@esm-bundle/chai';
 import { LitElement } from 'lit';
-// TODO: remove when the new version of eslint-config-vaadin is released.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { customElement } from 'lit/decorators.js';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 // API to test
 import { Binder, type BinderConfiguration } from '../src/index.js';
-import { type Employee, EmployeeModel, type Order, OrderModel, type TestEntity, TestModel } from './TestModels.js';
+import {
+  type Employee,
+  EmployeeModel,
+  type Order,
+  OrderModel,
+  type TestEntity,
+  TestModel,
+  type Level1,
+  Level1Model,
+  Level2Model,
+} from './TestModels.js';
 
 use(sinonChai);
 
@@ -383,6 +391,32 @@ describe('@hilla/form', () => {
         const superNameNode = binder.for(binder.model.supervisor.fullName);
         binder.clear();
         assert.equal('', superNameNode.value);
+      });
+    });
+
+    @customElement('lit-hierarchy-view')
+    class LitHierarchyView extends LitElement {
+      binder: Binder<Level1, Level1Model>;
+
+      constructor() {
+        super();
+        this.binder = new Binder(this, Level1Model);
+        const level1 = Level1Model.createEmptyValue();
+        const level2 = Level2Model.createEmptyValue();
+        level1.level2 = [level2];
+        this.binder.read(level1);
+      }
+    }
+
+    describe('complex hierarchy', () => {
+      it('should create binder in complex hierarchy', async () => {
+        const litHierarchyView = document.createElement('lit-hierarchy-view') as LitHierarchyView;
+        document.body.appendChild(litHierarchyView);
+        const { binder } = litHierarchyView;
+        await litHierarchyView.updateComplete;
+        for (const item of binder.model.level2) {
+          assert.isDefined(binder.for(item.model.level3.level4.name4).defaultValue);
+        }
       });
     });
   });

--- a/packages/ts/form/test/TestModels.ts
+++ b/packages/ts/form/test/TestModels.ts
@@ -222,3 +222,65 @@ export class WithPossibleCharListModel extends ObjectModel<WithPossibleCharList>
     return this[_getPropertyModel]('charList', StringModel, [true]);
   }
 }
+
+export interface Level4 {
+  name4?: string;
+}
+
+export interface Level3 {
+  level4?: Level4;
+  name3?: string;
+}
+
+export interface Level2 {
+  level3?: Level3;
+  name2?: string;
+}
+
+export interface Level1 {
+  level2?: Array<Level2 | undefined>;
+  name1?: string;
+}
+
+export class Level4Model<T extends Level4 = Level4> extends ObjectModel<T> {
+  declare static createEmptyValue: () => Level4;
+  get name4(): StringModel {
+    return this[_getPropertyModel]('name4', StringModel, [true]) as StringModel;
+  }
+}
+
+export class Level3Model<T extends Level3 = Level3> extends ObjectModel<T> {
+  declare static createEmptyValue: () => Level3;
+  get level4(): Level4Model {
+    return this[_getPropertyModel]('level4', Level4Model, [true]) as Level4Model;
+  }
+
+  get name3(): StringModel {
+    return this[_getPropertyModel]('name3', StringModel, [true]) as StringModel;
+  }
+}
+
+export class Level2Model<T extends Level2 = Level2> extends ObjectModel<T> {
+  declare static createEmptyValue: () => Level2;
+  get level3(): Level3Model {
+    return this[_getPropertyModel]('level3', Level3Model, [true]) as Level3Model;
+  }
+
+  get name2(): StringModel {
+    return this[_getPropertyModel]('name2', StringModel, [true]) as StringModel;
+  }
+}
+
+export class Level1Model<T extends Level1 = Level1> extends ObjectModel<T> {
+  declare static createEmptyValue: () => Level1;
+  get level2(): ArrayModel<Level2, Level2Model> {
+    return this[_getPropertyModel]('level2', ArrayModel, [true, Level2Model, [true]]) as ArrayModel<
+      Level2,
+      Level2Model
+    >;
+  }
+
+  get name1(): StringModel {
+    return this[_getPropertyModel]('name1', StringModel, [true]) as StringModel;
+  }
+}


### PR DESCRIPTION
In forms that have arrays, when `binder.defaultValue` contains array items (for example, when initialized using `.read()`), having deep bindings with array item object was causing an error. The reason is that the binder failed to change the user-defined default value for the array item when initializing deep objects inside the item.

This change makes the binder maintain the user-defined array-item default value applying the same approach to arrays as when initializing optional keys in objects. When it needs to initialize a deep object inside the array item, it automatically changes the value and defaultValue of the array item at the same time, so that both get the deep keys in this case.

Fixes #1294