### PR TITLE
chore: make mocha config work with Node 20.8

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": ["ts", "mts", "cts", "js", "mjs", "cjs"],
-  "loader": "tsx",
+  "import": "tsx",
   "exit": true
 }


### PR DESCRIPTION
Fixes the following issue during [test runs](https://github.com/vaadin/hilla/actions/runs/6640458023/job/18047435739?pr=1605):
```
@hilla/generator-typescript-cli: node:internal/process/esm_loader:40
@hilla/generator-typescript-cli:       internalBinding('errors').triggerUncaughtException(
@hilla/generator-typescript-cli:                                 ^
@hilla/generator-typescript-cli: Error: tsx must be loaded with --import instead of --loader
@hilla/generator-typescript-cli: The --loader flag was deprecated in Node v20.6.0
@hilla/generator-typescript-cli:     at X (file:///home/runner/work/hilla/hilla/node_modules/tsx/dist/esm/index.mjs:1:1920)
@hilla/generator-typescript-cli:     at Hooks.addCustomLoader (node:internal/modules/esm/hooks:178:24)
@hilla/generator-typescript-cli:     at Hooks.register (node:internal/modules/esm/hooks:144:16)
@hilla/generator-typescript-cli:     at async initializeHooks (node:internal/modules/esm/utils:184:5)
@hilla/generator-typescript-cli:     at async customizedModuleWorker (node:internal/modules/esm/worker:86:24)
```