### PR TITLE
feat: add box shadow to auto crud form

### DIFF
--- a/packages/ts/react-crud/src/autocrud.obj.css
+++ b/packages/ts/react-crud/src/autocrud.obj.css
@@ -1,5 +1,6 @@
 .auto-crud {
   display: flex;
+  overflow: hidden;
 }
 
 .auto-crud-main {
@@ -47,6 +48,8 @@
   width: 40%;
   border: solid 1px var(--lumo-contrast-20pct);
   border-left-width: 0;
+  box-shadow: var(--lumo-box-shadow-s);
+  z-index: 1;
 }
 
 .auto-crud .auto-form-fields,


### PR DESCRIPTION
Based on the UX feedback provided by Rolf, adds a box shadow to the form in auto-crud to have a clearer separation betwen the grid and the editor part.

<img width="764" alt="Bildschirmfoto 2023-11-07 um 11 46 49" src="https://github.com/vaadin/hilla/assets/357820/435beb0e-b223-418f-9960-19b1616e2960">
