### PR TITLE
feat: customize form and grid within auto crud

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -7,21 +7,39 @@ import AutoCrudActions from './autocrud-actions';
 import { AutoCrudContext } from './autocrud-context.js';
 import { AutoCrudDialog } from './autocrud-dialog';
 import css from './autocrud.obj.css';
-import { emptyItem, ExperimentalAutoForm } from './autoform.js';
-import { AutoGrid } from './autogrid.js';
+import { type AutoFormProps, emptyItem, ExperimentalAutoForm } from './autoform.js';
+import { AutoGrid, type AutoGridProps } from './autogrid.js';
 import type { CrudService } from './crud.js';
 import { useMediaQuery } from './media-query';
 import { getIdProperty, getProperties } from './property-info.js';
 
 document.adoptedStyleSheets.unshift(css);
 
+export type AutoCrudFormProps<TItem> = Omit<
+  Partial<AutoFormProps<AbstractModel<TItem>>>,
+  'afterSubmit' | 'disabled' | 'item' | 'model' | 'service'
+>;
+
+export type AutoCrudGridProps<TItem> = Omit<
+  Partial<AutoGridProps<TItem>>,
+  'customColumns' | 'model' | 'onActiveItemChanged' | 'refreshTrigger' | 'selectedItems' | 'service'
+>;
+
 export type AutoCrudProps<TItem> = Readonly<{
   service: CrudService<TItem>;
   model: DetachedModelConstructor<AbstractModel<TItem>>;
   noDelete?: boolean;
+  formProps?: AutoCrudFormProps<TItem>;
+  gridProps?: AutoCrudGridProps<TItem>;
 }>;
 
