### PR TITLE
feat: add support for header filtering of nested properties

### DIFF
--- a/packages/java/endpoint/src/main/java/dev/hilla/crud/JpaFilterConverter.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/crud/JpaFilterConverter.java
@@ -6,6 +6,8 @@ import dev.hilla.crud.filter.AndFilter;
 import dev.hilla.crud.filter.Filter;
 import dev.hilla.crud.filter.OrFilter;
 import dev.hilla.crud.filter.PropertyStringFilter;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
@@ -39,17 +41,34 @@ public class JpaFilterConverter {
             return Specification.anyOf(filter.getChildren().stream()
                     .map(f -> toSpec(f, entity)).toList());
         } else if (rawFilter instanceof PropertyStringFilter filter) {
-            Class<?> javaType = em.getMetamodel().entity(entity)
-                    .getAttribute(filter.getPropertyId()).getJavaType();
-
+            Class<?> javaType = extractPropertyJavaType(entity,
+                    filter.getPropertyId());
             return new PropertyStringFilterSpecification<>(filter, javaType);
-
         } else {
             if (rawFilter != null) {
                 throw new IllegalArgumentException("Unknown filter type "
                         + rawFilter.getClass().getName());
             }
             return Specification.anyOf();
+        }
+    }
+
+    private Class<?> extractPropertyJavaType(Class<?> entity,
+            String propertyId) {
+        if (propertyId.contains(".")) {
+            String[] parts = propertyId.split("\\.");
+            Root<?> root = em.getCriteriaBuilder().createQuery(entity)
+                    .from(entity);
+            Path<?> path = root.get(parts[0]);
+            int i = 1;
+            while (i < parts.length) {
+                path = path.get(parts[i]);
+                i++;
+            }
+            return path.getJavaType();
+        } else {
+            return em.getMetamodel().entity(entity).getAttribute(propertyId)
+                    .getJavaType();
         }
     }
 

