### PR TITLE
feat: generate JPA relationship annotations

### DIFF
--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -35,8 +35,10 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
     private static final String VALIDATION_CONSTRAINTS_PACKAGE_NAME = "jakarta.validation.constraints";
 
     // Include-list of annotations that should be added to the schema
-    private static final Set<String> INCLUDED_ANNOTATIONS = Set
-            .of("jakarta.persistence.Id", "jakarta.persistence.Version");
+    private static final Set<String> INCLUDED_ANNOTATIONS = Set.of(
+            "jakarta.persistence.Id", "jakarta.persistence.Version",
+            "jakarta.persistence.OneToOne", "jakarta.persistence.ManyToOne",
+            "jakarta.persistence.OneToMany", "jakarta.persistence.ManyToMany");
 
     public ModelPlugin() {
         super();

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsEndpoint.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsEndpoint.java
@@ -5,8 +5,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Version;
+
+import java.util.List;
 
 @Endpoint
 public class AnnotationsEndpoint {
@@ -22,6 +28,18 @@ public class AnnotationsEndpoint {
 
         private int version;
 
+        @OneToOne
+        public NestedEntity oneToOne;
+
+        @OneToMany
+        public List<NestedEntity> oneToMany;
+
+        @ManyToOne
+        public NestedEntity manyToOne;
+
+        @ManyToMany
+        public List<NestedEntity> manyToMany;
+
         @Column(name = "test_column")
         public String name;
 
@@ -33,5 +51,9 @@ public class AnnotationsEndpoint {
         public void setVersion(int version) {
             this.version = version;
         }
+    }
+
+    public static class NestedEntity {
+        public String name;
     }
 }

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
@@ -69,6 +69,78 @@
               }
             ]
           },
+          "oneToOne" : {
+            "nullable" : true,
+            "anyOf" : [
+              {
+                "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$NestedEntity"
+              }
+            ],
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.OneToOne"
+              }
+            ]
+          },
+          "oneToMany" : {
+            "type" : "array",
+            "nullable" : true,
+            "items" : {
+              "nullable" : true,
+              "anyOf" : [
+                {
+                  "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$NestedEntity"
+                }
+              ]
+            },
+            "x-java-type" : "java.util.List",
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.OneToMany"
+              }
+            ]
+          },
+          "manyToOne" : {
+            "nullable" : true,
+            "anyOf" : [
+              {
+                "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$NestedEntity"
+              }
+            ],
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.ManyToOne"
+              }
+            ]
+          },
+          "manyToMany" : {
+            "type" : "array",
+            "nullable" : true,
+            "items" : {
+              "nullable" : true,
+              "anyOf" : [
+                {
+                  "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$NestedEntity"
+                }
+              ]
+            },
+            "x-java-type" : "java.util.List",
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.ManyToMany"
+              }
+            ]
+          },
+          "name" : {
+            "type" : "string",
+            "nullable" : true,
+            "x-java-type" : "java.lang.String"
+          }
+        }
+      },
+      "dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$NestedEntity" : {
+        "type" : "object",
+        "properties" : {
           "name" : {
             "type" : "string",
             "nullable" : true,

--- a/packages/ts/generator-typescript-plugin-model/src/ModelSchemaProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-model/src/ModelSchemaProcessor.ts
@@ -229,13 +229,13 @@ export class ModelSchemaExpressionProcessor extends ModelSchemaPartProcessor<rea
   }
 
   override process(): readonly ts.Expression[] {
-    const schema = this[$schema];
+    const originalSchema = this[$originalSchema];
 
     let result = super.process();
 
     const modelOptionsProperties = [
-      this.#createValidatorsProperty(schema),
-      this.#createMetadataProperty(schema),
+      this.#createValidatorsProperty(originalSchema),
+      this.#createMetadataProperty(originalSchema),
     ].filter(Boolean) as PropertyAssignment[];
 
     if (modelOptionsProperties.length > 0) {
@@ -244,7 +244,7 @@ export class ModelSchemaExpressionProcessor extends ModelSchemaPartProcessor<rea
       result = [...result, optionsObject];
     }
 
-    return [isNullableSchema(this[$originalSchema]) ? ts.factory.createTrue() : ts.factory.createFalse(), ...result];
+    return [isNullableSchema(originalSchema) ? ts.factory.createTrue() : ts.factory.createFalse(), ...result];
   }
 
   protected override [$processArray](schema: ArraySchema): readonly Expression[] {

--- a/packages/ts/generator-typescript-plugin-model/test/model/Model.json
+++ b/packages/ts/generator-typescript-plugin-model/test/model/Model.json
@@ -368,6 +368,18 @@
               }
             ],
             "x-java-type": "java.lang.Long"
+          },
+          "nestedModelWithAnnotations" : {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/com.example.application.endpoints.TsFormEndpoint.FormEntity"
+              }
+            ],
+            "x-annotations": [
+              {
+                "name": "jakarta.persistence.OneToOne"
+              }
+            ]
           }
         }
       },

--- a/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityMetadataModel.snap.ts
+++ b/packages/ts/generator-typescript-plugin-model/test/model/fixtures/FormEntityMetadataModel.snap.ts
@@ -1,5 +1,6 @@
 import { _getPropertyModel as _getPropertyModel_1, ArrayModel as ArrayModel_1, makeObjectEmptyValueCreator as makeObjectEmptyValueCreator_1, NumberModel as NumberModel_1, ObjectModel as ObjectModel_1, StringModel as StringModel_1 } from "@hilla/form";
 import type FormEntityMetadata_1 from "./FormEntityMetadata.js";
+import FormEntityModel_1 from "./FormEntityModel.js";
 class FormEntityMetadataModel<T extends FormEntityMetadata_1 = FormEntityMetadata_1> extends ObjectModel_1<T> {
     static override createEmptyValue = makeObjectEmptyValueCreator_1(FormEntityMetadataModel);
     get withoutMetadata(): StringModel_1 {
@@ -19,6 +20,9 @@ class FormEntityMetadataModel<T extends FormEntityMetadata_1 = FormEntityMetadat
     }
     get withAll(): NumberModel_1 {
         return this[_getPropertyModel_1]("withAll", (parent, key) => new NumberModel_1(parent, key, false, { meta: { annotations: [{ name: "jakarta.persistence.Id" }, { name: "jakarta.persistence.Version" }], javaType: "java.lang.Long" } }));
+    }
+    get nestedModelWithAnnotations(): FormEntityModel_1 {
+        return this[_getPropertyModel_1]("nestedModelWithAnnotations", (parent, key) => new FormEntityModel_1(parent, key, false, { meta: { annotations: [{ name: "jakarta.persistence.OneToOne" }] } }));
     }
 }
 export default FormEntityMetadataModel;


### PR DESCRIPTION
Add support for generating JPA relationship annotations. Also fixes generator to use the property schema for generating metadata when handling nested models.