### PR TITLE
chore(2.3) update CRUD dependencies

### DIFF
--- a/packages/ts/react-crud/package.json
+++ b/packages/ts/react-crud/package.json
@@ -48,9 +48,9 @@
   },
   "dependencies": {
     "@hilla/form": "2.3.3",
-    "@hilla/react-components": "2.2.0",
+    "@hilla/react-components": "2.2.2",
     "@hilla/react-form": "2.3.3",
-    "@vaadin/vaadin-lumo-styles": "24.2.0"
+    "@vaadin/vaadin-lumo-styles": "24.2.2"
   },
   "peerDependencies": {
     "react": "^18"


### PR DESCRIPTION
Some versions are still lagging behind in branch 2.3. A new patch release is needed to avoid the `Tried to define vaadin-lumo-styles version 24.2.0 when version 24.2.1 is already in use. Something will probably break.` error.