### PR TITLE
refactor!: improve auto form event handler naming

### DIFF
--- a/packages/java/tests/spring/react-grid-test/frontend/views/AutoFormView.tsx
+++ b/packages/java/tests/spring/react-grid-test/frontend/views/AutoFormView.tsx
@@ -34,9 +34,9 @@ export function AutoFormView(): JSX.Element {
           <AutoForm
             service={AppointmentService}
             model={AppointmentModel}
-            afterSubmit={handleSubmit}
+            onSubmitSuccess={handleSubmit}
             onSubmitError={handleSubmitError}
-            afterDelete={handleDelete}
+            onDeleteSuccess={handleDelete}
             onDeleteError={handleDeleteError}
           />
         </>

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -14,7 +14,7 @@ document.adoptedStyleSheets.unshift(css);
 
 export type AutoCrudFormProps<TItem> = Omit<
   Partial<AutoFormProps<AbstractModel<TItem>>>,
-  'onDeleteSuccess' | 'onSubmitSuccess' | 'disabled' | 'item' | 'model' | 'service'
+  'disabled' | 'item' | 'model' | 'onDeleteSuccess' | 'onSubmitSuccess' | 'service'
 >;
 
 export type AutoCrudGridProps<TItem> = Omit<

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -14,7 +14,7 @@ document.adoptedStyleSheets.unshift(css);
 
 export type AutoCrudFormProps<TItem> = Omit<
   Partial<AutoFormProps<AbstractModel<TItem>>>,
-  'afterDelete' | 'afterSubmit' | 'disabled' | 'item' | 'model' | 'service'
+  'onDeleteSuccess' | 'onSubmitSuccess' | 'disabled' | 'item' | 'model' | 'service'
 >;
 
 export type AutoCrudGridProps<TItem> = Omit<
@@ -127,7 +127,7 @@ export function AutoCrud<TItem>({
       service={service}
       model={model}
       item={item}
-      afterSubmit={({ item: submittedItem }) => {
+      onSubmitSuccess={({ item: submittedItem }) => {
         if (fullScreen) {
           setItem(undefined);
         } else {
@@ -135,7 +135,7 @@ export function AutoCrud<TItem>({
         }
         refreshGrid();
       }}
-      afterDelete={() => {
+      onDeleteSuccess={() => {
         setItem(undefined);
         refreshGrid();
       }}

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -59,7 +59,7 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      * with values from the item's properties. In order to create a new item,
      * either pass `null`, or leave this prop as undefined.
      *
-     * Use the `afterSubmit` callback to get notified when the item has been
+     * Use the `onSubmitSuccess` callback to get notified when the item has been
      * saved.
      */
     item?: Value<M> | typeof emptyItem | null;
@@ -123,7 +123,7 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      * default. If enabled, the delete button will only be shown when editing
      * an existing item, which means that `item` is not null.
      *
-     * Use the `afterDelete` callback to get notified when the item has been
+     * Use the `onDeleteSuccess` callback to get notified when the item has been
      * deleted.
      *
      * NOTE: This only hides the button, it does not prevent from calling the
@@ -144,7 +144,7 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      * A callback that will be called after the form has been successfully
      * submitted and the item has been saved.
      */
-    afterSubmit?({ item }: SubmitEvent<Value<M>>): void;
+    onSubmitSuccess?({ item }: SubmitEvent<Value<M>>): void;
     /**
      * A callback that will be called if an unexpected error occurs while
      * deleting an item.
@@ -154,7 +154,7 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      * A callback that will be called after the form has been successfully
      * deleted.
      */
-    afterDelete?({ item }: DeleteEvent<Value<M>>): void;
+    onDeleteSuccess?({ item }: DeleteEvent<Value<M>>): void;
   }>;
 
 /**
@@ -170,7 +170,7 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
  * <AutoForm
  *   service={PersonService}
  *   model={PersonModel}
- *   afterSubmit={({ item }) => {
+ *   onSubmitSuccess={({ item }) => {
  *     console.log('Submitted item:', item);
  *   }}
  * />
@@ -181,7 +181,7 @@ export function AutoForm<M extends AbstractModel>({
   model,
   item = emptyItem,
   onSubmitError,
-  afterSubmit,
+  onSubmitSuccess,
   disabled,
   layoutRenderer: LayoutRenderer,
   visibleFields,
@@ -191,7 +191,7 @@ export function AutoForm<M extends AbstractModel>({
   id,
   className,
   deleteButtonVisible,
-  afterDelete,
+  onDeleteSuccess,
   onDeleteError,
 }: AutoFormProps<M>): JSX.Element {
   const form = useForm(model, {
@@ -217,8 +217,8 @@ export function AutoForm<M extends AbstractModel>({
       if (newItem === undefined) {
         // If update returns an empty object, then no update was performed
         throw new EndpointError('No update performed');
-      } else if (afterSubmit) {
-        afterSubmit({ item: newItem });
+      } else if (onSubmitSuccess) {
+        onSubmitSuccess({ item: newItem });
       }
     } catch (error) {
       if (error instanceof ValidationError) {
@@ -250,8 +250,8 @@ export function AutoForm<M extends AbstractModel>({
       // eslint-disable-next-line
       const id = (item as any)[idProperty.name];
       await service.delete(id);
-      if (afterDelete) {
-        afterDelete({ item: deletedItem });
+      if (onDeleteSuccess) {
+        onDeleteSuccess({ item: deletedItem });
       }
     } catch (error) {
       if (error instanceof EndpointError) {

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -226,14 +226,14 @@ describe('@hilla/react-crud', () => {
       newPerson.firstName = 'bar';
       await expect(form.getValues(...LABELS)).to.eventually.be.deep.equal(getExpectedValues(newPerson));
     });
-    it('retains the form values after a valid submit when using afterSubmit', async () => {
+    it('retains the form values after a valid submit when using onSubmitSuccess', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
       const person = await getItem(service, 1);
       const submitSpy = sinon.spy();
 
       const form = await FormController.init(
         user,
-        render(<AutoForm service={service} model={PersonModel} item={person} afterSubmit={submitSpy} />).container,
+        render(<AutoForm service={service} model={PersonModel} item={person} onSubmitSuccess={submitSpy} />).container,
       );
       await form.typeInField('First name', 'baz');
       await form.submit();
@@ -242,14 +242,14 @@ describe('@hilla/react-crud', () => {
       await expect(form.getValues(...LABELS)).to.eventually.be.deep.equal(getExpectedValues(newPerson));
     });
 
-    it('calls afterSubmit with the new item', async () => {
+    it('calls onSubmitSuccess with the new item', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
       const person = await getItem(service, 1);
       const submitSpy = sinon.spy();
 
       const form = await FormController.init(
         user,
-        render(<AutoForm service={service} model={PersonModel} item={person} afterSubmit={submitSpy} />).container,
+        render(<AutoForm service={service} model={PersonModel} item={person} onSubmitSuccess={submitSpy} />).container,
       );
       await form.typeInField('First name', 'bag');
       await form.submit();
@@ -265,7 +265,9 @@ describe('@hilla/react-crud', () => {
       const person = await getItem(service, 1);
       const submitSpy = sinon.spy();
 
-      const result = render(<AutoForm service={service} model={PersonModel} item={person} afterSubmit={submitSpy} />);
+      const result = render(
+        <AutoForm service={service} model={PersonModel} item={person} onSubmitSuccess={submitSpy} />,
+      );
       const form = await FormController.init(user, result.container);
       await form.typeInField('First name', 'J'); // to enable the submit button
       await form.submit();
@@ -322,7 +324,7 @@ describe('@hilla/react-crud', () => {
           service={service}
           model={PersonModel}
           item={person}
-          afterSubmit={submitSpy}
+          onSubmitSuccess={submitSpy}
           onSubmitError={errorSpy}
         />,
       );
@@ -333,7 +335,7 @@ describe('@hilla/react-crud', () => {
       expect(errorSpy).to.have.been.calledWith(sinon.match.hasNested('error.message', 'No update performed'));
     });
 
-    it('calls afterSubmitError and does not show error if the endpoint call fails', async () => {
+    it('calls onSubmitSuccessError and does not show error if the endpoint call fails', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
       // eslint-disable-next-line @typescript-eslint/require-await
       service.save = async (_item: Person): Promise<Person | undefined> => {
@@ -347,7 +349,7 @@ describe('@hilla/react-crud', () => {
           service={service}
           model={PersonModel}
           item={person}
-          afterSubmit={submitSpy}
+          onSubmitSuccess={submitSpy}
           onSubmitError={errorSpy}
         />,
       );
@@ -497,7 +499,7 @@ describe('@hilla/react-crud', () => {
       let service: CrudService<Person> & HasTestInfo;
       let person: Person;
       let deleteStub: sinon.SinonStub;
-      let afterDeleteSpy: sinon.SinonSpy;
+      let onDeleteSuccessSpy: sinon.SinonSpy;
       let onDeleteErrorSpy: sinon.SinonSpy;
 
       beforeEach(async () => {
@@ -505,7 +507,7 @@ describe('@hilla/react-crud', () => {
         person = (await getItem(service, 2))!;
         deleteStub = sinon.stub(service, 'delete');
         deleteStub.returns(Promise.resolve());
-        afterDeleteSpy = sinon.spy();
+        onDeleteSuccessSpy = sinon.spy();
         onDeleteErrorSpy = sinon.spy();
       });
 
@@ -526,7 +528,7 @@ describe('@hilla/react-crud', () => {
               model={PersonModel}
               item={item}
               deleteButtonVisible={enableDelete}
-              afterDelete={afterDeleteSpy}
+              onDeleteSuccess={onDeleteSuccessSpy}
               onDeleteError={onDeleteErrorSpy}
             />,
           ).container,
@@ -575,7 +577,7 @@ describe('@hilla/react-crud', () => {
         await dialog.confirm();
 
         expect(deleteStub).to.have.been.calledOnce;
-        expect(afterDeleteSpy).to.have.been.calledOnce;
+        expect(onDeleteSuccessSpy).to.have.been.calledOnce;
         expect(onDeleteErrorSpy).to.not.have.been.called;
       });
 
@@ -588,7 +590,7 @@ describe('@hilla/react-crud', () => {
         await dialog.cancel();
 
         expect(deleteStub).to.not.have.been.called;
-        expect(afterDeleteSpy).to.not.have.been.called;
+        expect(onDeleteSuccessSpy).to.not.have.been.called;
         expect(onDeleteErrorSpy).to.not.have.been.called;
       });
 
@@ -604,7 +606,7 @@ describe('@hilla/react-crud', () => {
         await dialog.confirm();
 
         expect(deleteStub).to.have.been.calledOnce;
-        expect(afterDeleteSpy).to.not.have.been.called;
+        expect(onDeleteSuccessSpy).to.not.have.been.called;
         expect(onDeleteErrorSpy).to.have.been.calledOnce;
         expect(onDeleteErrorSpy).to.have.been.calledWith(sinon.match.hasNested('error.message', 'Delete failed'));
       });


### PR DESCRIPTION
Renames:
- `afterSubmit` -> `onSubmitSuccess`
- `afterDelete` -> `onDeleteSuccess`

This ensures the event handler are prefixed with `on`, which is how event handlers are commonly named in React, and also aligns the event handler better with their error counterparts (`onSubmitSuccess` / `onSubmitError`, `onDeleteSuccess` / `onDeleteError`).

Fixes #1733 