### PR TITLE
feat: implement locale specific date parser

### DIFF
--- a/packages/ts/react-grid/src/date-formatter.ts
+++ b/packages/ts/react-grid/src/date-formatter.ts
@@ -1,5 +1,5 @@
 function getFormatRegex(format: Intl.DateTimeFormat) {
-  const sampleDate = new Date(1234, 5-1, 6);
+  const sampleDate = new Date(1234, 5 - 1, 6);
   const formattedSample = format.format(sampleDate);
   const pattern = formattedSample
     .replace('1234', '(?<year>\\d+)')

--- a/packages/ts/react-grid/src/date-formatter.ts
+++ b/packages/ts/react-grid/src/date-formatter.ts
@@ -1,5 +1,5 @@
 function getFormatRegex(format: Intl.DateTimeFormat) {
-  const sampleDate = new Date(1234, 4, 6);
+  const sampleDate = new Date(1234, 5-1, 6);
   const formattedSample = format.format(sampleDate);
   const pattern = formattedSample
     .replace('1234', '(?<year>\\d+)')

--- a/packages/ts/react-grid/src/date-formatter.ts
+++ b/packages/ts/react-grid/src/date-formatter.ts
@@ -1,0 +1,54 @@
+function getFormatRegex(format: Intl.DateTimeFormat) {
+  const sampleDate = new Date(1234, 4, 6);
+  const formattedSample = format.format(sampleDate);
+  const pattern = formattedSample
+    .replace('1234', '(?<year>\\d+)')
+    .replace('05', '(?<month>\\d+)')
+    .replace('5', '(?<month>\\d+)')
+    .replace('06', '(?<day>\\d+)')
+    .replace('6', '(?<day>\\d+)');
+
+  return new RegExp(pattern, 'u');
+}
+
+export interface DateObject {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export class DateFormatter {
+  private readonly _format: Intl.DateTimeFormat;
+  private readonly _formatRegex: RegExp;
+
+  constructor(locale?: string) {
+    this._format = new Intl.DateTimeFormat(locale);
+    this._formatRegex = getFormatRegex(this._format);
+  }
+
+  format(date: DateObject): string {
+    const dateInstance = new Date();
+    dateInstance.setFullYear(date.year);
+    dateInstance.setMonth(date.month);
+    dateInstance.setDate(date.day);
+    return this._format.format(dateInstance);
+  }
+
+  parse(dateString: string): DateObject | null {
+    const match = this._formatRegex.exec(dateString);
+    const year = Number(match?.groups?.year);
+    const month = Number(match?.groups?.month) - 1;
+    const day = Number(match?.groups?.day);
+
+    // Verify that the parsed date is valid
+    const dateInstance = new Date();
+    dateInstance.setFullYear(year);
+    dateInstance.setMonth(month);
+    dateInstance.setDate(day);
+    if (dateInstance.getFullYear() !== year || dateInstance.getMonth() !== month || dateInstance.getDate() !== day) {
+      return null;
+    }
+
+    return { year, month, day };
+  }
+}

--- a/packages/ts/react-grid/test/date-formatter.spec.ts
+++ b/packages/ts/react-grid/test/date-formatter.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from '@esm-bundle/chai';
+import { type DateObject, DateFormatter } from '../src/date-formatter';
+
+describe('DateFormatter', () => {
+  const testCases = [
+    { locale: 'en-US', input: '5/7/2020', output: '5/7/2020', iso: '2020-05-07' },
+    { locale: 'en-US', input: '05/07/2020', output: '5/7/2020', iso: '2020-05-07' },
+    { locale: 'en-US', input: '12/31/2020', output: '12/31/2020', iso: '2020-12-31' },
+    { locale: 'en-US', input: '5/7/1999', output: '5/7/1999', iso: '1999-05-07' },
+    { locale: 'en-US', input: '5/7/999', output: '5/7/999', iso: '0999-05-07' },
+    { locale: 'en-US', input: '5/7/99', output: '5/7/99', iso: '0099-05-07' },
+    { locale: 'de-DE', input: '7.5.2020', output: '7.5.2020', iso: '2020-05-07' },
+    { locale: 'de-DE', input: '07.05.2020', output: '7.5.2020', iso: '2020-05-07' },
+    { locale: 'de-DE', input: '31.12.2020', output: '31.12.2020', iso: '2020-12-31' },
+    { locale: 'de-DE', input: '7.5.1999', output: '7.5.1999', iso: '1999-05-07' },
+    { locale: 'de-DE', input: '7.5.999', output: '7.5.999', iso: '0999-05-07' },
+    { locale: 'de-DE', input: '7.5.99', output: '7.5.99', iso: '0099-05-07' },
+    { locale: 'ko-KR', input: '2020. 5. 7.', output: '2020. 5. 7.', iso: '2020-05-07' },
+    { locale: 'ko-KR', input: '2020. 05. 07.', output: '2020. 5. 7.', iso: '2020-05-07' },
+    { locale: 'ko-KR', input: '2020. 12. 31.', output: '2020. 12. 31.', iso: '2020-12-31' },
+    { locale: 'ko-KR', input: '1999. 12. 31.', output: '1999. 12. 31.', iso: '1999-12-31' },
+    { locale: 'ko-KR', input: '999. 12. 31.', output: '999. 12. 31.', iso: '0999-12-31' },
+    { locale: 'ko-KR', input: '99. 12. 31.', output: '99. 12. 31.', iso: '0099-12-31' },
+    { locale: 'bg', input: '7.5.2020 г.', output: '7.05.2020 г.', iso: '2020-05-07' },
+    { locale: 'bg', input: '07.05.2020 г.', output: '7.05.2020 г.', iso: '2020-05-07' },
+    { locale: 'bg', input: '31.12.2020 г.', output: '31.12.2020 г.', iso: '2020-12-31' },
+    { locale: 'bg', input: '5.07.1999 г.', output: '5.07.1999 г.', iso: '1999-07-05' },
+    { locale: 'bg', input: '5.07.999 г.', output: '5.07.999 г.', iso: '0999-07-05' },
+    { locale: 'bg', input: '5.07.99 г.', output: '5.07.99 г.', iso: '0099-07-05' },
+  ];
+
+  it('should format and parse dates', () => {
+    function toIso(dateObject: DateObject) {
+      const day = dateObject.day.toString().padStart(2, '0');
+      const month = (dateObject.month + 1).toString().padStart(2, '0');
+      const year = dateObject.year.toString().padStart(4, '0');
+      return `${year}-${month}-${day}`;
+    }
+
+    function fromIso(iso: string): DateObject {
+      const [year, month, day] = iso.split('-').map(Number);
+      return { year, month: month - 1, day };
+    }
+
+    testCases.forEach((testCase) => {
+      const { locale, iso, input, output } = testCase;
+      const formatter = new DateFormatter(locale);
+
+      const parsedDate = formatter.parse(input);
+      expect(parsedDate, `Failed to parse date in ${locale}: ${input}`).to.not.be.null;
+      const parsedIso = toIso(parsedDate!);
+      expect(parsedIso, `Parsing date in locale ${locale} returned wrong result`).to.equal(iso);
+
+      const formattedDate = formatter.format(fromIso(iso));
+      expect(formattedDate, `Formatting date in locale ${locale} returned wrong result`).to.equal(output);
+    });
+  });
+
+  it('should return null when parsing invalid dates', () => {
+    const formatter = new DateFormatter('en-US');
+
+    expect(formatter.parse('')).to.be.null;
+    expect(formatter.parse('23')).to.be.null;
+    expect(formatter.parse('11/23')).to.be.null;
+    expect(formatter.parse('11/32/2020')).to.be.null;
+    expect(formatter.parse('23/23/2020')).to.be.null;
+    expect(formatter.parse('0/23/2020')).to.be.null;
+    expect(formatter.parse('11/0/2020')).to.be.null;
+  });
+});


### PR DESCRIPTION
## Description

Implements locale-specific parsing of dates, as a pre-requisite for being able to parse and format dates in date pickers in the same format that is used for rendering cells (https://github.com/vaadin/hilla/pull/1442). The implementation is loosely based on that of the Flow component. The basic idea is to format an example date with a specific locale, and use that to extract a Regex pattern that allows to parse a date in that format in reverse. 

This implementation is far from perfect: there is no leniency for additional or missing whitespace, it does not handle dates before 0 (mostly because Intl.DateTimeFormat doesn't), only works with arabic numerals etc. 

Using a library like `date-fns` would help with some of those issues. But it doesn't solve figuring out which date format to use based on the current browser locale, so reverse engineering the pattern from a sample date would still be necessary.