### PR TITLE
refactor: clarify auto form renderer props

### DIFF
--- a/packages/ts/react-crud/src/autoform-field.tsx
+++ b/packages/ts/react-crud/src/autoform-field.tsx
@@ -36,8 +36,8 @@ export type FieldOptions = Readonly<{
    * Example:
    * ```tsx
    * {
-   *   renderer: ({ field, label }) => (
-   *     <TextArea {...field} label={label} />
+   *   renderer: ({ field }) => (
+   *     <TextArea {...field} />
    *   )
    * }
    * ```

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -68,8 +68,30 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      */
     disabled?: boolean;
     /**
-     * Allows to customize the layout of the form by providing a custom renderer.
-     * Check the component documentation for details.
+     * Allows to customize the layout of the form by providing a custom
+     * renderer. The renderer receives the form instance and the pre-rendered
+     * fields as props. The renderer can either reuse the pre-rendered fields in
+     * the custom layout, or render custom fields and connect them to the form
+     * manually.
+     *
+     * Check the component documentation for details and examples.
+     *
+     * Example using pre-rendered fields:
+     * ```tsx
+     * <AutoForm layoutRenderer={({ children }) =>
+     *   <VerticalLayout>{children}</VerticalLayout>
+     * } />
+     * ```
+     *
+     * Example rendering custom fields:
+     * ```tsx
+     * <AutoForm layoutRenderer={({ form }) =>
+     *   <VerticalLayout>
+     *     <TextField {...form.field(form.model.name)} />
+     *     ...
+     *   </VerticalLayout>
+     * } />
+     * ```
      */
     layoutRenderer?: ComponentType<AutoFormLayoutRendererProps<M>>;
     /**

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -79,7 +79,10 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      * Example using pre-rendered fields:
      * ```tsx
      * <AutoForm layoutRenderer={({ children }) =>
-     *   <VerticalLayout>{children}</VerticalLayout>
+     *   <VerticalLayout>
+     *     {children}
+     *     <p>All data is collected anonymously.</p>
+     *   </VerticalLayout>
      * } />
      * ```
      *


### PR DESCRIPTION
Following feedback from the DX tests:
- Fixes the field renderer docs to remove the label prop that was removed
- Expands the form layout renderer docs and adds examples