### PR TITLE
fix: reset form when creating new item

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -1,13 +1,12 @@
 import type { AbstractModel, DetachedModelConstructor } from '@hilla/form';
 import { Button } from '@hilla/react-components/Button.js';
-import type { GridElement } from '@hilla/react-components/Grid.js';
 import { GridColumn } from '@hilla/react-components/GridColumn.js';
 import { HorizontalLayout } from '@hilla/react-components/HorizontalLayout.js';
 import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
 import { type JSX, useState } from 'react';
 import { AutoCrudContext } from './autocrud-context.js';
 import DeleteButton from './autocrud-delete.js';
-import { defaultItem, ExperimentalAutoForm } from './autoform.js';
+import { emptyItem, ExperimentalAutoForm } from './autoform.js';
 import { AutoGrid } from './autogrid.js';
 import type { CrudService } from './crud.js';
 import { getProperties } from './property-info.js';
@@ -20,7 +19,7 @@ export type AutoCrudProps<TItem> = Readonly<{
 }>;
 
 export function ExperimentalAutoCrud<TItem>({ service, model, noDelete, header }: AutoCrudProps<TItem>): JSX.Element {
-  const [item, setItem] = useState<TItem | typeof defaultItem | undefined>(undefined);
+  const [item, setItem] = useState<TItem | typeof emptyItem | undefined>(undefined);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
   const customColumns = [];
@@ -46,7 +45,7 @@ export function ExperimentalAutoCrud<TItem>({ service, model, noDelete, header }
             }}
           >
             {header ? <h2 style={{ fontSize: 'var(--lumo-font-size-l)' }}>{header}</h2> : <></>}
-            <Button theme="primary" onClick={() => setItem(defaultItem)}>
+            <Button theme="primary" onClick={() => setItem(emptyItem)}>
               + New
             </Button>
           </HorizontalLayout>
@@ -55,17 +54,10 @@ export function ExperimentalAutoCrud<TItem>({ service, model, noDelete, header }
               refreshTrigger={refreshTrigger}
               service={service}
               model={model}
+              selectedItems={item && item !== emptyItem ? [item] : []}
               onActiveItemChanged={(e) => {
                 const activeItem = e.detail.value;
-                (e.target as GridElement).selectedItems = activeItem ? [activeItem] : [];
-              }}
-              onSelectedItemsChanged={(e) => {
-                if (e.detail.value.length === 0) {
-                  setItem(undefined);
-                } else {
-                  const selectedItem = e.detail.value[0];
-                  setItem({ ...selectedItem });
-                }
+                setItem(activeItem ?? undefined);
               }}
               customColumns={customColumns}
             ></AutoGrid>

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -8,7 +8,7 @@ import { AutoFormField } from './autoform-field.js';
 import type { CrudService } from './crud.js';
 import { getProperties, includeProperty } from './property-info.js';
 
-export const defaultItem = Symbol();
+export const emptyItem = Symbol();
 
 type SubmitErrorEvent = {
   error: unknown;
@@ -20,7 +20,7 @@ type SubmitEvent<TItem> = {
 export type AutoFormProps<TItem> = Readonly<{
   service: CrudService<TItem>;
   model: DetachedModelConstructor<AbstractModel<TItem>>;
-  item?: TItem | typeof defaultItem;
+  item?: TItem | typeof emptyItem;
   disabled?: boolean;
   onSubmitError?({ error }: SubmitErrorEvent): void;
   afterSubmit?({ item }: SubmitEvent<TItem>): void;
@@ -39,8 +39,10 @@ export function ExperimentalAutoForm<TItem>({
   });
   const [formError, setFormError] = useState('');
   useEffect(() => {
-    if (item !== defaultItem) {
+    if (item !== emptyItem) {
       form.read(item);
+    } else {
+      form.clear();
     }
   }, [item]);
 

--- a/packages/ts/react-crud/test/CrudController.ts
+++ b/packages/ts/react-crud/test/CrudController.ts
@@ -6,15 +6,18 @@ import GridController from './GridController.js';
 export class CrudController {
   readonly grid: GridController;
   readonly form: FormController;
+  readonly newButton: HTMLElement;
 
   static async init(result: RenderResult, user: ReturnType<(typeof userEvent)['setup']>): Promise<CrudController> {
     const [grid, form] = await Promise.all([GridController.init(result, user), FormController.init(result, user)]);
+    const newButton = await result.findByText('+ New');
 
-    return new CrudController(grid, form);
+    return new CrudController(grid, form, newButton);
   }
 
-  private constructor(grid: GridController, form: FormController) {
+  private constructor(grid: GridController, form: FormController, newButton: HTMLElement) {
     this.grid = grid;
     this.form = form;
+    this.newButton = newButton;
   }
 }

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -96,10 +96,10 @@ describe('@hilla/react-crud', () => {
     });
 
     it('can add a new item', async () => {
-      const service = personService();
-      const result = render(<ExperimentalAutoCrud service={service} model={PersonModel} />);
-      const { grid, form } = await CrudController.init(result, user);
-      const newButton = await result.findByText('+ New');
+      const { grid, form, newButton } = await CrudController.init(
+        render(<ExperimentalAutoCrud service={personService()} model={PersonModel} />),
+        user,
+      );
       await user.click(newButton);
       const [firstNameField, lastNameField, emailField, someIntegerField, someDecimalField] = await form.getFields(
         'First name',
@@ -123,10 +123,10 @@ describe('@hilla/react-crud', () => {
     });
 
     it('can update added item', async () => {
-      const service = personService();
-      const result = render(<ExperimentalAutoCrud service={service} model={PersonModel} />);
-      const { grid, form } = await CrudController.init(result, user);
-      const newButton = await result.findByText('+ New');
+      const { grid, form, newButton } = await CrudController.init(
+        render(<ExperimentalAutoCrud service={personService()} model={PersonModel} />),
+        user,
+      );
       await user.click(newButton);
 
       const [firstNameField, lastNameField, emailField, someIntegerField, someDecimalField] = await form.getFields(
@@ -147,6 +147,22 @@ describe('@hilla/react-crud', () => {
       await form.submit();
       expect(grid.getBodyCellContent(1, 0)).to.have.rendered.text('Jerp');
       expect(grid.getVisibleRowCount()).to.equal(3);
+    });
+
+    it('updates grid and form when creating a new item after selecting an existing item', async () => {
+      const { grid, form, newButton } = await CrudController.init(render(<TestAutoCrud />), user);
+      await grid.toggleRowSelected(0);
+      expect((await form.getField('First name')).value).to.equal('Jane');
+      expect((await form.getField('Last name')).value).to.equal('Love');
+
+      await user.click(newButton);
+
+      // form should be cleared
+      expect((await form.getField('First name')).value).to.equal('');
+      expect((await form.getField('Last name')).value).to.equal('');
+
+      // grid selection should reset
+      expect(grid.isSelected(0)).to.be.false;
     });
 
     it('deletes and refreshes grid after confirming', async () => {


### PR DESCRIPTION
Clears the form and removes the selection from grid when creating a new item. Also simplifies the grid selection logic a bit.