### PR TITLE
fix: Use the same Typescript version as Flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "simple-git-hooks": "^2.9.0",
         "sync-request": "^6.1.0",
         "tsx": "^3.13.0",
-        "typescript": "5.1.6",
+        "typescript": "^5.1.6",
         "vite": "^4.4.9"
       },
       "engines": {
@@ -12952,7 +12952,6 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13624,23 +13623,10 @@
         "chai-dom": "^1.11.0",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "peerDependencies": {
         "lit": "^2.3.0"
-      }
-    },
-    "packages/ts/form/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/ts/frontend": {
@@ -13668,23 +13654,10 @@
         "fetch-mock": "^9.11.0",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "peerDependencies": {
         "lit": "^2.3.0"
-      }
-    },
-    "packages/ts/frontend/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/ts/generator-typescript-cli": {
@@ -13753,7 +13726,7 @@
         "@hilla/generator-typescript-utils": "*",
         "meow": "^12.1.1",
         "openapi-types": "^12.1.3",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@types/chai": "^4.3.6",
@@ -13793,18 +13766,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-core/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-plugin-backbone": {
       "name": "@hilla/generator-typescript-plugin-backbone",
       "version": "2.3.0-alpha6",
@@ -13813,7 +13774,7 @@
         "@hilla/generator-typescript-utils": "*",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@hilla/generator-typescript-core": "*",
@@ -13860,25 +13821,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-plugin-backbone/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-plugin-barrel": {
       "name": "@hilla/generator-typescript-plugin-barrel",
       "version": "2.3.0-alpha6",
       "license": "Apache 2.0",
       "dependencies": {
         "@hilla/generator-typescript-utils": "*",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@hilla/generator-typescript-core": "*",
@@ -13925,25 +13874,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-plugin-barrel/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-plugin-client": {
       "name": "@hilla/generator-typescript-plugin-client",
       "version": "2.3.0-alpha6",
       "license": "Apache 2.0",
       "dependencies": {
         "@hilla/generator-typescript-utils": "*",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@hilla/generator-typescript-core": "*",
@@ -13988,18 +13925,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-plugin-client/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-plugin-model": {
       "name": "@hilla/generator-typescript-plugin-model",
       "version": "2.3.0-alpha6",
@@ -14008,7 +13933,7 @@
         "@hilla/generator-typescript-utils": "*",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@hilla/generator-typescript-core": "*",
@@ -14056,18 +13981,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-plugin-model/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-plugin-push": {
       "name": "@hilla/generator-typescript-plugin-push",
       "version": "2.3.0-alpha6",
@@ -14076,7 +13989,7 @@
         "@hilla/generator-typescript-utils": "*",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@hilla/generator-typescript-core": "*",
@@ -14123,18 +14036,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-plugin-push/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-plugin-subtypes": {
       "name": "@hilla/generator-typescript-plugin-subtypes",
       "version": "2.3.0-alpha6",
@@ -14143,7 +14044,7 @@
         "@hilla/generator-typescript-utils": "*",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@hilla/generator-typescript-core": "*",
@@ -14192,18 +14093,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-plugin-subtypes/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/generator-typescript-utils": {
       "name": "@hilla/generator-typescript-utils",
       "version": "2.3.0-alpha6",
@@ -14211,7 +14100,7 @@
       "dependencies": {
         "pino": "^8.15.1",
         "pino-pretty": "^10.2.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "devDependencies": {
         "@types/chai": "^4.3.6",
@@ -14251,18 +14140,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/ts/generator-typescript-utils/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts/react-auth": {
       "name": "@hilla/react-auth",
       "version": "2.3.0-alpha6",
@@ -14285,24 +14162,11 @@
         "react-router-dom": "^6.16.0",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "peerDependencies": {
         "react": "^18",
         "react-router-dom": "^6"
-      }
-    },
-    "packages/ts/react-auth/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/ts/react-form": {
@@ -14326,23 +14190,10 @@
         "chai-dom": "^1.11.0",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "peerDependencies": {
         "react": "^18"
-      }
-    },
-    "packages/ts/react-form/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/ts/react-grid": {
@@ -14369,23 +14220,10 @@
         "chai-dom": "^1.11.0",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
       },
       "peerDependencies": {
         "react": "^18"
-      }
-    },
-    "packages/ts/react-grid/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "simple-git-hooks": "^2.9.0",
         "sync-request": "^6.1.0",
         "tsx": "^3.13.0",
-        "typescript": "^5.2.2",
+        "typescript": "5.1.6",
         "vite": "^4.4.9"
       },
       "engines": {
@@ -12949,9 +12949,10 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13629,6 +13630,19 @@
         "lit": "^2.3.0"
       }
     },
