### PR TITLE
chore: clarify validation summary

### DIFF
--- a/.github/workflows/skip-validation.yml
+++ b/.github/workflows/skip-validation.yml
@@ -8,12 +8,14 @@ on:
       - 'README.md'
       - '.github/ISSUE_TEMPLATE/*'
       - 'packages/**/README.md'
+      - 'scripts/generator/templates/**/*.md'
   pull_request_target:
     paths:
       - 'hilla-logo.svg'
       - 'README.md'
       - '.github/ISSUE_TEMPLATE/*'
       - 'packages/**/README.md'
+      - 'scripts/generator/templates/**/*.md'
 
 jobs:
   test-all:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,12 +6,13 @@ defaults:
 
 on:
   push:
-    branches: [ main, '2.2', '2.1', '1.3' ]
+    branches: [ main, '2.3', '2.2', '2.1', '1.3' ]
     paths-ignore:
       - 'hilla-logo.svg'
       - 'README.md'
       - '.github/ISSUE_TEMPLATE/*'
       - 'packages/**/README.md'
+      - 'scripts/generator/templates/**/*.md'
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
     paths-ignore:
@@ -19,6 +20,7 @@ on:
       - 'README.md'
       - '.github/ISSUE_TEMPLATE/*'
       - 'packages/**/README.md'
+      - 'scripts/generator/templates/**/*.md'
   workflow_dispatch:
 permissions:
   contents: read
@@ -309,5 +311,5 @@ jobs:
       - test-gradle
     steps:
       - name: Fail if test jobs did not succeed
-        if: ${{ needs.test-it.result != 'success' }}
+        if: ${{ needs.check-style.result != 'success' || needs.test-java.result != 'success' || needs.test-typescript.result != 'success' || needs.test-it.result != 'success' || needs.test-gradle.result != 'success' }}
         run: exit 1


### PR DESCRIPTION
Let us explicitly fail the validation summary job if any of the parallel test / check jobs failed. This aims primarily to make sure that GitHub auto-merge does not bypass the important validation steps.
