### PR TITLE
chore: fix building hilla gradle plugin

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build TypeScript
         run: npm run build:nocache
       - name: Build Java
-        run: mvn install -B -ntp -DskipTests -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -pl '!:hilla-gradle-plugin'
+        run: mvn install -B -ntp -DskipTests -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
       - name: Save Workspace
         run: |
           tar cf workspace.tar -C ~/ $( \


### PR DESCRIPTION
The gradle plugin should build in CI same as every other module. Otherwise bumping a snapshot version results in the plugin missing from the build, causing it to fail.