### PR TITLE
fix: Make it work again with Node 18

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "extension": ["ts", "mts", "cts", "js", "mjs", "cjs"],
-  "import": "tsx",
+  "loader": "tsx",
   "exit": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14746,9 +14746,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.13.0.tgz",
+      "integrity": "sha512-rjmRpTu3as/5fjNq/kOkOtihgLxuIz6pbKdj9xwP4J5jOLkBxw/rjN5ANw+KyrrOXV5uB7HC8+SrrSJxT65y+A==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.18.20",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier": "^3.0.3",
     "simple-git-hooks": "^2.9.0",
     "sync-request": "^6.1.0",
-    "tsx": "^3.13.0",
+    "tsx": "3.13.0",
     "typescript": "5.1.6",
     "vite": "^4.4.9"
   }


### PR DESCRIPTION
Revert "chore: make mocha config work with Node 20.8 (#1609)"

This reverts commit 7c5c4dedf5a270dae270f8198c33c08f9ed81bac.
