### PR TITLE
feat(autoform): simplify basic form layout settings

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -44,7 +44,7 @@ export type AutoCrudProps<TItem> = ComponentStyleProps &
      * to customize which columns to show and in which order.
      *
      * By default, the form shows fields for all properties of the model which
-     * have a type that is supported. Use the `formProps.customLayoutRenderer`
+     * have a type that is supported. Use the `formProps.visibleFields`
      * option to customize which fields to show and in which order.
      */
     model: DetachedModelConstructor<AbstractModel<TItem>>;

--- a/packages/ts/react-crud/src/autoform-field.tsx
+++ b/packages/ts/react-crud/src/autoform-field.tsx
@@ -41,6 +41,12 @@ export type FieldOptions = Readonly<{
    * ```
    */
   renderer?(props: { field: FieldDirectiveResult; label: string }): JSX.Element;
+  /**
+   * The number of columns to span. This value is passed to the underlying
+   * FormLayout, unless a custom layout is used. In that case, the value is
+   * ignored.
+   */
+  colspan?: number;
 }>;
 
 function getPropertyModel(form: UseFormResult<any>, propertyInfo: PropertyInfo) {

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -4,7 +4,7 @@ import { ConfirmDialog } from '@hilla/react-components/ConfirmDialog';
 import { FormLayout } from '@hilla/react-components/FormLayout';
 import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
 import { useForm, type UseFormResult } from '@hilla/react-form';
-import { type ComponentType, type JSX, type ReactElement, useEffect, useState, cloneElement } from 'react';
+import { type ComponentType, type JSX, type ReactElement, useEffect, useState } from 'react';
 import { AutoFormField, type AutoFormFieldProps, type FieldOptions } from './autoform-field.js';
 import css from './autoform.obj.css';
 import type { CrudService } from './crud.js';

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -33,16 +33,6 @@ export type AutoFormLayoutRendererProps<M extends AbstractModel> = Readonly<{
   children: ReadonlyArray<ReactElement<AutoFormFieldProps>>;
 }>;
 
-type FieldColSpan = Readonly<{
-  property: string;
-  colSpan: number;
-}>;
-
-export type AutoFormLayoutProps = Readonly<{
-  template: FieldColSpan[][] | string[][];
-  responsiveSteps?: Array<{ minWidth: string; columns: number }>;
-}>;
-
 export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentStyleProps &
   Readonly<{
     /**

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -4,12 +4,12 @@ import { ConfirmDialog } from '@hilla/react-components/ConfirmDialog';
 import { FormLayout } from '@hilla/react-components/FormLayout';
 import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
 import { useForm, type UseFormResult } from '@hilla/react-form';
-import React, { type ComponentType, type JSX, type ReactElement, useEffect, useState } from 'react';
+import { type ComponentType, type JSX, type ReactElement, useEffect, useState, cloneElement } from 'react';
 import { AutoFormField, type AutoFormFieldProps, type FieldOptions } from './autoform-field.js';
 import css from './autoform.obj.css';
 import type { CrudService } from './crud.js';
 import { getIdProperty, getProperties, includeProperty, type PropertyInfo } from './property-info.js';
-import type { ComponentStyleProps } from './util';
+import type { ComponentStyleProps } from './util.js';
 
 document.adoptedStyleSheets.unshift(css);
 
@@ -59,8 +59,8 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      * used with a service that handles `Person` instances.
      *
      * By default, the form shows fields for all properties of the model which
-     * have a type that is supported. Use the `customLayoutRenderer` option to
-     * customize which fields to show and how to layout them.
+     * have a type that is supported. Use the `visibleFields` option to customize
+     * which fields to show and in which order.
      */
     model: DetachedModelConstructor<M>;
     /**
@@ -78,11 +78,24 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      */
     disabled?: boolean;
     /**
-     * Allows to customize the layout of the form, either by specifying rows of
-     * fields, or by providing a custom renderer. Please check the component's
-     * documentation for details.
+     * Allows to customize the layout of the form by providing a custom renderer.
+     * Check the component documentation for details.
      */
-    customLayoutRenderer?: AutoFormLayoutProps | ComponentType<AutoFormLayoutRendererProps<M>>;
+    layoutRenderer?: ComponentType<AutoFormLayoutRendererProps<M>>;
+    /**
+     * Defines the fields to show in the form, and in which order. This takes
+     * an array of property names. Properties that are not included in this
+     * array will not be shown in the form, and properties that are included,
+     * but don't exist in the model, will be ignored.
+     */
+    visibleFields?: string[];
+    /**
+     * Allows to customize the FormLayout used by default. This is especially useful
+     * to define the `responsiveSteps`. See the
+     * {@link https://hilla.dev/docs/react/components/form-layout | FormLayout documentation}
+     * for details.
+     */
+    formLayoutProps?: ComponentStyleProps & Pick<Parameters<typeof FormLayout>[0], 'responsiveSteps'>;
     /**
      * Allows to customize individual fields of the form. This takes an object
      * where the keys are property names, and the values are options for the
@@ -123,90 +136,6 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
     afterDelete?({ item }: DeleteEvent<Value<M>>): void;
   }>;
 
-type CustomFormLayoutProps = Readonly<{
-  customFormLayout: AutoFormLayoutProps;
-  children: ReadonlyArray<ReactElement<AutoFormFieldProps>>;
-}>;
-
-function findColumnCount(responsiveSteps: Array<{ minWidth: string; columns: number }>): number {
-  return responsiveSteps
-    .map((step: { minWidth: string; columns: number }) => ({
-      minWidth: parseInt(step.minWidth, 10),
-      columns: step.columns,
-    }))
-    .filter(({ minWidth }) => minWidth <= window.innerWidth)
-    .reduce(
-      (maxStep, step) => {
-        if (step.minWidth > maxStep.minWidth) {
-          return step;
-        }
-        return maxStep;
-      },
-      { minWidth: 0, columns: 1 },
-    ).columns;
-}
-
-function createGenericResponsiveSteps(
-  customFormLayout: AutoFormLayoutProps,
-): Array<{ minWidth: string; columns: number }> {
-  function gcd(a: number, b: number): number {
-    return a > 0 ? gcd(b % a, a) : b;
-  }
-
-  const lcm = (a: number, b: number) => (a * b) / gcd(a, b);
-
-  const minNeededColumns = customFormLayout.template.map((row) => row.length).reduce(lcm);
-
-  return [
-    { minWidth: '0', columns: 1 },
-    { minWidth: '800px', columns: minNeededColumns },
-  ];
-}
-
-function CustomFormLayout(customFormLayoutProps: CustomFormLayoutProps): JSX.Element {
-  const { customFormLayout, children } = customFormLayoutProps;
-  const fieldsByPropertyName = new Map<string, AutoFormFieldProps>();
-  children.forEach((field) => fieldsByPropertyName.set(field.props.propertyInfo.name, field.props));
-
-  let responsiveSteps: Array<{ minWidth: string; columns: number }>;
-  if (customFormLayout.responsiveSteps == null) {
-    responsiveSteps = createGenericResponsiveSteps(customFormLayout);
-  } else {
-    ({ responsiveSteps } = customFormLayout);
-  }
-
-  let weightedTemplate: FieldColSpan[][];
-  if (typeof customFormLayout.template[0][0] === 'string') {
-    const columnCount = findColumnCount(responsiveSteps);
-    weightedTemplate = (customFormLayout.template as string[][]).map((row) => {
-      const rowSize = row.length;
-      const colSpan = Math.ceil(columnCount / rowSize);
-      return row.map((property) => ({ property, colSpan }));
-    });
-  } else {
-    weightedTemplate = customFormLayout.template as FieldColSpan[][];
-  }
-
-  const spannedFields: JSX.Element[] = [];
-  weightedTemplate.forEach((row: FieldColSpan[]) => {
-    row.forEach((fieldColSpan: FieldColSpan) => {
-      const fieldProps = fieldsByPropertyName.get(fieldColSpan.property)!;
-      const spannedField = (
-        <AutoFormField
-          key={fieldProps.propertyInfo.name}
-          propertyInfo={fieldProps.propertyInfo}
-          form={fieldProps.form}
-          disabled={fieldProps.disabled}
-          colSpan={fieldColSpan.colSpan}
-        />
-      );
-      spannedFields.push(spannedField);
-    });
-  });
-
-  return <FormLayout responsiveSteps={responsiveSteps}>{spannedFields}</FormLayout>;
-}
-
 /**
  * Auto Form is a component that automatically generates a form for editing,
  * updating and deleting items from a backend service.
@@ -233,7 +162,9 @@ export function ExperimentalAutoForm<M extends AbstractModel>({
   onSubmitError,
   afterSubmit,
   disabled,
-  customLayoutRenderer: CustomLayoutRenderer,
+  layoutRenderer: LayoutRenderer,
+  visibleFields,
+  formLayoutProps,
   fieldOptions,
   style,
   id,
@@ -313,6 +244,9 @@ export function ExperimentalAutoForm<M extends AbstractModel>({
 
   function createAutoFormField(propertyInfo: PropertyInfo): JSX.Element {
     const fieldOptionsForProperty = fieldOptions?.[propertyInfo.name];
+    const colspanValue = fieldOptionsForProperty?.colspan;
+    const colspan = colspanValue ? { colspan: colspanValue } : {};
+
     return (
       <AutoFormField
         key={propertyInfo.name}
@@ -320,22 +254,27 @@ export function ExperimentalAutoForm<M extends AbstractModel>({
         form={form}
         disabled={disabled}
         options={fieldOptionsForProperty}
+        {...colspan}
       />
     );
   }
 
-  let layout: JSX.Element;
-  if (CustomLayoutRenderer === undefined) {
-    const fields = getProperties(model).filter(includeProperty).map(createAutoFormField);
-    layout = <FormLayout>{fields}</FormLayout>;
-  } else {
-    const fields = getProperties(model).map(createAutoFormField);
-    if (typeof CustomLayoutRenderer === 'function') {
-      layout = <CustomLayoutRenderer form={form}>{fields}</CustomLayoutRenderer>;
-    } else {
-      layout = <CustomFormLayout customFormLayout={CustomLayoutRenderer}>{fields}</CustomFormLayout>;
-    }
-  }
+  const defaultProperties = getProperties(model);
+
+  const visibleProperties = visibleFields
+    ? visibleFields.reduce<PropertyInfo[]>((foundProperties, propertyName) => {
+        const maybeProperty = defaultProperties.find((p) => p.name === propertyName);
+        return maybeProperty ? [...foundProperties, maybeProperty] : foundProperties;
+      }, [])
+    : defaultProperties.filter(includeProperty);
+
+  const fields = visibleProperties.map(createAutoFormField);
+
+  const layout = LayoutRenderer ? (
+    <LayoutRenderer form={form}>{fields}</LayoutRenderer>
+  ) : (
+    <FormLayout {...formLayoutProps}>{fields}</FormLayout>
+  );
 
   return (
     <div className={`auto-form ${className ?? ''}`} id={id} style={style} data-testid="auto-form">

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -327,7 +327,7 @@ describe('@hilla/react-crud', () => {
             <ExperimentalAutoCrud
               service={personService()}
               model={PersonModel}
-              formProps={{ customLayoutRenderer: { template: [['firstName', 'lastName']] } }}
+              formProps={{ visibleFields: ['firstName', 'lastName'] }}
             />,
           ),
           user,

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -404,7 +404,6 @@ describe('@hilla/react-crud', () => {
     describe('layoutRenderer', () => {
       it('uses default two-column form layout if layoutRenderer is not defined', async () => {
         const form = await populatePersonForm(1);
-        expect(form.formLayout.responsiveSteps).to.have.length(3);
         expect(form.formLayout.responsiveSteps).to.be.deep.equal([
           { minWidth: 0, columns: 1, labelsPosition: 'top' },
           { minWidth: '20em', columns: 1 },
@@ -437,6 +436,8 @@ describe('@hilla/react-crud', () => {
         const tagNames = fields.map((field) => field.localName);
         expect(tagNames).to.eql(['vaadin-text-field', 'vaadin-text-field', 'vaadin-number-field']);
         expect(form.queryField('Dummy')).to.be.undefined;
+        const genderField = form.queryField('Gender');
+        expect(genderField).to.be.undefined;
       });
     });
 

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -8,12 +8,11 @@ import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
 import { render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import chaiAsPromised from 'chai-as-promised';
-import type { ComponentType } from 'react';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
-  type AutoFormLayoutProps,
   type AutoFormLayoutRendererProps,
+  type AutoFormProps,
   emptyItem,
   ExperimentalAutoForm,
 } from '../src/autoform.js';
@@ -90,7 +89,7 @@ describe('@hilla/react-crud', () => {
 
     async function populatePersonForm(
       personId: number,
-      customLayoutRenderer?: AutoFormLayoutProps | ComponentType<AutoFormLayoutRendererProps<PersonModel>>,
+      formProps?: Omit<AutoFormProps<PersonModel>, 'item' | 'model' | 'service'>,
       screenSize?: string,
       disabled?: boolean,
     ): Promise<FormController> {
@@ -100,13 +99,7 @@ describe('@hilla/react-crud', () => {
       const service = personService();
       const person = await getItem(service, personId);
       const result = render(
-        <ExperimentalAutoForm
-          service={service}
-          model={PersonModel}
-          item={person}
-          disabled={disabled}
-          customLayoutRenderer={customLayoutRenderer}
-        />,
+        <ExperimentalAutoForm service={service} model={PersonModel} item={person} disabled={disabled} {...formProps} />,
       );
       return await FormController.init(user, result.container);
     }
@@ -408,7 +401,7 @@ describe('@hilla/react-crud', () => {
       expect(submitButton.disabled).to.be.true;
     });
 
-    it('customLayoutRenderer is not defined, default two-column form layout is used', async () => {
+    it('layoutRenderer is not defined, default two-column form layout is used', async () => {
       const form = await populatePersonForm(1);
       expect(form.formLayout.responsiveSteps).to.have.length(3);
       expect(form.formLayout.responsiveSteps).to.be.deep.equal([
@@ -424,175 +417,12 @@ describe('@hilla/react-crud', () => {
       await expectFieldColSpan(form, 'Some decimal', null);
     });
 
-    it('customLayoutRenderer is defined by string[][], number of columns and colspan is based on template rows', async () => {
-      const form = await populatePersonForm(
-        1,
-        {
-          template: [
-            ['firstName', 'lastName', 'email'],
-            ['someInteger', 'someDecimal'],
-            ['id', 'version'],
-          ],
-        },
-        'screen-1440-900',
-      );
-      expect(form.formLayout.responsiveSteps).to.have.length(2);
-      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
-        { minWidth: '0', columns: 1 },
-        { minWidth: '800px', columns: 6 },
-      ]);
-      await expectFieldColSpan(form, 'First name', '2');
-      await expectFieldColSpan(form, 'Last name', '2');
-      await expectFieldColSpan(form, 'Email', '2');
-      await expectFieldColSpan(form, 'Some integer', '3');
-      await expectFieldColSpan(form, 'Some decimal', '3');
-      await expectFieldColSpan(form, 'Id', '3');
-      await expectFieldColSpan(form, 'Version', '3');
-    });
-
-    it('customLayoutRenderer is defined by string[][] and custom responsiveSteps, number of columns and colspan is based on responsive steps', async () => {
-      const form = await populatePersonForm(
-        1,
-        {
-          responsiveSteps: [
-            { minWidth: '0', columns: 1 },
-            { minWidth: '800px', columns: 2 },
-            { minWidth: '1200px', columns: 3 },
-          ],
-          template: [['firstName', 'lastName', 'email'], ['someInteger'], ['someDecimal']],
-        },
-        'screen-1440-900',
-      );
-      expect(form.formLayout.responsiveSteps).to.have.length(3);
-      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
-        { minWidth: '0', columns: 1 },
-        { minWidth: '800px', columns: 2 },
-        { minWidth: '1200px', columns: 3 },
-      ]);
-      await expectFieldColSpan(form, 'First name', '1');
-      await expectFieldColSpan(form, 'Last name', '1');
-      await expectFieldColSpan(form, 'Email', '1');
-      await expectFieldColSpan(form, 'Some integer', '3');
-      await expectFieldColSpan(form, 'Some decimal', '3');
-    });
-
-    it('customLayoutRenderer is defined by string[][] and custom responsiveSteps, number of columns and colspan respects the screen size', async () => {
-      const form = await populatePersonForm(
-        1,
-        {
-          responsiveSteps: [
-            { minWidth: '0', columns: 1 },
-            { minWidth: '800px', columns: 2 },
-            { minWidth: '1200px', columns: 3 },
-          ],
-          template: [['firstName', 'lastName', 'email'], ['someInteger'], ['someDecimal']],
-        },
-        'screen-1024-768',
-      );
-
-      await expectFieldColSpan(form, 'First name', '1');
-      await expectFieldColSpan(form, 'Last name', '1');
-      await expectFieldColSpan(form, 'Email', '1');
-      await expectFieldColSpan(form, 'Some integer', '2');
-      await expectFieldColSpan(form, 'Some decimal', '2');
-    });
-
-    it('customLayoutRenderer is defined by string[][] and form is disabled, rendered fields are disabled properly', async () => {
-      const form = await populatePersonForm(
-        1,
-        {
-          responsiveSteps: [
-            { minWidth: '0', columns: 1 },
-            { minWidth: '800px', columns: 2 },
-            { minWidth: '1200px', columns: 3 },
-          ],
-          template: [['firstName', 'lastName', 'email'], ['someInteger'], ['someDecimal']],
-        },
-        'screen-1024-768',
-        true,
-      );
-
-      expect(await form.getField('First name')).to.have.attribute('disabled');
-    });
-
-    it('customLayoutRenderer is defined by FieldColSpan[][], number of columns is based on template rows and colspan is based on each FieldColSpan', async () => {
-      const form = await populatePersonForm(
-        1,
-        {
-          template: [
-            [
-              { property: 'firstName', colSpan: 2 },
-              { property: 'lastName', colSpan: 2 },
-              { property: 'email', colSpan: 2 },
-            ],
-            [
-              { property: 'someInteger', colSpan: 3 },
-              { property: 'someDecimal', colSpan: 3 },
-            ],
-            [
-              { property: 'id', colSpan: 3 },
-              { property: 'version', colSpan: 3 },
-            ],
-          ],
-        },
-        'screen-1440-900',
-      );
-      expect(form.formLayout.responsiveSteps).to.have.length(2);
-      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
-        { minWidth: '0', columns: 1 },
-        { minWidth: '800px', columns: 6 },
-      ]);
-      await expectFieldColSpan(form, 'First name', '2');
-      await expectFieldColSpan(form, 'Last name', '2');
-      await expectFieldColSpan(form, 'Email', '2');
-      await expectFieldColSpan(form, 'Some integer', '3');
-      await expectFieldColSpan(form, 'Some decimal', '3');
-      await expectFieldColSpan(form, 'Id', '3');
-      await expectFieldColSpan(form, 'Version', '3');
-    });
-
-    it('customLayoutRenderer is defined by FieldColSpan[][] and responsiveSteps, number of columns is based on responsiveSteps and colspan is based on each FieldColSpan', async () => {
-      const form = await populatePersonForm(
-        1,
-        {
-          responsiveSteps: [
-            { minWidth: '0', columns: 1 },
-            { minWidth: '800px', columns: 2 },
-            { minWidth: '1200px', columns: 3 },
-          ],
-          template: [
-            [
-              { property: 'firstName', colSpan: 1 },
-              { property: 'lastName', colSpan: 1 },
-              { property: 'email', colSpan: 1 },
-            ],
-            [
-              { property: 'someInteger', colSpan: 2 },
-              { property: 'someDecimal', colSpan: 1 },
-            ],
-          ],
-        },
-        'screen-1440-900',
-      );
-      expect(form.formLayout.responsiveSteps).to.have.length(3);
-      expect(form.formLayout.responsiveSteps).to.be.deep.equal([
-        { minWidth: '0', columns: 1 },
-        { minWidth: '800px', columns: 2 },
-        { minWidth: '1200px', columns: 3 },
-      ]);
-      await expectFieldColSpan(form, 'First name', '1');
-      await expectFieldColSpan(form, 'Last name', '1');
-      await expectFieldColSpan(form, 'Email', '1');
-      await expectFieldColSpan(form, 'Some integer', '2');
-      await expectFieldColSpan(form, 'Some decimal', '1');
-    });
-
-    it('customLayoutRenderer is defined as a function that renders the fields in a vertical manner, VerticalLayout is used instead of FormLayout', async () => {
-      function MyCustomLayoutRenderer({ children, form }: AutoFormLayoutRendererProps<PersonModel>) {
+    it('layoutRenderer is defined as a function that renders the fields in a vertical manner, VerticalLayout is used instead of FormLayout', async () => {
+      function MyLayoutRenderer({ children }: AutoFormLayoutRendererProps<PersonModel>) {
         return <VerticalLayout>{children}</VerticalLayout>;
       }
 
-      const form = await populatePersonForm(1, MyCustomLayoutRenderer, 'screen-1440-900');
+      const form = await populatePersonForm(1, { layoutRenderer: MyLayoutRenderer }, 'screen-1440-900');
       expect(form.formLayout).to.not.exist;
       const layout = await waitFor(() => form.renderResult.querySelector('vaadin-vertical-layout')!);
       expect(layout).to.exist;


### PR DESCRIPTION
The way `AutoForm` is customized changes:

- `visibleFields` is used to list fields that are visible in the form (and their order)
- `formLayoutProps` is used to pass `responsiveSteps` and `ComponentStyleProps` properties to the default `FormLayout`
- `colspan` is added to `fieldOptions` and passed to the default `FormLayout`
- `customLayoutRenderder` is renamed to `layoutRenderer`

Closes #1678