--- a/packages/java/endpoint/src/main/java/dev/hilla/crud/PropertyStringFilterSpecification.java
+++ b/packages/java/endpoint/src/main/java/dev/hilla/crud/PropertyStringFilterSpecification.java
@@ -18,8 +18,8 @@ import org.springframework.data.jpa.domain.Specification;
 
 public class PropertyStringFilterSpecification<T> implements Specification<T> {
 
-    private PropertyStringFilter filter;
-    private Class<?> javaType;
+    private final PropertyStringFilter filter;
+    private final Class<?> javaType;
 
     public PropertyStringFilterSpecification(PropertyStringFilter filter,
             Class<?> javaType) {
@@ -31,7 +31,7 @@ public class PropertyStringFilterSpecification<T> implements Specification<T> {
     public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query,
             CriteriaBuilder criteriaBuilder) {
         String value = filter.getFilterValue();
-        Path<String> propertyPath = root.get(filter.getPropertyId());
+        Path<String> propertyPath = getPath(filter.getPropertyId(), root);
         if (javaType == String.class) {
             Expression<String> expr = criteriaBuilder.lower(propertyPath);
             switch (filter.getMatcher()) {
@@ -157,6 +157,17 @@ public class PropertyStringFilterSpecification<T> implements Specification<T> {
         return javaType == int.class || javaType == Integer.class
                 || javaType == double.class || javaType == Double.class
                 || javaType == long.class || javaType == Long.class;
+    }
+
+    private Path<String> getPath(String propertyId, Root<T> root) {
+        String[] parts = propertyId.split("\\.");
+        Path<String> path = root.get(parts[0]);
+        int i = 1;
+        while (i < parts.length) {
+            path = path.get(parts[i]);
+            i++;
+        }
+        return path;
     }
 
     private boolean isBoolean(Class<?> javaType) {

--- a/packages/java/endpoint/src/test/java/dev/hilla/crud/FilterTest.java
+++ b/packages/java/endpoint/src/test/java/dev/hilla/crud/FilterTest.java
@@ -29,27 +29,30 @@ public class FilterTest {
 
     @Autowired
     private TestRepository repository;
+
     @Autowired
     private JpaFilterConverter jpaFilterConverter;
 
     @Test
     public void filterStringPropertyUsingContains() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter = createNameFilter(Matcher.CONTAINS, "Jo");
+        PropertyStringFilter filter = createFilter("name", Matcher.CONTAINS,
+                "Jo");
         assertFilterResult(filter, "John", "Johnny", "Josh");
     }
 
     @Test
     public void filterStringPropertyUsingEquals() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter = createNameFilter(Matcher.EQUALS, "John");
+        PropertyStringFilter filter = createFilter("name", Matcher.EQUALS,
+                "John");
         assertFilterResult(filter, "John");
     }
 
     @Test(expected = InvalidDataAccessApiUsageException.class)
     public void filterStringPropertyUsingLessThan() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter = createNameFilter(Matcher.LESS_THAN,
+        PropertyStringFilter filter = createFilter("name", Matcher.LESS_THAN,
                 "John");
         executeFilter(filter);
     }
@@ -57,7 +60,7 @@ public class FilterTest {
     @Test(expected = InvalidDataAccessApiUsageException.class)
     public void filterStringPropertyUsingGreaterThan() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter = createNameFilter(Matcher.GREATER_THAN,
+        PropertyStringFilter filter = createFilter("name", Matcher.GREATER_THAN,
                 "John");
         executeFilter(filter);
     }
@@ -65,7 +68,7 @@ public class FilterTest {
     @Test(expected = InvalidDataAccessApiUsageException.class)
     public void filterNumberPropertyUsingContains() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter = createIdFilter(Matcher.CONTAINS, "2");
+        PropertyStringFilter filter = createFilter("id", Matcher.CONTAINS, "2");
         executeFilter(filter);
     }
 
@@ -74,7 +77,7 @@ public class FilterTest {
         List<TestObject> created = setupNames("Jack", "John", "Johnny", "Polly",
                 "Josh");
         Integer johnId = created.get(1).getId();
-        PropertyStringFilter filter = createIdFilter(Matcher.EQUALS,
+        PropertyStringFilter filter = createFilter("id", Matcher.EQUALS,
                 johnId + "");
         assertFilterResult(filter, "John");
     }
@@ -84,7 +87,7 @@ public class FilterTest {
         List<TestObject> created = setupNames("Jack", "John", "Johnny", "Polly",
                 "Josh");
         Integer johnnyId = created.get(2).getId();
-        PropertyStringFilter filter = createIdFilter(Matcher.LESS_THAN,
+        PropertyStringFilter filter = createFilter("id", Matcher.LESS_THAN,
                 johnnyId + "");
         assertFilterResult(filter, "Jack", "John");
     }
@@ -94,7 +97,7 @@ public class FilterTest {
         List<TestObject> created = setupNames("Jack", "John", "Johnny", "Polly",
                 "Josh");
         Integer johnnyId = created.get(2).getId();
-        PropertyStringFilter filter = createIdFilter(Matcher.GREATER_THAN,
+        PropertyStringFilter filter = createFilter("id", Matcher.GREATER_THAN,
                 johnnyId + "");
         assertFilterResult(filter, "Polly", "Josh");
     }
@@ -102,8 +105,8 @@ public class FilterTest {
     @Test(expected = InvalidDataAccessApiUsageException.class)
     public void filterBooleanPropertyUsingContains() {
         setupBooleans();
-        PropertyStringFilter filter = createBooleanFilter(Matcher.CONTAINS,
-                "True");
+        PropertyStringFilter filter = createFilter("booleanValue",
+                Matcher.CONTAINS, "True");
         executeFilter(filter);
     }
 
@@ -111,14 +114,14 @@ public class FilterTest {
     public void filterBooleanPropertyUsingEquals() {
         setupBooleans();
 
-        PropertyStringFilter filter = createBooleanFilter(Matcher.EQUALS,
-                "True");
+        PropertyStringFilter filter = createFilter("booleanValue",
+                Matcher.EQUALS, "True");
         List<TestObject> testObjects = executeFilter(filter);
 
         assertEquals(1, testObjects.size());
         Assert.assertTrue(testObjects.get(0).getBooleanValue());
 
-        filter = createBooleanFilter(Matcher.EQUALS, "False");
+        filter = createFilter("booleanValue", Matcher.EQUALS, "False");
         testObjects = executeFilter(filter);
 
         assertEquals(1, testObjects.size());
@@ -128,23 +131,24 @@ public class FilterTest {
     @Test(expected = InvalidDataAccessApiUsageException.class)
     public void filterBooleanPropertyUsingLessThan() {
         setupBooleans();
-        PropertyStringFilter filter = createBooleanFilter(Matcher.LESS_THAN,
-                "True");
+        PropertyStringFilter filter = createFilter("booleanValue",
+                Matcher.LESS_THAN, "True");
         executeFilter(filter);
     }
 
     @Test(expected = InvalidDataAccessApiUsageException.class)
     public void filterBooleanPropertyUsingGreaterThan() {
         setupBooleans();
-        PropertyStringFilter filter = createBooleanFilter(Matcher.GREATER_THAN,
-                "True");
+        PropertyStringFilter filter = createFilter("booleanValue",
+                Matcher.GREATER_THAN, "True");
         executeFilter(filter);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void filterNonExistingProperty() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter = createNameFilter(Matcher.EQUALS, "John");
+        PropertyStringFilter filter = createFilter("name", Matcher.EQUALS,
+                "John");
         filter.setPropertyId("foo");
         assertFilterResult(filter, "John");
     }
@@ -152,8 +156,9 @@ public class FilterTest {
     @Test
     public void basicOrFilter() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter1 = createNameFilter(Matcher.EQUALS, "John");
-        PropertyStringFilter filter2 = createNameFilter(Matcher.EQUALS,
+        PropertyStringFilter filter1 = createFilter("name", Matcher.EQUALS,
+                "John");
+        PropertyStringFilter filter2 = createFilter("name", Matcher.EQUALS,
                 "Polly");
         OrFilter filter = new OrFilter();
         filter.setChildren(List.of(filter1, filter2));
@@ -163,9 +168,9 @@ public class FilterTest {
     @Test
     public void basicAndFilter() {
         setupNames("Jack", "John", "Johnny", "Polly", "Josh");
-        PropertyStringFilter filter1 = createNameFilter(Matcher.CONTAINS,
+        PropertyStringFilter filter1 = createFilter("name", Matcher.CONTAINS,
                 "Joh");
-        PropertyStringFilter filter2 = createNameFilter(Matcher.CONTAINS,
+        PropertyStringFilter filter2 = createFilter("name", Matcher.CONTAINS,
                 "nny");
         AndFilter filter = new AndFilter();
         filter.setChildren(List.of(filter1, filter2));
@@ -175,9 +180,11 @@ public class FilterTest {
     @Test
     public void nestedPropertyFilterString() {
         setupNestedObjects();
-        PropertyStringFilter filter = createNestedPropertyFilter("name",
+        PropertyStringFilter filter = createFilter("nestedObject.name",
                 Matcher.CONTAINS, "42");
-        TestObject testObject = executeFilter(filter).get(0);
+        List<TestObject> result = executeFilter(filter);
+        assertEquals(1, result.size());
+        TestObject testObject = result.get(0);
         assertEquals("some name 1", testObject.getName());
         assertEquals(42, testObject.getNestedObject().getLuckyNumber());
     }
@@ -185,9 +192,11 @@ public class FilterTest {
     @Test
     public void nestedPropertyFilterNumber() {
         setupNestedObjects();
-        PropertyStringFilter filter = createNestedPropertyFilter("luckyNumber",
+        PropertyStringFilter filter = createFilter("nestedObject.luckyNumber",
                 Matcher.EQUALS, "84");
-        TestObject testObject = executeFilter(filter).get(0);
+        List<TestObject> result = executeFilter(filter);
+        assertEquals(1, result.size());
+        TestObject testObject = result.get(0);
         assertEquals("some name 2", testObject.getName());
         assertEquals(84, testObject.getNestedObject().getLuckyNumber());
     }
@@ -195,53 +204,50 @@ public class FilterTest {
     @Test
     public void nestedPropertyFilterNumberNoResult() {
         setupNestedObjects();
-        PropertyStringFilter filter = createNestedPropertyFilter("luckyNumber",
+        PropertyStringFilter filter = createFilter("nestedObject.luckyNumber",
                 Matcher.EQUALS, "85");
         assertEquals(0, executeFilter(filter).size());
     }
 
     @Test
     public void secondLevelNestedPropertyFilterString() {
-        setupSecondLevelNestedObjects();
-        PropertyStringFilter filter = createSecondLevelNestedPropertyFilter(
-                "name", Matcher.CONTAINS, "second level nested object 1");
-        TestObject testObject = executeFilter(filter).get(0);
+        setupNestedObjects();
+        PropertyStringFilter filter = createFilter(
+                "nestedObject.secondLevelNestedObject.name", Matcher.CONTAINS,
+                "second level nested object 1");
+        List<TestObject> result = executeFilter(filter);
+        assertEquals(1, result.size());
+        TestObject testObject = result.get(0);
         assertEquals("some name 1", testObject.getName());
         assertEquals(42, testObject.getNestedObject().getLuckyNumber());
     }
 
     @Test
     public void secondLevelNestedPropertyFilterNumber() {
-        setupSecondLevelNestedObjects();
-        PropertyStringFilter filter = createSecondLevelNestedPropertyFilter(
-                "luckyNumber", Matcher.EQUALS, "2");
-        TestObject testObject = executeFilter(filter).get(0);
+        setupNestedObjects();
+        PropertyStringFilter filter = createFilter(
+                "nestedObject.secondLevelNestedObject.luckyNumber",
+                Matcher.EQUALS, "2");
+        List<TestObject> result = executeFilter(filter);
+        assertEquals(1, result.size());
+        TestObject testObject = result.get(0);
         assertEquals("some name 2", testObject.getName());
         assertEquals(84, testObject.getNestedObject().getLuckyNumber());
     }
 
     @Test
     public void secondLevelNestedPropertyFilterNumberNoResult() {
-        setupSecondLevelNestedObjects();
-        PropertyStringFilter filter = createSecondLevelNestedPropertyFilter(
-                "luckyNumber", Matcher.EQUALS, "3");
+        setupNestedObjects();
+        PropertyStringFilter filter = createFilter(
+                "nestedObject.secondLevelNestedObject.luckyNumber",
+                Matcher.EQUALS, "3");
         assertEquals(0, executeFilter(filter).size());
     }
 
-    private PropertyStringFilter createNestedPropertyFilter(String propertyId,
+    private PropertyStringFilter createFilter(String propertyPath,
             Matcher matcher, String filterValue) {
         PropertyStringFilter filter = new PropertyStringFilter();
-        filter.setPropertyId("nestedObject." + propertyId);
-        filter.setFilterValue(filterValue);
-        filter.setMatcher(matcher);
-        return filter;
-    }
-
-    private PropertyStringFilter createSecondLevelNestedPropertyFilter(
-            String propertyId, Matcher matcher, String filterValue) {
-        PropertyStringFilter filter = new PropertyStringFilter();
-        filter.setPropertyId(
-                "nestedObject.secondLevelNestedObject." + propertyId);
+        filter.setPropertyId(propertyPath);
         filter.setFilterValue(filterValue);
         filter.setMatcher(matcher);
         return filter;
@@ -262,33 +268,6 @@ public class FilterTest {
         Specification<TestObject> spec = jpaFilterConverter.toSpec(filter,
                 TestObject.class);
         return repository.findAll(spec);
-    }
-
-    private PropertyStringFilter createNameFilter(Matcher matcher,
-            String filterString) {
-        PropertyStringFilter filter = new PropertyStringFilter();
-        filter.setPropertyId("name");
-        filter.setFilterValue(filterString);
-        filter.setMatcher(matcher);
-        return filter;
-    }
-
-    private PropertyStringFilter createIdFilter(Matcher matcher,
-            String filterString) {
-        PropertyStringFilter filter = new PropertyStringFilter();
-        filter.setPropertyId("id");
-        filter.setFilterValue(filterString);
-        filter.setMatcher(matcher);
-        return filter;
-    }
-
-    private PropertyStringFilter createBooleanFilter(Matcher matcher,
-            String filterString) {
-        PropertyStringFilter filter = new PropertyStringFilter();
-        filter.setPropertyId("booleanValue");
-        filter.setFilterValue(filterString);
-        filter.setMatcher(matcher);
-        return filter;
     }
 
     private List<TestObject> setupNames(String... names) {
@@ -313,26 +292,6 @@ public class FilterTest {
     }
 
     private void setupNestedObjects() {
-        NestedObject nestedObject1 = new NestedObject();
-        nestedObject1.setName("nested object 42");
-        nestedObject1.setLuckyNumber(42);
-        entityManager.persist(nestedObject1);
-        NestedObject nestedObject2 = new NestedObject();
-        nestedObject2.setName("nested object 84");
-        nestedObject2.setLuckyNumber(84);
-        entityManager.persist(nestedObject2);
-        TestObject testObject1 = new TestObject();
-        testObject1.setName("some name 1");
-        testObject1.setNestedObject(nestedObject1);
-        entityManager.persist(testObject1);
-        TestObject testObject2 = new TestObject();
-        testObject2.setName("some name 2");
-        testObject2.setNestedObject(nestedObject2);
-        entityManager.persist(testObject2);
-        entityManager.flush();
-    }
-
-    private void setupSecondLevelNestedObjects() {
         SecondLevelNestedObject secondLevelNestedObject1 = new SecondLevelNestedObject();
         secondLevelNestedObject1.setName("second level nested object 1");
         secondLevelNestedObject1.setLuckyNumber(1);

--- a/packages/java/endpoint/src/test/java/dev/hilla/crud/NestedObject.java
+++ b/packages/java/endpoint/src/test/java/dev/hilla/crud/NestedObject.java
@@ -1,0 +1,55 @@
+package dev.hilla.crud;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class NestedObject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String name;
+
+    private long luckyNumber;
+
+    @OneToOne
+    private SecondLevelNestedObject secondLevelNestedObject;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public long getLuckyNumber() {
+        return luckyNumber;
+    }
+
+    public void setLuckyNumber(long luckyNumber) {
+        this.luckyNumber = luckyNumber;
+    }
+
+    public SecondLevelNestedObject getSecondLevelNestedObject() {
+        return secondLevelNestedObject;
+    }
+
+    public void setSecondLevelNestedObject(
+            SecondLevelNestedObject secondLevelNestedObject) {
+        this.secondLevelNestedObject = secondLevelNestedObject;
+    }
+}

--- a/packages/java/endpoint/src/test/java/dev/hilla/crud/SecondLevelNestedObject.java
+++ b/packages/java/endpoint/src/test/java/dev/hilla/crud/SecondLevelNestedObject.java
@@ -1,0 +1,42 @@
+package dev.hilla.crud;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class SecondLevelNestedObject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String name;
+
+    private long luckyNumber;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public long getLuckyNumber() {
+        return luckyNumber;
+    }
+
+    public void setLuckyNumber(long luckyNumber) {
+        this.luckyNumber = luckyNumber;
+    }
+}

--- a/packages/java/endpoint/src/test/java/dev/hilla/crud/TestObject.java
+++ b/packages/java/endpoint/src/test/java/dev/hilla/crud/TestObject.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,6 +21,9 @@ public class TestObject {
     private LocalTime localTime;
     private LocalDateTime localDateTime;
     private Boolean booleanValue;
+
+    @OneToOne
+    private NestedObject nestedObject;
 
     public Integer getId() {
         return id;
@@ -67,5 +71,13 @@ public class TestObject {
 
     public void setBooleanValue(Boolean aBoolean) {
         this.booleanValue = aBoolean;
+    }
+
+    public NestedObject getNestedObject() {
+        return nestedObject;
+    }
+
+    public void setNestedObject(NestedObject nestedObject) {
+        this.nestedObject = nestedObject;
     }
 }


### PR DESCRIPTION
## Description

At the moment, properties of nested objects
with `@OneToOne` is automatically expanded
and shown as columns. The path for those
columns looks like `nestedObject.propertyName`
and this PR adds support for handling the
header filtering for those nested paths.
## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
