### PR TITLE
fix: remove infinite recursion when listing annotations in OpenAPI

### DIFF
--- a/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
+++ b/packages/java/parser-jvm-plugin-model/src/main/java/dev/hilla/parser/plugins/model/ModelPlugin.java
@@ -59,13 +59,7 @@ public final class ModelPlugin extends AbstractPlugin<PluginConfiguration> {
 
     private static Annotation convertAnnotation(
             AnnotationInfoModel annotation) {
-        var attributes = annotation.getParameters().stream()
-                .filter(Predicate.not(AnnotationParameterModel::isDefault))
-                .collect(Collectors.toMap(AnnotationParameterModel::getName,
-                        AnnotationParameterModel::getValue));
-
-        return new Annotation(annotation.getName(),
-                !attributes.isEmpty() ? attributes : null);
+        return new Annotation(annotation.getName(), null);
     }
 
     private static String extractSimpleName(String fullyQualifiedName) {

--- a/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsEndpoint.java
+++ b/packages/java/parser-jvm-plugin-model/src/test/java/dev/hilla/parser/plugins/model/annotations/AnnotationsEndpoint.java
@@ -2,6 +2,7 @@ package dev.hilla.parser.plugins.model.annotations;
 
 import dev.hilla.parser.plugins.model.Endpoint;
 import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,6 +40,9 @@ public class AnnotationsEndpoint {
 
         @ManyToMany
         public List<NestedEntity> manyToMany;
+
+        @ManyToMany(fetch = FetchType.EAGER)
+        public List<NestedEntity> manyToManyWithFetchType;
 
         @Column(name = "test_column")
         public String name;

--- a/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
+++ b/packages/java/parser-jvm-plugin-model/src/test/resources/dev/hilla/parser/plugins/model/annotations/openapi.json
@@ -131,6 +131,24 @@
               }
             ]
           },
+          "manyToManyWithFetchType" : {
+            "type" : "array",
+            "nullable" : true,
+            "items" : {
+              "nullable" : true,
+              "anyOf" : [
+                {
+                  "$ref" : "#/components/schemas/dev.hilla.parser.plugins.model.annotations.AnnotationsEndpoint$NestedEntity"
+                }
+              ]
+            },
+            "x-java-type" : "java.util.List",
+            "x-annotations" : [
+              {
+                "name" : "jakarta.persistence.ManyToMany"
+              }
+            ]
+          },
           "name" : {
             "type" : "string",
             "nullable" : true,


### PR DESCRIPTION
This PR removes all annotation attributes as we don't need them right now. Trying to write them will easily lead to recursion.

Closes #1481