### PR TITLE
fix(form): use correct call for interpolateMessageCallback (#1694) (CP: 2.2)

### DIFF
--- a/packages/ts/form/package.json
+++ b/packages/ts/form/package.json
@@ -49,6 +49,9 @@
     "./Models.js": {
       "default": "./Models.js"
     },
+    "./util.js": {
+      "types": "./util.d.ts"
+    },
     "./Validation.js": {
       "default": "./Validation.js"
     },

--- a/packages/ts/form/src/Binder.ts
+++ b/packages/ts/form/src/Binder.ts
@@ -11,6 +11,8 @@ import type { AbstractModel, ModelConstructor } from './Models.js';
  * @typeParam M - Type of the model that describes the structure of the value
  */
 export class Binder<T, M extends AbstractModel<T>> extends BinderRoot<T, M> {
+  declare readonly ['constructor']: Omit<typeof Binder<T, M>, 'constructor'>;
+
   context: Element;
 
   /**

--- a/packages/ts/form/src/BinderNode.ts
+++ b/packages/ts/form/src/BinderNode.ts
@@ -29,6 +29,7 @@ import {
   type ModelValue,
   ObjectModel,
 } from './Models.js';
+import type { ClassStaticProperties } from './util.js';
 import type { Validator, ValueError } from './Validation.js';
 import { ValidityStateValidator } from './Validators.js';
 import { _validity } from './Validity.js';
@@ -96,6 +97,7 @@ export const CHANGED = new Event('binder-node-changed');
  * instances.
  */
 export class BinderNode<T, M extends AbstractModel<T>> extends EventTarget {
+  declare readonly ['constructor']: ClassStaticProperties<typeof BinderNode<T, M>>;
   readonly model: M;
 
   /**

--- a/packages/ts/form/src/BinderRoot.ts
+++ b/packages/ts/form/src/BinderRoot.ts
@@ -2,6 +2,7 @@ import { EndpointValidationError, type ValidationErrorData } from '@hilla/fronte
 import { BinderNode, CHANGED } from './BinderNode.js';
 import { type FieldStrategy, getDefaultFieldStrategy } from './Field.js';
 import { _parent, type AbstractModel, type HasValue, type ModelConstructor } from './Models.js';
+import type { ClassStaticProperties } from './util.js';
 import {
   type InterpolateMessageCallback,
   runValidator,
@@ -59,6 +60,8 @@ export class BinderRoot<T, M extends AbstractModel<T>> extends BinderNode<T, M> 
   private [_validations] = new Map<AbstractModel<any>, Map<Validator<any>, Promise<ReadonlyArray<ValueError<any>>>>>();
 
   #context: any = this;
+
+  declare readonly ['constructor']: ClassStaticProperties<typeof BinderRoot<T, M>>;
 
   /**
    *
@@ -244,7 +247,7 @@ export class BinderRoot<T, M extends AbstractModel<T>> extends BinderNode<T, M> 
       return modelValidations.get(validator)!;
     }
 
-    const promise = runValidator(model, validator, BinderRoot.interpolateMessageCallback);
+    const promise = runValidator(model, validator, this.constructor.interpolateMessageCallback);
     modelValidations.set(validator, promise);
     const valueErrors = await promise;
 

--- a/packages/ts/form/src/util.d.ts
+++ b/packages/ts/form/src/util.d.ts
@@ -1,0 +1,3 @@
+import type { Constructor } from 'type-fest';
+
+export type ClassStaticProperties<T extends Constructor<unknown>> = Omit<T, 'constructor'>;

--- a/packages/ts/form/test/Validation.test.ts
+++ b/packages/ts/form/test/Validation.test.ts
@@ -10,7 +10,6 @@ import sinonChai from 'sinon-chai';
 // API to test
 import {
   Binder,
-  BinderRoot,
   field,
   type InterpolateMessageCallback,
   NotBlank,
@@ -804,10 +803,10 @@ describe('@hilla/form', () => {
         const callback: InterpolateMessageCallback<any> = (_message, _validator, _binderNode) =>
           // Interpolates all error messages as 'custom message'
           'custom message';
-        BinderRoot.interpolateMessageCallback = sinon.spy(callback);
+        Binder.interpolateMessageCallback = sinon.spy(callback);
 
         const errors = await testMessageBinder.validate();
-        expect(BinderRoot.interpolateMessageCallback).to.be.called;
+        expect(Binder.interpolateMessageCallback).to.be.called;
         expect(errors).to.have.lengthOf.at.least(1);
         for (const [i, error] of errors.entries()) {
           expect(error.message).to.equal('custom message', `errors[${i}]`);
@@ -823,10 +822,10 @@ describe('@hilla/form', () => {
           }
           return message;
         };
-        BinderRoot.interpolateMessageCallback = sinon.spy(callback);
+        Binder.interpolateMessageCallback = sinon.spy(callback);
 
         const errors = await testMessageBinder.validate();
-        expect(BinderRoot.interpolateMessageCallback).to.be.called;
+        expect(Binder.interpolateMessageCallback).to.be.called;
         const error = errors.find((e) => e.validator instanceof NotBlank);
         expect(error?.message).to.equal('must *NOT BE* blank');
       });
@@ -837,10 +836,10 @@ describe('@hilla/form', () => {
           expect(binderNode).to.have.property('model');
           return `[value: ${String(binderNode.value)}] ${message}`;
         };
-        BinderRoot.interpolateMessageCallback = sinon.spy(callback);
+        Binder.interpolateMessageCallback = sinon.spy(callback);
 
         const errors = await testMessageBinder.validate();
-        expect(BinderRoot.interpolateMessageCallback).to.be.called;
+        expect(Binder.interpolateMessageCallback).to.be.called;
         const error = errors.find((e) => e.validator instanceof Size);
         expect(error?.message ?? '').to.include('[value: 123]');
       });

--- a/packages/ts/react-form/src/index.ts
+++ b/packages/ts/react-form/src/index.ts
@@ -234,7 +234,7 @@ export function useForm<T, M extends AbstractModel<T>>(
   }, [binder]);
 
   return {
-    ...getFormPart(binder),
+    ...getFormPart<T, M>(binder),
     clear: binder.clear.bind(binder),
     field,
     read: binder.read.bind(binder),


### PR DESCRIPTION
* fix(form): use correct call for interpolateMessageCallback

* fix(form): resolve typings failure

(cherry picked from commit ad5ee2b3ad3fcb87de72a55c503401a09093c6a2)