### PR TITLE
fix(form): inference for generic binder.model type

### DIFF
--- a/packages/ts/form/src/Binder.ts
+++ b/packages/ts/form/src/Binder.ts
@@ -1,7 +1,6 @@
 import type { LitElement } from 'lit';
-import type { Class } from 'type-fest';
 import { BinderRoot, type BinderConfiguration } from './BinderRoot.js';
-import type { AbstractModel } from './Models.js';
+import type { AbstractModel, DetachedModelConstructor } from './Models.js';
 import type { Value } from './Models.js';
 
 /**
@@ -27,7 +26,7 @@ export class Binder<M extends AbstractModel> extends BinderRoot<M> {
    * binder = new Binder(orderView, OrderModel, {onSubmit: async (order) => {endpoint.save(order)}});
    * ```
    */
-  constructor(context: Element, Model: Class<M>, config?: BinderConfiguration<Value<M>>) {
+  constructor(context: Element, Model: DetachedModelConstructor<M>, config?: BinderConfiguration<Value<M>>) {
     const changeCallback =
       config?.onChange ??
       (typeof (context as LitElement).requestUpdate === 'function'

--- a/packages/ts/form/src/Binder.ts
+++ b/packages/ts/form/src/Binder.ts
@@ -1,5 +1,5 @@
 import type { LitElement } from 'lit';
-import type { Constructor } from 'type-fest';
+import type { Class } from 'type-fest';
 import { BinderRoot, type BinderConfiguration } from './BinderRoot.js';
 import type { AbstractModel } from './Models.js';
 import type { Value } from './Models.js';
@@ -27,7 +27,7 @@ export class Binder<M extends AbstractModel> extends BinderRoot<M> {
    * binder = new Binder(orderView, OrderModel, {onSubmit: async (order) => {endpoint.save(order)}});
    * ```
    */
-  constructor(context: Element, Model: Constructor<M>, config?: BinderConfiguration<Value<M>>) {
+  constructor(context: Element, Model: Class<M>, config?: BinderConfiguration<Value<M>>) {
     const changeCallback =
       config?.onChange ??
       (typeof (context as LitElement).requestUpdate === 'function'

--- a/packages/ts/form/src/Models.ts
+++ b/packages/ts/form/src/Models.ts
@@ -44,12 +44,8 @@ export interface ModelOptions<T> {
 }
 
 export type DetachedModelConstructor<M> = {
-  prototype: M;
-  new (
-    parent: typeof modelDetachedParent,
-    key: '$value$',
-    optional: boolean,
-  ): M;
+  prototype: object;
+  new (parent: typeof modelDetachedParent, key: '$value$', optional: boolean): M;
 };
 
 export function createDetachedModel<M extends AbstractModel>(type: DetachedModelConstructor<M>): M {

--- a/packages/ts/form/src/Models.ts
+++ b/packages/ts/form/src/Models.ts
@@ -43,11 +43,14 @@ export interface ModelOptions<T> {
   meta?: ModelMetadata;
 }
 
-export type DetachedModelConstructor<M> = new (
-  parent: typeof modelDetachedParent,
-  key: '$value$',
-  optional: boolean,
-) => M;
+export type DetachedModelConstructor<M> = {
+  prototype: M;
+  new (
+    parent: typeof modelDetachedParent,
+    key: '$value$',
+    optional: boolean,
+  ): M;
+};
 
 export function createDetachedModel<M extends AbstractModel>(type: DetachedModelConstructor<M>): M {
   return new type(modelDetachedParent, '$value$', false);

--- a/packages/ts/form/test/TestModels.ts
+++ b/packages/ts/form/test/TestModels.ts
@@ -85,7 +85,7 @@ export interface Order extends IdEntity {
   customer: Customer;
   notes: string;
   priority: number;
-  products: readonly Product[];
+  products: Product[];
   total?: number;
 }
 
@@ -127,9 +127,9 @@ export interface TestEntity {
   fieldNumber: number;
   fieldBoolean: boolean;
   fieldObject: Record<string, unknown>;
-  fieldArrayString: readonly string[];
-  fieldArrayModel: readonly IdEntity[];
-  fieldMatrixNumber: ReadonlyArray<readonly number[]>;
+  fieldArrayString: string[];
+  fieldArrayModel: IdEntity[];
+  fieldMatrixNumber: number[][];
   fieldEnum: RecordStatus;
   fieldAny: any;
 }


### PR DESCRIPTION
Fixes TypeScript type inference for `binder.model` that was broken after #1252