### PR TITLE
feat: make auto crud panels resizable

### DIFF
--- a/packages/ts/react-crud/src/autocrud.obj.css
+++ b/packages/ts/react-crud/src/autocrud.obj.css
@@ -1,28 +1,23 @@
 .auto-crud {
   display: flex;
   overflow: hidden;
+  border: solid 1px var(--lumo-contrast-20pct);
+}
+
+.auto-crud vaadin-split-layout::part(splitter) {
+  border-top: solid 1px var(--lumo-contrast-20pct);
+  border-left: solid 1px var(--lumo-contrast-20pct);
 }
 
 .auto-crud-main {
   flex: 1 1 100%;
+  min-width: 200px;
   display: flex;
   flex-direction: column;
 }
 
-.auto-crud-actions {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 0 var(--lumo-space-xs);
-  display: flex;
-  gap: var(--lumo-space-xs);
-  align-items: center;
-}
-
-.auto-crud-actions vaadin-button {
-  margin: 0;
+.auto-crud-main vaadin-grid {
+  border: none;
 }
 
 .auto-crud-toolbar {
@@ -33,8 +28,7 @@
 
   padding: var(--lumo-space-s) var(--lumo-space-m);
   background-color: var(--lumo-contrast-5pct);
-  border: 1px solid var(--lumo-contrast-10pct);
-  border-top: none;
+  border-top: solid 1px var(--lumo-contrast-10pct);
 }
 
 .auto-crud .auto-form,
@@ -46,10 +40,19 @@
 
 .auto-crud .auto-form {
   width: 40%;
-  border: solid 1px var(--lumo-contrast-20pct);
-  border-left-width: 0;
-  box-shadow: var(--lumo-box-shadow-s);
+  min-width: 300px;
+}
+
+/* Move box shadow and required z-index modification into pseudo-element
+   as it otherwise messes with the drag handle of the split layout */
+.auto-crud .auto-form::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  height: 100%;
   z-index: 1;
+  box-shadow: var(--lumo-box-shadow-s);
 }
 
 .auto-crud .auto-form-fields,

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -1,5 +1,6 @@
 import type { AbstractModel, DetachedModelConstructor } from '@hilla/form';
 import { Button } from '@hilla/react-components/Button.js';
+import { SplitLayout } from '@hilla/react-components/SplitLayout';
 import { type JSX, useState } from 'react';
 import { AutoCrudDialog } from './autocrud-dialog';
 import css from './autocrud.obj.css';
@@ -103,6 +104,27 @@ export function ExperimentalAutoCrud<TItem>({
     setItem(undefined);
   }
 
+  const mainSection = (
+    <div className="auto-crud-main">
+      <AutoGrid
+        {...gridProps}
+        refreshTrigger={refreshTrigger}
+        service={service}
+        model={model}
+        selectedItems={item && item !== emptyItem ? [item] : []}
+        onActiveItemChanged={(e) => {
+          const activeItem = e.detail.value;
+          setItem(activeItem ?? undefined);
+        }}
+      ></AutoGrid>
+      <div className="auto-crud-toolbar">
+        <Button theme="primary" onClick={() => setItem(emptyItem)}>
+          + New
+        </Button>
+      </div>
+    </div>
+  );
+
   const autoForm = (
     <ExperimentalAutoForm
       {...formProps}
@@ -128,31 +150,18 @@ export function ExperimentalAutoCrud<TItem>({
 
   return (
     <div className={`auto-crud ${className}`} id={id} style={style}>
-      <div className="auto-crud-main">
-        <AutoGrid
-          {...gridProps}
-          refreshTrigger={refreshTrigger}
-          service={service}
-          model={model}
-          selectedItems={item && item !== emptyItem ? [item] : []}
-          onActiveItemChanged={(e) => {
-            const activeItem = e.detail.value;
-            setItem(activeItem ?? undefined);
-          }}
-        ></AutoGrid>
-        <div className="auto-crud-toolbar">
-          <Button theme="primary" onClick={() => setItem(emptyItem)}>
-            + New
-          </Button>
-        </div>
-      </div>
-
       {fullScreen ? (
-        <AutoCrudDialog opened={!!item} onClose={handleCancel}>
-          {autoForm}
-        </AutoCrudDialog>
+        <>
+          {mainSection}
+          <AutoCrudDialog opened={!!item} onClose={handleCancel}>
+            {autoForm}
+          </AutoCrudDialog>
+        </>
       ) : (
-        autoForm
+        <SplitLayout theme="small">
+          {mainSection}
+          {autoForm}
+        </SplitLayout>
       )}
     </div>
   );


### PR DESCRIPTION
Makes the panels in auto crud resizable by wrapping them in a split layout. The split layout is only used for the desktop layout.