-export function ExperimentalAutoCrud<TItem>({ service, model, noDelete }: AutoCrudProps<TItem>): JSX.Element {
+export function ExperimentalAutoCrud<TItem>({
+  service,
+  model,
+  noDelete,
+  formProps,
+  gridProps,
+}: AutoCrudProps<TItem>): JSX.Element {
   const [item, setItem] = useState<TItem | typeof emptyItem | undefined>(undefined);
   const [pendingItemToDelete, setPendingItemToDelete] = useState<TItem | undefined>(undefined);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
@@ -66,6 +84,7 @@ export function ExperimentalAutoCrud<TItem>({ service, model, noDelete }: AutoCr
 
   const autoForm = (
     <ExperimentalAutoForm
+      {...formProps}
       disabled={!item}
       service={service}
       model={model}
@@ -87,6 +106,7 @@ export function ExperimentalAutoCrud<TItem>({ service, model, noDelete }: AutoCr
         <div className="auto-crud">
           <div className="auto-crud-main">
             <AutoGrid
+              {...gridProps}
               refreshTrigger={refreshTrigger}
               service={service}
               model={model}

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -200,7 +200,7 @@ export function ExperimentalAutoForm<M extends AbstractModel>({
   }
 
   return (
-    <VerticalLayout className="auto-form" theme="spacing">
+    <VerticalLayout className="auto-form" theme="spacing" data-testid="auto-form">
       <VerticalLayout className="auto-form-fields">
         {layout}
         {formError ? <div style={{ color: 'var(--lumo-error-color)' }}>{formError}</div> : <></>}

--- a/packages/ts/react-crud/test/FormController.ts
+++ b/packages/ts/react-crud/test/FormController.ts
@@ -1,5 +1,5 @@
 import type { FormLayoutElement } from '@hilla/react-components/FormLayout';
-import { screen, waitFor } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 import type userEvent from '@testing-library/user-event';
 
 export type FormElement = HTMLElement & {
@@ -29,7 +29,11 @@ export default class FormController {
   }
 
   async getField(label: string): Promise<FormElement> {
-    return (await screen.findByLabelText(label)).parentElement as FormElement;
+    return (await within(this.instance).findByLabelText(label)).parentElement as FormElement;
+  }
+
+  queryField(label: string): FormElement | undefined {
+    return within(this.instance).queryByLabelText(label)?.parentElement as FormElement | undefined;
   }
 
   async getFields(...labels: readonly string[]): Promise<readonly FormElement[]> {
@@ -37,11 +41,11 @@ export default class FormController {
   }
 
   async findButton(text: string): Promise<HTMLButtonElement> {
-    return await screen.findByText(text);
+    return await within(this.instance).findByText(text);
   }
 
   async typeInField(label: string, value: string): Promise<void> {
-    const field = await screen.findByLabelText(label);
+    const field = await within(this.instance).findByLabelText(label);
     await this.#user.dblClick(field);
     await this.#user.keyboard(value);
   }

--- a/packages/ts/react-crud/test/FormController.ts
+++ b/packages/ts/react-crud/test/FormController.ts
@@ -9,21 +9,19 @@ export type FormElement = HTMLElement & {
 };
 
 export default class FormController {
-  readonly instance: FormLayoutElement;
+  readonly instance: HTMLElement;
+  readonly formLayout: FormLayoutElement;
   readonly #user: ReturnType<(typeof userEvent)['setup']>;
   readonly renderResult: HTMLElement;
 
   static async init(user: ReturnType<(typeof userEvent)['setup']>, source = document.body): Promise<FormController> {
-    const form = await waitFor(() => source.querySelector('vaadin-form-layout')!);
+    const form = await waitFor(() => within(source).getByTestId('auto-form'));
     return new FormController(form, source, user);
   }
 
-  private constructor(
-    instance: FormLayoutElement,
-    renderResult: HTMLElement,
-    user: ReturnType<(typeof userEvent)['setup']>,
-  ) {
+  private constructor(instance: HTMLElement, renderResult: HTMLElement, user: ReturnType<(typeof userEvent)['setup']>) {
     this.instance = instance;
+    this.formLayout = instance.querySelector('vaadin-form-layout')!;
     this.renderResult = renderResult;
     this.#user = user;
   }

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -311,5 +311,41 @@ describe('@hilla/react-crud', () => {
         expect(saveSpy).to.have.been.called;
       });
     });
+
+    describe('customize grid', () => {
+      it('allows passing custom grid props', async () => {
+        const { grid } = await CrudController.init(
+          render(
+            <ExperimentalAutoCrud
+              service={personService()}
+              model={PersonModel}
+              gridProps={{ visibleColumns: ['firstName', 'lastName'] }}
+            />,
+          ),
+          user,
+        );
+
+        await expect(grid.getHeaderCellContents()).to.eventually.eql(['First name', 'Last name', '']);
+      });
+    });
+
+    describe('customize form', () => {
+      it('allows passing custom form props', async () => {
+        const { form } = await CrudController.init(
+          render(
+            <ExperimentalAutoCrud
+              service={personService()}
+              model={PersonModel}
+              formProps={{ customLayoutRenderer: { template: [['firstName', 'lastName']] } }}
+            />,
+          ),
+          user,
+        );
+
+        expect(form.queryField('First name')).to.exist;
+        expect(form.queryField('Last name')).to.exist;
+        expect(form.queryField('Email')).not.to.exist;
+      });
+    });
   });
 });

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -20,17 +20,14 @@ describe('@hilla/react-crud', () => {
   describe('Auto crud', () => {
     let user: ReturnType<(typeof userEvent)['setup']>;
 
-    before(() => {
+    beforeEach(() => {
       // Desktop resolution
       viewport.set(1024, 768);
+      user = userEvent.setup();
     });
 
     after(() => {
       viewport.reset();
-    });
-
-    beforeEach(() => {
-      user = userEvent.setup();
     });
 
     function TestAutoCrud(props: Partial<AutoCrudProps<Person>> = {}) {
@@ -236,12 +233,10 @@ describe('@hilla/react-crud', () => {
       let saveSpy: sinon.SinonSpy;
       let result: RenderResult;
 
-      before(() => {
+      beforeEach(() => {
         // iPhone 13 Pro resolution
         viewport.set(390, 844);
-      });
 
-      beforeEach(() => {
         const service = personService();
         saveSpy = sinon.spy(service, 'save');
         result = render(<TestAutoCrud service={service} />);

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -408,8 +408,8 @@ describe('@hilla/react-crud', () => {
 
     it('customLayoutRenderer is not defined, default two-column form layout is used', async () => {
       const form = await populatePersonForm(1);
-      expect(form.instance.responsiveSteps).to.have.length(3);
-      expect(form.instance.responsiveSteps).to.be.deep.equal([
+      expect(form.formLayout.responsiveSteps).to.have.length(3);
+      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
         { minWidth: 0, columns: 1, labelsPosition: 'top' },
         { minWidth: '20em', columns: 1 },
         { minWidth: '40em', columns: 2 },
@@ -434,8 +434,8 @@ describe('@hilla/react-crud', () => {
         },
         'screen-1440-900',
       );
-      expect(form.instance.responsiveSteps).to.have.length(2);
-      expect(form.instance.responsiveSteps).to.be.deep.equal([
+      expect(form.formLayout.responsiveSteps).to.have.length(2);
+      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
         { minWidth: '0', columns: 1 },
         { minWidth: '800px', columns: 6 },
       ]);
@@ -461,8 +461,8 @@ describe('@hilla/react-crud', () => {
         },
         'screen-1440-900',
       );
-      expect(form.instance.responsiveSteps).to.have.length(3);
-      expect(form.instance.responsiveSteps).to.be.deep.equal([
+      expect(form.formLayout.responsiveSteps).to.have.length(3);
+      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
         { minWidth: '0', columns: 1 },
         { minWidth: '800px', columns: 2 },
         { minWidth: '1200px', columns: 3 },
@@ -535,8 +535,8 @@ describe('@hilla/react-crud', () => {
         },
         'screen-1440-900',
       );
-      expect(form.instance.responsiveSteps).to.have.length(2);
-      expect(form.instance.responsiveSteps).to.be.deep.equal([
+      expect(form.formLayout.responsiveSteps).to.have.length(2);
+      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
         { minWidth: '0', columns: 1 },
         { minWidth: '800px', columns: 6 },
       ]);
@@ -572,8 +572,8 @@ describe('@hilla/react-crud', () => {
         },
         'screen-1440-900',
       );
-      expect(form.instance.responsiveSteps).to.have.length(3);
-      expect(form.instance.responsiveSteps).to.be.deep.equal([
+      expect(form.formLayout.responsiveSteps).to.have.length(3);
+      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
         { minWidth: '0', columns: 1 },
         { minWidth: '800px', columns: 2 },
         { minWidth: '1200px', columns: 3 },
@@ -590,7 +590,7 @@ describe('@hilla/react-crud', () => {
         return <VerticalLayout>{children}</VerticalLayout>;
       }
       const form = await populatePersonForm(1, MyCustomLayoutRenderer, 'screen-1440-900');
-      expect(form.instance).to.not.exist;
+      expect(form.formLayout).to.not.exist;
       const layout = await waitFor(() => form.renderResult.querySelector('vaadin-vertical-layout')!);
       expect(layout).to.exist;
     });


### PR DESCRIPTION
Allows customizing the form and grid rendered by auto crud by passing respective props.

Fixes https://github.com/vaadin/hilla/issues/1614