### PR TITLE
feat: add multi-sort support to auto-grid

### DIFF
--- a/packages/ts/react-crud/src/autogrid-column-context.tsx
+++ b/packages/ts/react-crud/src/autogrid-column-context.tsx
@@ -3,16 +3,17 @@ import { type Dispatch, type SetStateAction, createContext } from 'react';
 import type { PropertyInfo } from './property-info';
 import type PropertyStringFilter from './types/dev/hilla/crud/filter/PropertyStringFilter';
 
-export interface SortState {
-  path: string;
+export interface SorterState {
   direction: GridSorterDirection;
 }
+
+export type SortState = Record<string, SorterState | undefined>;
 
 export type ColumnContext = {
   propertyInfo: PropertyInfo;
   setPropertyFilter(propertyFilter: PropertyStringFilter): void;
-  sortState: SortState | null;
-  setSortState: Dispatch<SetStateAction<SortState | null>>;
+  sortState: SortState;
+  setSortState: Dispatch<SetStateAction<SortState>>;
 };
 
 export const ColumnContext = createContext<ColumnContext | null>(null);

--- a/packages/ts/react-crud/src/autogrid.tsx
+++ b/packages/ts/react-crud/src/autogrid.tsx
@@ -10,9 +10,9 @@ import {
 } from '@hilla/react-components/Grid.js';
 import { GridColumn } from '@hilla/react-components/GridColumn.js';
 import { GridColumnGroup } from '@hilla/react-components/GridColumnGroup.js';
-import { useEffect, useRef, useState, type JSX } from 'react';
+import { type JSX, useEffect, useRef, useState } from 'react';
 import { ColumnContext, type SortState } from './autogrid-column-context.js';
-import { getColumnOptions, type ColumnOptions } from './autogrid-columns.js';
+import { type ColumnOptions, getColumnOptions } from './autogrid-columns.js';
 import { AutoGridRowNumberRenderer } from './autogrid-renderers.js';
 import type { ListService } from './crud';
 import { HeaderSorter } from './header-sorter';
@@ -108,11 +108,11 @@ function useColumns(
     .map((name) => properties.find((prop) => prop.name === name))
     .filter(Boolean) as PropertyInfo[];
 
-  const [sortState, setSortState] = useState<SortState | null>(
-    effectiveProperties.length > 0 ? { path: effectiveProperties[0].name, direction: 'asc' } : null,
+  const [sortState, setSortState] = useState<SortState>(
+    effectiveProperties.length > 0 ? { [effectiveProperties[0].name]: { direction: 'asc' } } : {},
   );
 
-  const autoColumns = effectiveProperties.map((propertyInfo) => {
+  let columns = effectiveProperties.map((propertyInfo) => {
     let column;
 
     const customColumnOptions = options.columnOptions ? options.columnOptions[propertyInfo.name] : undefined;
@@ -139,7 +139,6 @@ function useColumns(
       </ColumnContext.Provider>
     );
   });
-  let columns = autoColumns;
   if (options.customColumns) {
     columns = [...columns, ...options.customColumns];
   }

--- a/packages/ts/react-crud/src/header-sorter.tsx
+++ b/packages/ts/react-crud/src/header-sorter.tsx
@@ -4,14 +4,18 @@ import { ColumnContext } from './autogrid-column-context.js';
 
 export function HeaderSorter(): ReactElement {
   const context = useContext(ColumnContext)!;
+  const sorterState = context.sortState[context.propertyInfo.name];
+  const direction = sorterState?.direction ?? null;
 
-  const direction = context.sortState?.path === context.propertyInfo.name ? context.sortState.direction : null;
   return (
     <GridSorter
       path={context.propertyInfo.name}
       direction={direction}
       onDirectionChanged={(e) => {
-        context.setSortState({ path: context.propertyInfo.name, direction: e.detail.value });
+        context.setSortState((prevState) => {
+          const newSorterState = e.detail.value ? { direction: e.detail.value } : undefined;
+          return { ...prevState, [context.propertyInfo.name]: newSorterState };
+        });
       }}
     >
       {context.propertyInfo.humanReadableName}

--- a/packages/ts/react-crud/test/autogrid.spec.tsx
+++ b/packages/ts/react-crud/test/autogrid.spec.tsx
@@ -6,11 +6,14 @@ import type { TextFieldElement } from '@hilla/react-components/TextField.js';
 import { render, type RenderResult } from '@testing-library/react';
 
 import sinonChai from 'sinon-chai';
+import type { CrudService } from '../crud';
 import { AutoGrid, type AutoGridProps } from '../src/autogrid.js';
 import { _generateHeader } from '../src/property-info.js';
 import type AndFilter from '../src/types/dev/hilla/crud/filter/AndFilter.js';
 import Matcher from '../src/types/dev/hilla/crud/filter/PropertyStringFilter/Matcher.js';
 import type PropertyStringFilter from '../src/types/dev/hilla/crud/filter/PropertyStringFilter.js';
+import type Sort from '../types/dev/hilla/mappedtypes/Sort';
+import Direction from '../types/org/springframework/data/domain/Sort/Direction';
 import {
   getBodyCellContent,
   getGrid,
@@ -23,12 +26,13 @@ import {
 } from './grid-test-helpers.js';
 import {
   ColumnRendererTestModel,
-  CompanyModel,
-  PersonModel,
   columnRendererTestService,
+  CompanyModel,
   companyService,
-  personService,
+  type HasTestInfo,
   type Person,
+  PersonModel,
+  personService,
 } from './test-models-and-services.js';
 
 use(sinonChai);
@@ -69,29 +73,35 @@ describe('@hilla/react-crud', () => {
       await assertColumns(result, 'name', 'foundedDate');
     });
     it('sorts according to first column by default', async () => {
-      const result = render(<TestAutoGridNoHeaderFilters />);
-      const grid: GridElement = result.container.querySelector('vaadin-grid')!;
+      const service = personService();
+      const result = render(<TestAutoGridNoHeaderFilters service={service} />);
+      const grid = getGrid(result);
       await reactRender();
-      expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('Jane');
-      expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('John');
+
+      const expectedSort: Sort = { orders: [{ property: 'firstName', direction: Direction.ASC, ignoreCase: false }] };
+      expect(service.lastSort).to.eql(expectedSort);
+      expect(getSortOrder(grid)).to.eql([{ property: 'firstName', direction: Direction.ASC }]);
     });
     it('retains sorting when re-rendering', async () => {
       const result = render(<TestAutoGridNoHeaderFilters />);
       const grid: GridElement = result.container.querySelector('vaadin-grid')!;
       await reactRender();
       sortGrid(grid, 'lastName', 'desc');
-      expect(getSortOrder(grid)).to.eql({ path: 'lastName', direction: 'desc' });
+      expect(getSortOrder(grid)).to.eql([{ property: 'lastName', direction: Direction.DESC }]);
       result.rerender(<TestAutoGridNoHeaderFilters />);
-      expect(getSortOrder(grid)).to.eql({ path: 'lastName', direction: 'desc' });
+      expect(getSortOrder(grid)).to.eql([{ property: 'lastName', direction: Direction.DESC }]);
     });
     it('creates sortable columns', async () => {
-      const result = render(<TestAutoGridNoHeaderFilters />);
+      const service = personService();
+      const result = render(<TestAutoGridNoHeaderFilters service={service} />);
       const grid = getGrid(result);
       await reactRender();
       sortGrid(grid, 'firstName', 'desc');
       await reactRender();
-      expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('John');
-      expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('Jane');
+
+      const expectedSort: Sort = { orders: [{ property: 'firstName', direction: Direction.DESC, ignoreCase: false }] };
+      expect(service.lastSort).to.eql(expectedSort);
+      expect(getSortOrder(grid)).to.eql([{ property: 'firstName', direction: Direction.DESC }]);
     });
     it('sets a data provider, but only once', async () => {
       const service = personService();
@@ -139,6 +149,66 @@ describe('@hilla/react-crud', () => {
       expect(getVisibleRowCount(grid)).to.equal(1);
       expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('Jane');
       expect(getBodyCellContent(grid, 0, 1).innerText).to.equal('Love');
+    });
+
+    describe('multi-sort', () => {
+      let grid: GridElement;
+      let service: CrudService<Person> & HasTestInfo;
+
+      function TestAutoGridWithMultiSort(customProps: Partial<AutoGridProps<Person>>) {
+        return (
+          <AutoGrid
+            service={personService()}
+            model={PersonModel}
+            noHeaderFilters
+            multiSort
+            multiSortPriority="append"
+            {...customProps}
+          ></AutoGrid>
+        );
+      }
+
+      beforeEach(async () => {
+        service = personService();
+        const result = render(<TestAutoGridWithMultiSort service={service} />);
+        await reactRender();
+        grid = getGrid(result);
+      });
+
+      it('sorts according to first column by default', () => {
+        expect(service.lastSort).to.eql({
+          orders: [{ property: 'firstName', direction: Direction.ASC, ignoreCase: false }],
+        });
+        expect(getSortOrder(grid)).to.eql([{ property: 'firstName', direction: Direction.ASC }]);
+      });
+
+      it('sorts by multiple columns', async () => {
+        sortGrid(grid, 'lastName', 'asc');
+        await reactRender();
+        expect(service.lastSort).to.eql({
+          orders: [
+            { property: 'firstName', direction: Direction.ASC, ignoreCase: false },
+            { property: 'lastName', direction: Direction.ASC, ignoreCase: false },
+          ],
+        });
+        expect(getSortOrder(grid)).to.eql([
+          { property: 'firstName', direction: Direction.ASC },
+          { property: 'lastName', direction: Direction.ASC },
+        ]);
+
+        sortGrid(grid, 'lastName', 'desc');
+        await reactRender();
+        expect(service.lastSort).to.eql({
+          orders: [
+            { property: 'firstName', direction: Direction.ASC, ignoreCase: false },
+            { property: 'lastName', direction: Direction.DESC, ignoreCase: false },
+          ],
+        });
+        expect(getSortOrder(grid)).to.eql([
+          { property: 'firstName', direction: Direction.ASC },
+          { property: 'lastName', direction: Direction.DESC },
+        ]);
+      });
     });
 
     describe('header filters', () => {

--- a/packages/ts/react-crud/test/autogrid.spec.tsx
+++ b/packages/ts/react-crud/test/autogrid.spec.tsx
@@ -208,6 +208,13 @@ describe('@hilla/react-crud', () => {
           { property: 'firstName', direction: Direction.ASC },
           { property: 'lastName', direction: Direction.DESC },
         ]);
+
+        sortGrid(grid, 'lastName', null);
+        await reactRender();
+        expect(service.lastSort).to.eql({
+          orders: [{ property: 'firstName', direction: Direction.ASC, ignoreCase: false }],
+        });
+        expect(getSortOrder(grid)).to.eql([{ property: 'firstName', direction: Direction.ASC }]);
       });
     });
 

--- a/packages/ts/react-crud/test/test-models-and-services.ts
+++ b/packages/ts/react-crud/test/test-models-and-services.ts
@@ -208,6 +208,7 @@ type HasIdVersion = {
 };
 
 export const createService = <T extends HasIdVersion>(initialData: T[]): CrudService<T> & HasTestInfo => {
+  let _lastSort: Sort | undefined;
   let _lastFilter: Filter | undefined;
   let data = initialData;
   let _callCount = 0;
@@ -215,6 +216,7 @@ export const createService = <T extends HasIdVersion>(initialData: T[]): CrudSer
   return {
     // eslint-disable-next-line @typescript-eslint/require-await
     async list(request: Pageable, filter: Filter | undefined): Promise<T[]> {
+      _lastSort = request.sort;
       _lastFilter = filter;
       _callCount += 1;
 
@@ -269,6 +271,9 @@ export const createService = <T extends HasIdVersion>(initialData: T[]): CrudSer
     // eslint-disable-next-line
     async delete(id: any): Promise<void> {
       data = data.filter((item) => item.id !== id);
+    },
+    get lastSort() {
+      return _lastSort;
     },
     get lastFilter() {
       return _lastFilter;
@@ -339,6 +344,7 @@ export const columnRendererTestData: ColumnRendererTestValues[] = [
 ];
 
 export type HasTestInfo = {
+  lastSort: Sort | undefined;
   lastFilter: Filter | undefined;
   callCount: number;
 };


### PR DESCRIPTION
Changes the auto-grid's internal sort state to support multi-sort. 

For now I did not enable multi-sort by default, as I found it quite bothersome that you first have to remove sort from one column (two clicks) if you just want to sort a different column (third click). Let's discuss this separately, maybe we can use the new multi-sort on shift click mode as a compromise.

Closes https://github.com/vaadin/hilla/issues/1509