### PR TITLE
feat: throw if an @EndpointExposed class contains AccessControl annotations

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Parser.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Parser.java
@@ -3,13 +3,19 @@ package dev.hilla.parser.core;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
-import io.github.classgraph.AnnotationInfo;
 import io.github.classgraph.ClassInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Parser.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Parser.java
@@ -1,18 +1,16 @@
 package dev.hilla.parser.core;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.ClassInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +24,22 @@ import io.swagger.v3.oas.models.OpenAPI;
 public final class Parser {
     private static final Logger logger = LoggerFactory.getLogger(Parser.class);
     private final Config config;
+
+    private static final String ENDPOINT_EXPOSED_AND_ACL_ANNOTATIONS_ERROR_TEMPLATE = """
+            Class `%s` is annotated with `%s` and `%s` annotation. %n
+            Classes annotated with `%s` should not contain any of access control annotations and %n
+            this exception is for preventing the confusion. The class level access control rules of the child class %n
+            will be applied for the inherited methods of this class. If the access control rules for an inherited %n
+            method should not follow the rules of the child endpoint, that method should be overridden and annotated %n
+            with the desired access control annotations explicitly.%n
+            """
+            .stripIndent();
+
+    private static final Set<String> ACL_ANNOTATIONS = Set.of(
+            "jakarta.annotation.security.DenyAll",
+            "jakarta.annotation.security.PermitAll",
+            "jakarta.annotation.security.RolesAllowed",
+            "com.vaadin.flow.server.auth.AnonymousAllowed");
 
     public Parser() {
         try {
@@ -309,6 +323,7 @@ public final class Parser {
         }
 
         try (var scanResult = classGraph.scan()) {
+            validateEndpointExposedClassesForAclAnnotations(scanResult);
             var rootNode = new RootNode(new ScanResult(scanResult),
                     storage.getOpenAPI());
             var pluginManager = new PluginManager(
@@ -321,6 +336,47 @@ public final class Parser {
         logger.debug("JVM Parser finished successfully");
 
         return storage.getOpenAPI();
+    }
+
+    private void validateEndpointExposedClassesForAclAnnotations(
+            io.github.classgraph.ScanResult scanResult) {
+
+        Optional.ofNullable(config.getEndpointExposedAnnotationName())
+                .ifPresent(endpointExposedAnnotation -> scanResult
+                        .getClassesWithAnnotation(endpointExposedAnnotation)
+                        .forEach(classInfo -> {
+                            checkClassLevelAnnotation(classInfo);
+                            checkMethodLevelAnnotation(classInfo);
+                        }));
+    }
+
+    private void checkClassLevelAnnotation(ClassInfo classInfo) {
+        classInfo.getAnnotationInfo()
+                .forEach(annotationInfo -> throwIfAnnotationIsAclAnnotation(
+                        annotationInfo.getName(), classInfo));
+    }
+
+    private void checkMethodLevelAnnotation(ClassInfo classInfo) {
+        for (Method method : classInfo.loadClass().getMethods()) {
+            var annotations = method.getDeclaredAnnotations();
+            for (Annotation annotation : annotations) {
+                throwIfAnnotationIsAclAnnotation(
+                        annotation.annotationType().getName(), classInfo);
+            }
+        }
+    }
+
+    private void throwIfAnnotationIsAclAnnotation(String annotationName,
+            ClassInfo classInfo) {
+        var endpointExposedAnnotation = config
+                .getEndpointExposedAnnotationName();
+
+        if (ACL_ANNOTATIONS.contains(annotationName)) {
+            throw new ParserException(String.format(
+                    ENDPOINT_EXPOSED_AND_ACL_ANNOTATIONS_ERROR_TEMPLATE,
+                    classInfo.getName(), endpointExposedAnnotation,
+                    annotationName, endpointExposedAnnotation));
+        }
     }
 
     /**

--- a/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Parser.java
+++ b/packages/java/parser-jvm-core/src/main/java/dev/hilla/parser/core/Parser.java
@@ -33,11 +33,11 @@ public final class Parser {
 
     private static final String ENDPOINT_EXPOSED_AND_ACL_ANNOTATIONS_ERROR_TEMPLATE = """
             Class `%s` is annotated with `%s` and `%s` annotation. %n
-            Classes annotated with `%s` should not contain any of access control annotations and %n
-            this exception is for preventing the confusion. The class level access control rules of the child class %n
-            will be applied for the inherited methods of this class. If the access control rules for an inherited %n
-            method should not follow the rules of the child endpoint, that method should be overridden and annotated %n
-            with the desired access control annotations explicitly.%n
+            Classes annotated with `%s` must not contain any of access control annotations and %n
+            this exception is for preventing the application startup with misconfiguration. The class level access %n
+            control rules of the child class will be applied for the inherited methods of this class. If the access %n
+            control rules for an inherited method should not follow the rules of the child endpoint, that method %n
+            should be overridden and annotated with the desired access control annotations explicitly. %n
             """
             .stripIndent();
 

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/Endpoint.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/Endpoint.java
@@ -1,0 +1,11 @@
+package dev.hilla.parser.core.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Endpoint {
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/EndpointExposed.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/EndpointExposed.java
@@ -1,0 +1,11 @@
+package dev.hilla.parser.core.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EndpointExposed {
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/classlevel/EndpointExposedAndSecurityAnnotationTest.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/classlevel/EndpointExposedAndSecurityAnnotationTest.java
@@ -1,0 +1,45 @@
+package dev.hilla.parser.core.security.classlevel;
+
+import dev.hilla.parser.core.Parser;
+import dev.hilla.parser.core.ParserException;
+import dev.hilla.parser.core.basic.Endpoint;
+import dev.hilla.parser.core.security.EndpointExposed;
+import dev.hilla.parser.testutils.ResourceLoader;
+import org.junit.jupiter.api.Test;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EndpointExposedAndSecurityAnnotationTest {
+
+    private final List<String> classPath;
+    private final ResourceLoader resourceLoader = new ResourceLoader(
+            getClass());
+
+    {
+        try {
+            classPath = List.of(resourceLoader.findTargetDirPath().toString());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void throws_when_parentEndpointClass_annotatedWithSecurityAnnotations() {
+        var exception = assertThrows(ParserException.class, () -> new Parser()
+                .classLoader(getClass().getClassLoader()).classPath(classPath)
+                .exposedPackages(
+                        Set.of("dev.hilla.parser.core.security.classlevel"))
+                .endpointAnnotation(Endpoint.class.getName())
+                .endpointExposedAnnotation(EndpointExposed.class.getName())
+                .execute());
+
+        assertTrue(exception.getMessage().startsWith(
+                "Class `dev.hilla.parser.core.security.classlevel.ParentEndpoint` is annotated with `dev.hilla.parser.core.security.EndpointExposed` and `jakarta.annotation.security.RolesAllowed` annotation."));
+
+    }
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/classlevel/ParentEndpoint.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/classlevel/ParentEndpoint.java
@@ -1,0 +1,14 @@
+package dev.hilla.parser.core.security.classlevel;
+
+import dev.hilla.parser.core.security.EndpointExposed;
+import jakarta.annotation.security.RolesAllowed;
+
+@RolesAllowed("admin")
+@EndpointExposed
+public class ParentEndpoint {
+
+    public String getSensitiveData() {
+        return "sensitive data";
+    }
+
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/classlevel/SomeEndpoint.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/classlevel/SomeEndpoint.java
@@ -1,0 +1,10 @@
+package dev.hilla.parser.core.security.classlevel;
+
+import dev.hilla.parser.core.security.Endpoint;
+import jakarta.annotation.security.PermitAll;
+
+@PermitAll
+@Endpoint
+public class SomeEndpoint extends ParentEndpoint {
+
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/methodlevel/AnotherEndpoint.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/methodlevel/AnotherEndpoint.java
@@ -1,0 +1,10 @@
+package dev.hilla.parser.core.security.methodlevel;
+
+import dev.hilla.parser.core.security.Endpoint;
+import jakarta.annotation.security.PermitAll;
+
+@PermitAll
+@Endpoint
+public class AnotherEndpoint extends ParentEndpoint {
+
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/methodlevel/EndpointExposedMethodAndSecurityAnnotationTest.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/methodlevel/EndpointExposedMethodAndSecurityAnnotationTest.java
@@ -1,0 +1,45 @@
+package dev.hilla.parser.core.security.methodlevel;
+
+import dev.hilla.parser.core.Parser;
+import dev.hilla.parser.core.ParserException;
+import dev.hilla.parser.core.basic.Endpoint;
+import dev.hilla.parser.core.security.EndpointExposed;
+import dev.hilla.parser.testutils.ResourceLoader;
+import org.junit.jupiter.api.Test;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EndpointExposedMethodAndSecurityAnnotationTest {
+
+    private final List<String> classPath;
+    private final ResourceLoader resourceLoader = new ResourceLoader(
+            getClass());
+
+    {
+        try {
+            classPath = List.of(resourceLoader.findTargetDirPath().toString());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void throws_when_parentEndpointMethod_annotatedWithSecurityAnnotations() {
+        var exception = assertThrows(ParserException.class, () -> new Parser()
+                .classLoader(getClass().getClassLoader()).classPath(classPath)
+                .exposedPackages(
+                        Set.of("dev.hilla.parser.core.security.methodlevel"))
+                .endpointAnnotation(Endpoint.class.getName())
+                .endpointExposedAnnotation(EndpointExposed.class.getName())
+                .execute());
+
+        assertTrue(exception.getMessage().startsWith(
+                "Class `dev.hilla.parser.core.security.methodlevel.ParentEndpoint` is annotated with `dev.hilla.parser.core.security.EndpointExposed` and `jakarta.annotation.security.RolesAllowed` annotation."));
+
+    }
+}

--- a/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/methodlevel/ParentEndpoint.java
+++ b/packages/java/parser-jvm-core/src/test/java/dev/hilla/parser/core/security/methodlevel/ParentEndpoint.java
@@ -1,0 +1,13 @@
+package dev.hilla.parser.core.security.methodlevel;
+
+import dev.hilla.parser.core.security.EndpointExposed;
+import jakarta.annotation.security.RolesAllowed;
+
+@EndpointExposed
+public class ParentEndpoint {
+
+    @RolesAllowed("admin")
+    public String getSensibleData() {
+        return "sensitive data";
+    }
+}


### PR DESCRIPTION
## Description

Throw a ParserException if an `@EndpointExposed` class contains AccessControl annotations.

Fixes #1314

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
