### PR TITLE
fix(form): use correct call for interpolateMessageCallback (#1694) (CP: 2.3)

### DIFF
--- a/packages/ts/form/package.json
+++ b/packages/ts/form/package.json
@@ -48,6 +48,9 @@
     "./Models.js": {
       "default": "./Models.js"
     },
+    "./util.js": {
+      "types": "./util.d.ts"
+    },
     "./Validation.js": {
       "default": "./Validation.js"
     },

--- a/packages/ts/form/src/Binder.ts
+++ b/packages/ts/form/src/Binder.ts
@@ -1,7 +1,6 @@
 import type { LitElement } from 'lit';
-import { BinderRoot, type BinderConfiguration } from './BinderRoot.js';
-import type { AbstractModel, DetachedModelConstructor } from './Models.js';
-import type { Value } from './Models.js';
+import { type BinderConfiguration, BinderRoot } from './BinderRoot.js';
+import type { AbstractModel, DetachedModelConstructor, Value } from './Models.js';
 
 /**
  * A Binder controls all aspects of a single form.
@@ -12,6 +11,8 @@ import type { Value } from './Models.js';
  * @typeParam M - Type of the model that describes the structure of the value
  */
 export class Binder<M extends AbstractModel> extends BinderRoot<M> {
+  declare readonly ['constructor']: Omit<typeof Binder<M>, 'constructor'>;
+
   context: Element;
 
   /**

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -29,6 +29,7 @@ import {
   ObjectModel,
   type Value,
 } from './Models.js';
+import type { ClassStaticProperties } from './util.js';
 import type { Validator, ValueError } from './Validation.js';
 import { ValidityStateValidator } from './Validators.js';
 import { _validity } from './Validity.js';
@@ -113,7 +114,7 @@ const defaultArrayItemCache = new WeakMap<BinderNode, unknown>();
  * instances.
  */
 export class BinderNode<M extends AbstractModel = AbstractModel> extends EventTarget {
-  declare readonly ['constructor']: typeof BinderNode;
+  declare readonly ['constructor']: ClassStaticProperties<typeof BinderNode<M>>;
   readonly model: M;
   /**
    * The validity state read from the bound element, if any. Represents the

--- a/packages/ts/form/src/BinderRoot.ts
+++ b/packages/ts/form/src/BinderRoot.ts
@@ -9,12 +9,13 @@ import {
 } from './BinderNode.js';
 import { type FieldElement, type FieldStrategy, getDefaultFieldStrategy } from './Field.js';
 import {
-  createDetachedModel,
   _parent,
   type AbstractModel,
+  createDetachedModel,
   type DetachedModelConstructor,
   type Value,
 } from './Models.js';
+import type { ClassStaticProperties } from './util.js';
 import {
   type InterpolateMessageCallback,
   runValidator,
@@ -61,6 +62,8 @@ export class BinderRoot<M extends AbstractModel = AbstractModel> extends BinderN
   #validations = new Map<AbstractModel, Map<Validator, Promise<readonly ValueError[]>>>();
 
   readonly #context: unknown = this;
+
+  declare readonly ['constructor']: ClassStaticProperties<typeof BinderRoot<M>>;
 
   /**
    *
@@ -255,7 +258,7 @@ export class BinderRoot<M extends AbstractModel = AbstractModel> extends BinderN
       return modelValidations.get(validator)!;
     }
 
-    const promise = runValidator(model, validator, BinderRoot.interpolateMessageCallback);
+    const promise = runValidator(model, validator, this.constructor.interpolateMessageCallback);
     modelValidations.set(validator, promise);
     const valueErrors = await promise;
 

--- a/packages/ts/form/src/util.d.ts
+++ b/packages/ts/form/src/util.d.ts
@@ -1,0 +1,3 @@
+import type { Constructor } from 'type-fest';
+
+export type ClassStaticProperties<T extends Constructor<unknown>> = Omit<T, 'constructor'>;

--- a/packages/ts/form/test/Validation.test.ts
+++ b/packages/ts/form/test/Validation.test.ts
@@ -10,7 +10,6 @@ import sinonChai from 'sinon-chai';
 // API to test
 import {
   Binder,
-  BinderRoot,
   field,
   type InterpolateMessageCallback,
   NotBlank,
@@ -810,10 +809,10 @@ describe('@hilla/form', () => {
         const callback: InterpolateMessageCallback<any> = (_message, _validator, _binderNode) =>
           // Interpolates all error messages as 'custom message'
           'custom message';
-        BinderRoot.interpolateMessageCallback = sinon.spy(callback);
+        Binder.interpolateMessageCallback = sinon.spy(callback);
 
         const errors = await testMessageBinder.validate();
-        expect(BinderRoot.interpolateMessageCallback).to.be.called;
+        expect(Binder.interpolateMessageCallback).to.be.called;
         expect(errors).to.have.lengthOf.at.least(1);
         for (const [i, error] of errors.entries()) {
           expect(error.message).to.equal('custom message', `errors[${i}]`);
@@ -829,10 +828,10 @@ describe('@hilla/form', () => {
           }
           return message;
         };
-        BinderRoot.interpolateMessageCallback = sinon.spy(callback);
+        Binder.interpolateMessageCallback = sinon.spy(callback);
 
         const errors = await testMessageBinder.validate();
-        expect(BinderRoot.interpolateMessageCallback).to.be.called;
+        expect(Binder.interpolateMessageCallback).to.be.called;
         const error = errors.find((e) => e.validator instanceof NotBlank);
         expect(error?.message).to.equal('must *NOT BE* blank');
       });
@@ -843,10 +842,10 @@ describe('@hilla/form', () => {
           expect(binderNode).to.have.property('model');
           return `[value: ${String(binderNode.value)}] ${message}`;
         };
-        BinderRoot.interpolateMessageCallback = sinon.spy(callback);
+        Binder.interpolateMessageCallback = sinon.spy(callback);
 
         const errors = await testMessageBinder.validate();
-        expect(BinderRoot.interpolateMessageCallback).to.be.called;
+        expect(Binder.interpolateMessageCallback).to.be.called;
         const error = errors.find((e) => e.validator instanceof Size);
         expect(error?.message ?? '').to.include('[value: 123]');
       });


### PR DESCRIPTION
* fix(form): use correct call for interpolateMessageCallback

* fix(form): resolve typings failure

(cherry picked from commit ad5ee2b3ad3fcb87de72a55c503401a09093c6a2)