### PR TITLE
Log exceptions immediately

### DIFF
--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateEndpointImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateEndpointImpl.java
@@ -23,11 +23,17 @@ import com.vaadin.flow.server.frontend.TaskGenerateEndpoint;
 import dev.hilla.engine.GeneratorException;
 import dev.hilla.engine.GeneratorProcessor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Starts the generation of TS files for endpoints.
  */
 public class TaskGenerateEndpointImpl extends AbstractTaskEndpointGenerator
         implements TaskGenerateEndpoint {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(TaskGenerateEndpointImpl.class);
 
     private final String nodeCommand;
 
@@ -67,8 +73,10 @@ public class TaskGenerateEndpointImpl extends AbstractTaskEndpointGenerator
                     nodeCommand);
             processor.process();
         } catch (GeneratorException e) {
+            // Make sure the exception is printed in the logs
+            LOGGER.error("Failed to run TypeScript endpoint generator", e);
             throw new ExecutionFailedException(
-                    "Failed to run TypeScript endpoint generator", e);
+                    "Failed to run TypeScript endpoint generator");
         }
     }
 }

--- a/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateOpenAPIImpl.java
+++ b/packages/java/engine-runtime/src/main/java/dev/hilla/internal/TaskGenerateOpenAPIImpl.java
@@ -25,11 +25,17 @@ import dev.hilla.engine.ParserProcessor;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.TaskGenerateOpenAPI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Generate OpenAPI json file for Vaadin Endpoints.
  */
 public class TaskGenerateOpenAPIImpl extends AbstractTaskEndpointGenerator
         implements TaskGenerateOpenAPI {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(TaskGenerateOpenAPIImpl.class);
 
     private final ClassLoader classLoader;
 
@@ -69,7 +75,9 @@ public class TaskGenerateOpenAPIImpl extends AbstractTaskEndpointGenerator
                     classLoader);
             processor.process();
         } catch (ParserException e) {
-            throw new ExecutionFailedException("Java code parsing failed", e);
+            // Make sure the exception is printed in the logs
+            LOGGER.error("Java code parsing failed", e);
+            throw new ExecutionFailedException("Java code parsing failed");
         }
     }
 }


### PR DESCRIPTION
Rather than counting on Flow to log exceptions, let's print them immediately in the logs and send a generic exception (without cause) to the caller.

Fixes #1530 