### PR TITLE
fix: depend on release versions of Flow and TestBench

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,10 @@
     <jackson.version>2.15.2</jackson.version>
     <junit.version>5.8.0</junit.version>
     <mockito.version>4.5.0</mockito.version>
-    <flow.version>24.2.0.rc2</flow.version>
+    <flow.version>24.2.0</flow.version>
     <slf4j.version>2.0.7</slf4j.version>
     <spring.boot.version>3.1.4</spring.boot.version>
-    <testbench.version>9.1.0.rc2</testbench.version>
+    <testbench.version>9.1.0</testbench.version>
     <jakarta.validation.version>3.0.2</jakarta.validation.version>
     <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
     <jakarta.activation.api.version>2.1.2</jakarta.activation.api.version>


### PR DESCRIPTION
Pre-release dependency versions do not work for applications that depend on stable Hilla version, as the respective artifacts are only published on pre-release Maven repositories.