### PR TITLE
chore: fix check style errors remained from 1563

### DIFF
--- a/packages/ts/react-crud/test/FormController.ts
+++ b/packages/ts/react-crud/test/FormController.ts
@@ -41,12 +41,12 @@ export default class FormController {
 
   async submit(): Promise<void> {
     const btn = await this.findButton('Submit');
-    await this.#user.click(btn!);
+    await this.#user.click(btn);
   }
 
   async discard(): Promise<void> {
     const btn = await this.findButton('Discard');
-    await this.#user.click(btn!);
+    await this.#user.click(btn);
   }
 
   async getValues(labels: readonly string[]): Promise<readonly unknown[]> {

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -288,7 +288,7 @@ describe('@hilla/react-crud', () => {
       const form = await FormController.init(result, user);
 
       const submitButton = await form.findButton('Submit');
-      expect(submitButton!.disabled).to.be.false;
+      expect(submitButton.disabled).to.be.false;
     });
 
     it('passing null interprets as creating new, submit button is enabled at the beginning', async () => {
@@ -297,7 +297,7 @@ describe('@hilla/react-crud', () => {
       const form = await FormController.init(result, user);
 
       const submitButton = await form.findButton('Submit');
-      expect(submitButton!.disabled).to.be.false;
+      expect(submitButton.disabled).to.be.false;
     });
 
     it('passing undefined interprets as creating new, submit button is enabled at the beginning', async () => {
@@ -306,7 +306,7 @@ describe('@hilla/react-crud', () => {
       const form = await FormController.init(result, user);
 
       const submitButton = await form.findButton('Submit');
-      expect(submitButton!.disabled).to.be.false;
+      expect(submitButton.disabled).to.be.false;
     });
 
     it('when editing, submit button remains disabled before any changes', async () => {
@@ -316,7 +316,7 @@ describe('@hilla/react-crud', () => {
       const form = await FormController.init(result, user);
 
       const submitButton = await form.findButton('Submit');
-      expect(submitButton!.disabled).to.be.true;
+      expect(submitButton.disabled).to.be.true;
     });
 
     it('when editing, submit button becomes disabled again when the form is reset', async () => {
@@ -327,10 +327,10 @@ describe('@hilla/react-crud', () => {
       const submitButton = await form.findButton('Submit');
 
       await form.typeInField('First name', 'J'); // to enable the submit button
-      expect(submitButton!.disabled).to.be.false;
+      expect(submitButton.disabled).to.be.false;
 
       await form.discard();
-      expect(submitButton!.disabled).to.be.true;
+      expect(submitButton.disabled).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description

Check Style errors didn't prevent the auto-merge from being triggered.
This address those remained errors from #1563 