### PR TITLE
chore: keep generated frontend files after build

### DIFF
--- a/packages/java/maven-plugin/src/main/java/dev/hilla/maven/BuildFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/dev/hilla/maven/BuildFrontendMojo.java
@@ -9,4 +9,16 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Execute(goal = "configure")
 public class BuildFrontendMojo
         extends com.vaadin.flow.plugin.maven.BuildFrontendMojo {
+    /**
+     * Override this to not clean generated frontend files after the build. For
+     * Hilla, the generated files can still be useful for developers after the
+     * build. For example, a developer can use {@code vite.generated.ts} to run
+     * tests with vitest in CI.
+     *
+     * @return {@code false}
+     */
+    @Override
+    protected boolean cleanFrontendFiles() {
+        return false;
+    }
 }


### PR DESCRIPTION
Changes the Hilla Maven plugin to not remove generated frontend files after the build. Those files can still be useful to developers after the build. For example, to run frontend tests in CI with vitest, you would like to keep the `vite.generated.ts` file.