### PR TITLE
chore: upgrade jackson.version to 2.15.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <swagger.core.version>2.2.16</swagger.core.version>
     <swagger.models.version>2.2.16</swagger.models.version>
     <swagger.parser.v3.version>2.1.15</swagger.parser.v3.version>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.15.3</jackson.version>
     <junit.version>5.8.0</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>24.2.0.rc2</flow.version>


### PR DESCRIPTION
this will also resolve one found vulnerability https://nvd.nist.gov/vuln/detail/CVE-2023-35116

