### PR TITLE
test: enforce en-US as default locale

### DIFF
--- a/packages/ts/react-crud/src/i18n.ts
+++ b/packages/ts/react-crud/src/i18n.ts
@@ -1,4 +1,9 @@
 // The default locale to use for renderers, filter inputs, etc.
 // If undefined, the browser's locale will be used.
 // Allows to modify the locale for testing purposes.
-export const defaultLocale: string | undefined = undefined;
+// eslint-disable-next-line import/no-mutable-exports
+export let defaultLocale: string | undefined;
+
+export function setDefaultLocale(locale: string | undefined): void {
+  defaultLocale = locale;
+}

--- a/packages/ts/react-crud/test/autogrid.spec.tsx
+++ b/packages/ts/react-crud/test/autogrid.spec.tsx
@@ -7,6 +7,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
 import { AutoGrid, type AutoGridProps } from '../src/autogrid.js';
 import type { CrudService } from '../src/crud.js';
+import { setDefaultLocale } from '../src/i18n';
 import type AndFilter from '../src/types/dev/hilla/crud/filter/AndFilter.js';
 import Matcher from '../src/types/dev/hilla/crud/filter/PropertyStringFilter/Matcher.js';
 import type PropertyStringFilter from '../src/types/dev/hilla/crud/filter/PropertyStringFilter.js';
@@ -52,6 +53,10 @@ async function assertColumns(grid: GridController, ...ids: string[]) {
 }
 
 describe('@hilla/react-crud', () => {
+  before(() => {
+    setDefaultLocale('en-US');
+  });
+
   describe('Auto grid', () => {
     function TestAutoGridNoHeaderFilters(customProps: Partial<AutoGridProps<Person>>) {
       return <AutoGrid service={personService()} model={PersonModel} noHeaderFilters {...customProps} />;


### PR DESCRIPTION
Use `en-US` as default locale in auto grid tests, so that they pass if Karma starts browsers with a different locale.