### PR TITLE
fix: allow hiding delete button through form props

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -14,7 +14,7 @@ document.adoptedStyleSheets.unshift(css);
 
 export type AutoCrudFormProps<TItem> = Omit<
   Partial<AutoFormProps<AbstractModel<TItem>>>,
-  'afterSubmit' | 'disabled' | 'item' | 'model' | 'service'
+  'afterDelete' | 'afterSubmit' | 'disabled' | 'item' | 'model' | 'service'
 >;
 
 export type AutoCrudGridProps<TItem> = Omit<
@@ -49,11 +49,6 @@ export type AutoCrudProps<TItem> = ComponentStyleProps &
      */
     model: DetachedModelConstructor<AbstractModel<TItem>>;
     /**
-     * Allows to disable the delete functionality, which means that no delete
-     * button is shown in the form.
-     */
-    noDelete?: boolean;
-    /**
      * Props to pass to the form. See the `AutoForm` component for details.
      */
     formProps?: AutoCrudFormProps<TItem>;
@@ -81,7 +76,6 @@ export type AutoCrudProps<TItem> = ComponentStyleProps &
 export function AutoCrud<TItem>({
   service,
   model,
-  noDelete,
   formProps,
   gridProps,
   style,
@@ -127,12 +121,12 @@ export function AutoCrud<TItem>({
 
   const autoForm = (
     <AutoForm
+      deleteButtonVisible={true}
       {...formProps}
       disabled={!item}
       service={service}
       model={model}
       item={item}
-      deleteButtonVisible={!noDelete}
       afterSubmit={({ item: submittedItem }) => {
         if (fullScreen) {
           setItem(undefined);

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -125,6 +125,11 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      *
      * Use the `afterDelete` callback to get notified when the item has been
      * deleted.
+     *
+     * NOTE: This only hides the button, it does not prevent from calling the
+     * delete method on the service. To completely disable deleting, you must
+     * override the `delete` method in the backend Java service to either throw
+     * an exception or annotate it with `@DenyAll` to prevent access.
      */
     deleteButtonVisible?: boolean;
     /**

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -211,15 +211,18 @@ describe('@hilla/react-crud', () => {
       expect(grid.getVisibleRowCount()).to.equal(2);
     });
 
-    it('does render a delete button without noDelete', async () => {
+    it('does render a delete button by default', async () => {
       const { grid, form } = await CrudController.init(render(<TestAutoCrud />), user);
       await grid.toggleRowSelected(1);
       const deleteButton = form.queryButton('Delete...');
       expect(deleteButton).to.exist;
     });
 
-    it('does not render a delete button with noDelete', async () => {
-      const { grid, form } = await CrudController.init(render(<TestAutoCrud noDelete />), user);
+    it('does not render a delete button when hiding the delete button through form props', async () => {
+      const { grid, form } = await CrudController.init(
+        render(<TestAutoCrud formProps={{ deleteButtonVisible: false }} />),
+        user,
+      );
       await grid.toggleRowSelected(1);
       const deleteButton = form.queryButton('Delete...');
       expect(deleteButton).to.not.exist;


### PR DESCRIPTION
Based on the DX test feedback, most testers were not able to hide the delete button, as most tried to hide it through the `deleteButtonVisible` form prop, which was overridden by the auto crud's `noDelete` prop (which is not documented). This change removes the `noDelete` prop, so that hiding the button can only be done through `formProps`. This aligns it with how other form options are configured and also resolves the naming conflict. 

This also adds a note to the JS Doc that hiding the button does not prevent calling the service directly and advises for possible solutions.