### PR TITLE
chore: restore previous Jetty version

### DIFF
--- a/packages/java/tests/csrf-context/pom.xml
+++ b/packages/java/tests/csrf-context/pom.xml
@@ -42,8 +42,8 @@
 
       <!-- This module is mapped to default web context -->
       <plugin>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
         <configuration>
           <webApp>
             <contextPath>/foo</contextPath>

--- a/packages/java/tests/csrf/pom.xml
+++ b/packages/java/tests/csrf/pom.xml
@@ -45,8 +45,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <testbench.element.version>24.3.0.alpha5</testbench.element.version>
+        <jetty.version>11.0.7</jetty.version>
         <jetty.scantrigger></jetty.scantrigger>
 
         <license.skipDownloadLicenses>true</license.skipDownloadLicenses>
@@ -182,8 +183,8 @@
                 </plugin>
                 <!-- jetty plugin for those child modules that need it -->
                 <plugin>
-                    <groupId>org.eclipse.jetty.ee10</groupId>
-                    <artifactId>jetty-ee10-maven-plugin</artifactId>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                     <executions>
                         <execution>


### PR DESCRIPTION
Some tests are failing due a new Jetty version that doesn't seem to work with our test setup.

Tests are failing only when executed from the project root directory.

This PR simply restores the old Jetty version for those tests.