### PR TITLE
test: re-enable react-crud tests

### DIFF
--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -241,7 +241,7 @@ describe('@hilla/react-crud', () => {
       await expect(form.getValues(...LABELS)).to.eventually.be.deep.equal(getExpectedValues(updatedPerson));
     });
 
-    it.only('clears the form values after submitting a new item', async () => {
+    it('clears the form values after submitting a new item', async () => {
       const service: CrudService<Person> & HasTestInfo = createService<Person>(personData);
 
       // Item is undefined


### PR DESCRIPTION
Tests were accidentally disabled in #1751 , this should re-enable them.