### PR TITLE
chore: fix getting file path for lint stage

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -6,7 +6,7 @@ function createExcludeCallback(command) {
   return (files) => {
     const matched = micromatch.not(files, excludePatterns);
 
-    return matched.length > 0 ? [`${command} ${matched.join(' ')}`] : [];
+    return matched.length > 0 ? [`${command} ${matched.map((filename) => `"${filename}"`).join(' ')}`] : [];
   };
 }
 


### PR DESCRIPTION
Wrap lint stage filename path with double quotes

Solution from: https://github.com/lint-staged/lint-staged/issues/773#issuecomment-1260416318

Fixes #1646