### PR TITLE
feat: add discard button to auto form

### DIFF
--- a/packages/java/tests/spring/react-grid-test/src/test/java/dev/hilla/test/reactgrid/AutoFormViewIT.java
+++ b/packages/java/tests/spring/react-grid-test/src/test/java/dev/hilla/test/reactgrid/AutoFormViewIT.java
@@ -58,7 +58,14 @@ public class AutoFormViewIT extends ChromeBrowserTest {
     }
 
     private void submit() {
-        $(ButtonElement.class).first().click();
+        var submitButton = $(ButtonElement.class).all().stream()
+                .filter(button -> button.getText().equals("Submit"))
+                .findFirst();
+        if (submitButton.isPresent()) {
+            submitButton.get().click();
+        } else {
+            Assert.fail("Submit button not found");
+        }
     }
 
     private TextFieldElement getTextField(String name) {

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -76,8 +76,14 @@ export function ExperimentalAutoForm<TItem>({
           <AutoFormField key={propertyInfo.name} propertyInfo={propertyInfo} form={form} disabled={disabled} />
         ))}
       {formError ? <div style={{ color: 'var(--lumo-error-color)' }}>{formError}</div> : <></>}
-      <HorizontalLayout style={{ marginTop: 'var(--lumo-space-m)' }}>
+      <HorizontalLayout theme="spacing" style={{ marginTop: 'var(--lumo-space-m)', alignSelf: 'flex-end' }}>
+        {form.dirty ? (
+          <Button theme="tertiary" onClick={() => form.reset()}>
+            Discard
+          </Button>
+        ) : null}
         <Button
+          theme="primary"
           disabled={disabled}
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={submitButtonClicked}

--- a/packages/ts/react-crud/test/FormController.ts
+++ b/packages/ts/react-crud/test/FormController.ts
@@ -29,6 +29,10 @@ export default class FormController {
     return await Promise.all(labels.map(async (label) => await this.getField(label)));
   }
 
+  getButton(label: string): HTMLElement | null {
+    return this.#result.queryByText(label);
+  }
+
   async typeInField(label: string, value: string): Promise<void> {
     const field = await this.#result.findByLabelText(label);
     await this.#user.dblClick(field);
@@ -36,8 +40,13 @@ export default class FormController {
   }
 
   async submit(): Promise<void> {
-    const btn = await this.#result.findByText('Submit');
-    await this.#user.click(btn);
+    const btn = this.getButton('Submit');
+    await this.#user.click(btn!);
+  }
+
+  async discard(): Promise<void> {
+    const btn = this.getButton('Discard');
+    await this.#user.click(btn!);
   }
 
   async getValues(labels: readonly string[]): Promise<readonly unknown[]> {

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -247,5 +247,37 @@ describe('@hilla/react-crud', () => {
       const form = await FormController.init(result, user);
       await expect(form.areEnabled(LABELS)).to.eventually.be.true;
     });
+
+    describe('discard button', () => {
+      it('does not show a discard button if the form is not dirty', async () => {
+        const form = await FormController.init(
+          render(<ExperimentalAutoForm service={personService()} model={PersonModel} />),
+          user,
+        );
+        expect(form.getButton('Discard')).to.be.null;
+      });
+
+      it('does show a discard button if the form is dirty', async () => {
+        const form = await FormController.init(
+          render(<ExperimentalAutoForm service={personService()} model={PersonModel} />),
+          user,
+        );
+        await form.typeInField('First name', 'foo');
+        expect(form.getButton('Discard')).to.exist;
+      });
+
+      it('resets the form when clicking the discard button', async () => {
+        const form = await FormController.init(
+          render(<ExperimentalAutoForm service={personService()} model={PersonModel} />),
+          user,
+        );
+        await form.typeInField('First name', 'foo');
+        expect(form.getButton('Discard')).to.exist;
+
+        await form.discard();
+        await expect(form.getValues(['First name'])).to.eventually.eql(['']);
+        expect(form.getButton('Discard')).to.be.null;
+      });
+    });
   });
 });


### PR DESCRIPTION
Shows a discard button in auto form if the form is dirty. Clicking the button resets the form.

Fixes #1433 