### PR TITLE
fix: avoid adding 'undefined' as class name

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -149,7 +149,7 @@ export function ExperimentalAutoCrud<TItem>({
   );
 
   return (
-    <div className={`auto-crud ${className}`} id={id} style={style}>
+    <div className={`auto-crud ${className ?? ''}`} id={id} style={style}>
       {fullScreen ? (
         <>
           {mainSection}

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -338,7 +338,7 @@ export function ExperimentalAutoForm<M extends AbstractModel>({
   }
 
   return (
-    <div className={`auto-form ${className}`} id={id} style={style} data-testid="auto-form">
+    <div className={`auto-form ${className ?? ''}`} id={id} style={style} data-testid="auto-form">
       <VerticalLayout className="auto-form-fields">
         {layout}
         {formError ? <div style={{ color: 'var(--lumo-error-color)' }}>{formError}</div> : <></>}

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -339,23 +339,34 @@ describe('@hilla/react-crud', () => {
       });
     });
 
-    it('renders with custom id, class name and style property on top most element', () => {
-      const { container } = render(
-        <ExperimentalAutoCrud
-          service={personService()}
-          model={PersonModel}
-          id="my-id"
-          className="custom-auto-crud"
-          style={{ backgroundColor: 'blue' }}
-        />,
-      );
+    describe('customize style props', () => {
+      it('renders properly without custom id, class name and style property', () => {
+        const { container } = render(<ExperimentalAutoCrud service={personService()} model={PersonModel} />);
+        const autoCrudElement = container.firstElementChild as HTMLElement;
 
-      const autoCrudElement = container.firstElementChild as HTMLElement;
+        expect(autoCrudElement).to.exist;
+        expect(autoCrudElement.id).to.equal('');
+        expect(autoCrudElement.className.trim()).to.equal('auto-crud');
+        expect(autoCrudElement.getAttribute('style')).to.equal(null);
+      });
 
-      expect(autoCrudElement).to.exist;
-      expect(autoCrudElement.id).to.equal('my-id');
-      expect(autoCrudElement.style.backgroundColor).to.equal('blue');
-      expect(autoCrudElement.className).to.include('custom-auto-crud');
+      it('renders with custom id, class name and style property on top most element', () => {
+        const { container } = render(
+          <ExperimentalAutoCrud
+            service={personService()}
+            model={PersonModel}
+            id="my-id"
+            className="custom-auto-crud"
+            style={{ backgroundColor: 'blue' }}
+          />,
+        );
+        const autoCrudElement = container.firstElementChild as HTMLElement;
+
+        expect(autoCrudElement).to.exist;
+        expect(autoCrudElement.id).to.equal('my-id');
+        expect(autoCrudElement.className.trim()).to.equal('auto-crud custom-auto-crud');
+        expect(autoCrudElement.getAttribute('style')).to.equal('background-color: blue;');
+      });
     });
   });
 });

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -804,23 +804,34 @@ describe('@hilla/react-crud', () => {
       });
     });
 
-    it('renders with custom id, class name and style property on top most element', () => {
-      const { container } = render(
-        <ExperimentalAutoForm
-          service={personService()}
-          model={PersonModel}
-          id="my-id"
-          className="custom-auto-form"
-          style={{ backgroundColor: 'blue' }}
-        />,
-      );
+    describe('customize style props', () => {
+      it('renders properly without custom id, class name and style property', () => {
+        const { container } = render(<ExperimentalAutoForm service={personService()} model={PersonModel} />);
+        const autoFormElement = container.firstElementChild as HTMLElement;
 
-      const autoFormElement = container.firstElementChild as HTMLElement;
+        expect(autoFormElement).to.exist;
+        expect(autoFormElement.id).to.equal('');
+        expect(autoFormElement.className.trim()).to.equal('auto-form');
+        expect(autoFormElement.getAttribute('style')).to.equal(null);
+      });
 
-      expect(autoFormElement).to.exist;
-      expect(autoFormElement.id).to.equal('my-id');
-      expect(autoFormElement.style.backgroundColor).to.equal('blue');
-      expect(autoFormElement.className).to.include('custom-auto-form');
+      it('renders with custom id, class name and style property on top most element', () => {
+        const { container } = render(
+          <ExperimentalAutoForm
+            service={personService()}
+            model={PersonModel}
+            id="my-id"
+            className="custom-auto-form"
+            style={{ backgroundColor: 'blue' }}
+          />,
+        );
+        const autoFormElement = container.firstElementChild as HTMLElement;
+
+        expect(autoFormElement).to.exist;
+        expect(autoFormElement.id).to.equal('my-id');
+        expect(autoFormElement.className.trim()).to.equal('auto-form custom-auto-form');
+        expect(autoFormElement.getAttribute('style')).to.equal('background-color: blue;');
+      });
     });
   });
 });


### PR DESCRIPTION
When not providing a custom class name to auto crud / form, it adds the class name `undefined`. This change sanitizes the class names to use an empty string as fallback if the class name is not defined.