+    "packages/ts/form/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/frontend": {
       "name": "@hilla/frontend",
       "version": "2.3.0-alpha6",
@@ -13658,6 +13672,19 @@
       },
       "peerDependencies": {
         "lit": "^2.3.0"
+      }
+    },
+    "packages/ts/frontend/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ts/generator-typescript-cli": {
@@ -13766,6 +13793,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/ts/generator-typescript-core/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/generator-typescript-plugin-backbone": {
       "name": "@hilla/generator-typescript-plugin-backbone",
       "version": "2.3.0-alpha6",
@@ -13821,6 +13860,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/ts/generator-typescript-plugin-backbone/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/generator-typescript-plugin-barrel": {
       "name": "@hilla/generator-typescript-plugin-barrel",
       "version": "2.3.0-alpha6",
@@ -13874,6 +13925,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/ts/generator-typescript-plugin-barrel/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/generator-typescript-plugin-client": {
       "name": "@hilla/generator-typescript-plugin-client",
       "version": "2.3.0-alpha6",
@@ -13923,6 +13986,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/ts/generator-typescript-plugin-client/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ts/generator-typescript-plugin-model": {
@@ -13981,6 +14056,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/ts/generator-typescript-plugin-model/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/generator-typescript-plugin-push": {
       "name": "@hilla/generator-typescript-plugin-push",
       "version": "2.3.0-alpha6",
@@ -14034,6 +14121,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/ts/generator-typescript-plugin-push/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ts/generator-typescript-plugin-subtypes": {
@@ -14093,6 +14192,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/ts/generator-typescript-plugin-subtypes/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/generator-typescript-utils": {
       "name": "@hilla/generator-typescript-utils",
       "version": "2.3.0-alpha6",
@@ -14140,6 +14251,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/ts/generator-typescript-utils/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/react-auth": {
       "name": "@hilla/react-auth",
       "version": "2.3.0-alpha6",
@@ -14169,6 +14292,19 @@
         "react-router-dom": "^6"
       }
     },
+    "packages/ts/react-auth/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ts/react-form": {
       "name": "@hilla/react-form",
       "version": "2.3.0-alpha6",
@@ -14194,6 +14330,19 @@
       },
       "peerDependencies": {
         "react": "^18"
+      }
+    },
+    "packages/ts/react-form/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ts/react-grid": {
@@ -14224,6 +14373,19 @@
       },
       "peerDependencies": {
         "react": "^18"
+      }
+    },
+    "packages/ts/react-grid/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "simple-git-hooks": "^2.9.0",
         "sync-request": "^6.1.0",
         "tsx": "^3.13.0",
-        "typescript": "^5.1.6",
+        "typescript": "5.1.6",
         "vite": "^4.4.9"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "simple-git-hooks": "^2.9.0",
     "sync-request": "^6.1.0",
     "tsx": "^3.13.0",
-    "typescript": "^5.2.2",
+    "typescript": "5.1.6",
     "vite": "^4.4.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "simple-git-hooks": "^2.9.0",
     "sync-request": "^6.1.0",
     "tsx": "^3.13.0",
-    "typescript": "5.1.6",
+    "typescript": "^5.1.6",
     "vite": "^4.4.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "simple-git-hooks": "^2.9.0",
     "sync-request": "^6.1.0",
     "tsx": "^3.13.0",
-    "typescript": "^5.1.6",
+    "typescript": "5.1.6",
     "vite": "^4.4.9"
   }
 }

--- a/packages/ts/form/package.json
+++ b/packages/ts/form/package.json
@@ -85,6 +85,6 @@
     "chai-dom": "^1.11.0",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/ts/frontend/package.json
+++ b/packages/ts/frontend/package.json
@@ -83,6 +83,6 @@
     "fetch-mock": "^9.11.0",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/ts/generator-typescript-core/package.json
+++ b/packages/ts/generator-typescript-core/package.json
@@ -75,7 +75,7 @@
     "@hilla/generator-typescript-utils": "*",
     "meow": "^12.1.1",
     "openapi-types": "^12.1.3",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@types/chai": "^4.3.6",

--- a/packages/ts/generator-typescript-plugin-backbone/package.json
+++ b/packages/ts/generator-typescript-plugin-backbone/package.json
@@ -58,7 +58,7 @@
     "@hilla/generator-typescript-utils": "*",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@hilla/generator-typescript-core": "*",

--- a/packages/ts/generator-typescript-plugin-barrel/package.json
+++ b/packages/ts/generator-typescript-plugin-barrel/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "*",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@hilla/generator-typescript-core": "*",

--- a/packages/ts/generator-typescript-plugin-client/package.json
+++ b/packages/ts/generator-typescript-plugin-client/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@hilla/generator-typescript-utils": "*",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@hilla/generator-typescript-core": "*",

--- a/packages/ts/generator-typescript-plugin-model/package.json
+++ b/packages/ts/generator-typescript-plugin-model/package.json
@@ -59,7 +59,7 @@
     "@hilla/generator-typescript-utils": "*",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@hilla/generator-typescript-core": "*",

--- a/packages/ts/generator-typescript-plugin-push/package.json
+++ b/packages/ts/generator-typescript-plugin-push/package.json
@@ -58,7 +58,7 @@
     "@hilla/generator-typescript-utils": "*",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@hilla/generator-typescript-core": "*",

--- a/packages/ts/generator-typescript-plugin-subtypes/package.json
+++ b/packages/ts/generator-typescript-plugin-subtypes/package.json
@@ -58,7 +58,7 @@
     "@hilla/generator-typescript-utils": "*",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@hilla/generator-typescript-core": "*",

--- a/packages/ts/generator-typescript-utils/package.json
+++ b/packages/ts/generator-typescript-utils/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "pino": "^8.15.1",
     "pino-pretty": "^10.2.0",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@types/chai": "^4.3.6",

--- a/packages/ts/react-auth/package.json
+++ b/packages/ts/react-auth/package.json
@@ -67,6 +67,6 @@
     "react-router-dom": "^6.16.0",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/ts/react-form/package.json
+++ b/packages/ts/react-form/package.json
@@ -65,6 +65,6 @@
     "chai-dom": "^1.11.0",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }

--- a/packages/ts/react-grid/package.json
+++ b/packages/ts/react-grid/package.json
@@ -69,6 +69,6 @@
     "chai-dom": "^1.11.0",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.2.2"
+    "typescript": "5.1.6"
   }
 }


### PR DESCRIPTION
This should fix problems with multiple TypeScript versions being mixed and TypeScript 5.2 installed in node_modules/@hilla/something/node_modules
