### PR TITLE
fix(frontend+autoform): use proper error types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16909,6 +16909,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hilla/form": "2.4.0-alpha7",
+        "@hilla/frontend": "2.4.0-alpha7",
         "@hilla/react-components": "2.2.1",
         "@hilla/react-form": "2.4.0-alpha7",
         "@vaadin/vaadin-lumo-styles": "24.2.2"

--- a/packages/ts/frontend/src/Connect.ts
+++ b/packages/ts/frontend/src/Connect.ts
@@ -67,9 +67,10 @@ const assertResponseIsOk = async (response: Response): Promise<void> => {
     }
 
     const message =
-      errorJson?.message ?? errorText.length > 0
+      errorJson?.message ??
+      (errorText.length > 0
         ? errorText
-        : `expected "200 OK" response, but got ${response.status} ${response.statusText}`;
+        : `expected "200 OK" response, but got ${response.status} ${response.statusText}`);
     const type = errorJson?.type;
 
     if (errorJson?.validationErrorData) {

--- a/packages/ts/react-crud/package.json
+++ b/packages/ts/react-crud/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@hilla/form": "2.4.0-alpha7",
+    "@hilla/frontend": "2.4.0-alpha7",
     "@hilla/react-components": "2.2.1",
     "@hilla/react-form": "2.4.0-alpha7",
     "@vaadin/vaadin-lumo-styles": "24.2.2"

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -223,9 +223,14 @@ export function AutoForm<M extends AbstractModel>({
         afterDelete({ item: deletedItem });
       }
     } catch (error) {
-      if (onDeleteError && error instanceof EndpointError) {
-        onDeleteError({ error });
+      if (error instanceof EndpointError) {
+        if (onDeleteError) {
+          onDeleteError({ error });
+        } else {
+          setFormError(error.message);
+        }
       }
+      throw error;
     } finally {
       setShowDeleteDialog(false);
     }

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -1,4 +1,5 @@
 import { type AbstractModel, type DetachedModelConstructor, ValidationError, type Value } from '@hilla/form';
+import { EndpointError } from '@hilla/frontend';
 import { Button } from '@hilla/react-components/Button.js';
 import { ConfirmDialog } from '@hilla/react-components/ConfirmDialog';
 import { FormLayout } from '@hilla/react-components/FormLayout';
@@ -16,13 +17,13 @@ document.adoptedStyleSheets.unshift(css);
 export const emptyItem = Symbol();
 
 type SubmitErrorEvent = {
-  error: unknown;
+  error: EndpointError;
 };
 type SubmitEvent<TItem> = {
   item: TItem;
 };
 type DeleteErrorEvent = {
-  error: unknown;
+  error: EndpointError;
 };
 type DeleteEvent<TItem> = {
   item: TItem;
@@ -185,7 +186,7 @@ export function AutoForm<M extends AbstractModel>({
       const newItem = await form.submit();
       if (newItem === undefined) {
         // If update returns an empty object, then no update was performed
-        throw new Error('generic error');
+        throw new EndpointError('No update performed');
       } else if (afterSubmit) {
         afterSubmit({ item: newItem });
       }
@@ -195,7 +196,7 @@ export function AutoForm<M extends AbstractModel>({
         return;
       }
       const genericError = 'Something went wrong, please check all your values';
-      if (onSubmitError) {
+      if (onSubmitError && error instanceof EndpointError) {
         onSubmitError({ error });
       } else {
         setFormError(genericError);
@@ -220,7 +221,7 @@ export function AutoForm<M extends AbstractModel>({
         afterDelete({ item: deletedItem });
       }
     } catch (error) {
-      if (onDeleteError) {
+      if (onDeleteError && error instanceof EndpointError) {
         onDeleteError({ error });
       }
     } finally {

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -195,12 +195,14 @@ export function AutoForm<M extends AbstractModel>({
         // Handled automatically
         return;
       }
-      const genericError = 'Something went wrong, please check all your values';
-      if (onSubmitError && error instanceof EndpointError) {
-        onSubmitError({ error });
-      } else {
-        setFormError(genericError);
+      if (error instanceof EndpointError) {
+        if (onSubmitError) {
+          onSubmitError({ error });
+        } else {
+          setFormError(error.message);
+        }
       }
+      throw error;
     }
   }
 

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -272,6 +272,30 @@ describe('@hilla/react-crud', () => {
       expect(result.queryByText('foobar')).to.not.be.null;
     });
 
+    it('shows a predefined error message when the service returns no entity after saving', async () => {
+      const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
+      service.save = async (item: Person): Promise<Person | undefined> => {
+        return Promise.resolve(undefined);
+      };
+      const person = await getItem(service, 1);
+      const errorSpy = sinon.spy();
+      const submitSpy = sinon.spy();
+      const result = render(
+        <AutoForm
+          service={service}
+          model={PersonModel}
+          item={person}
+          afterSubmit={submitSpy}
+          onSubmitError={errorSpy}
+        />,
+      );
+      const form = await FormController.init(user, result.container);
+      await form.typeInField('First name', 'J'); // to enable the submit button
+      await form.submit();
+      expect(submitSpy).to.have.not.been.called;
+      expect(errorSpy).to.have.been.calledWith(sinon.match.hasNested('error.message', 'No update performed'));
+    });
+
     it('calls afterSubmitError and does not show error if the endpoint call fails', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
       // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -274,9 +274,7 @@ describe('@hilla/react-crud', () => {
 
     it('shows a predefined error message when the service returns no entity after saving', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
-      service.save = async (item: Person): Promise<Person | undefined> => {
-        return Promise.resolve(undefined);
-      };
+      service.save = async (item: Person): Promise<Person | undefined> => Promise.resolve(undefined);
       const person = await getItem(service, 1);
       const errorSpy = sinon.spy();
       const submitSpy = sinon.spy();

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -2,6 +2,7 @@
 /// <reference types="karma-viewport" />
 
 import { expect, use } from '@esm-bundle/chai';
+import { EndpointError } from '@hilla/frontend';
 import type { SelectElement } from '@hilla/react-components/Select.js';
 import { TextArea } from '@hilla/react-components/TextArea.js';
 import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
@@ -28,7 +29,6 @@ import {
 use(sinonChai);
 use(chaiAsPromised);
 
-const DEFAULT_ERROR_MESSAGE = 'Something went wrong, please check all your values';
 describe('@hilla/react-crud', () => {
   describe('Auto form', () => {
     const LABELS = [
@@ -259,7 +259,7 @@ describe('@hilla/react-crud', () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
       // eslint-disable-next-line @typescript-eslint/require-await
       service.save = async (item: Person): Promise<Person | undefined> => {
-        throw new Error('foobar');
+        throw new EndpointError('foobar');
       };
       const person = await getItem(service, 1);
       const submitSpy = sinon.spy();
@@ -269,14 +269,14 @@ describe('@hilla/react-crud', () => {
       await form.typeInField('First name', 'J'); // to enable the submit button
       await form.submit();
       expect(submitSpy).to.have.not.been.called;
-      expect(result.queryByText(DEFAULT_ERROR_MESSAGE)).to.not.be.null;
+      expect(result.queryByText('foobar')).to.not.be.null;
     });
 
     it('calls afterSubmitError and does not show error if the endpoint call fails', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
       // eslint-disable-next-line @typescript-eslint/require-await
       service.save = async (item: Person): Promise<Person | undefined> => {
-        throw new Error('foobar');
+        throw new EndpointError('foobar');
       };
       const person = await getItem(service, 1);
       const errorSpy = sinon.spy();
@@ -293,7 +293,7 @@ describe('@hilla/react-crud', () => {
       const form = await FormController.init(user, result.container);
       await form.typeInField('First name', 'J'); // to enable the submit button
       await form.submit();
-      expect(result.queryByText(DEFAULT_ERROR_MESSAGE)).to.be.null;
+      expect(result.queryByText('foobar')).to.be.null;
       expect(submitSpy).to.have.not.been.called;
       expect(errorSpy).to.have.been.calledWith(sinon.match.hasNested('error.message', 'foobar'));
     });
@@ -532,7 +532,7 @@ describe('@hilla/react-crud', () => {
       });
 
       it('calls error callback if delete fails', async () => {
-        const error = new Error('Delete failed');
+        const error = new EndpointError('Delete failed');
         deleteStub.returns(Promise.reject(error));
 
         const form = await renderForm(person, true);


### PR DESCRIPTION
Fixes `frontend` error message logic.
Proposes a way to handle error types in Auto Form.

It works better if endpoints throw `EndpointException`s, as in that case it's able to get back the message of the original exception, but also works reasonably for other exceptions.

If this can be a good solution, I'll work on the tests.

Conflicts with #1715, we should make a choice.