### PR TITLE
fix: add executable names to not found message

### DIFF
--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/CommandRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/CommandRunner.java
@@ -66,11 +66,11 @@ public interface CommandRunner {
      */
     default void run(Consumer<OutputStream> stdIn)
             throws CommandRunnerException {
+        var execs = executables();
         // Find the first executable that works
-        var executable = executables().stream()
-                .filter(this::executeWithTestArguments).findFirst()
-                .orElseThrow(() -> new CommandNotFoundException(
-                        "No valid executable found"));
+        var executable = execs.stream().filter(this::executeWithTestArguments)
+                .findFirst().orElseThrow(() -> new CommandNotFoundException(
+                        "No valid executable found between " + execs));
         getLogger().debug("Running command {}", executable);
         // Execute the command with the given arguments
         executeCommand(executable, arguments(), stdIn, true);

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/CommandRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/CommandRunnerTest.java
@@ -76,6 +76,7 @@ public class CommandRunnerTest {
                 () -> runner.run(null));
         assertNull(e.getCause());
         assertFalse(e.getMessage().contains("exit"));
+        assertTrue(e.getMessage().contains("unknownCommand"));
     }
 
     @Test


### PR DESCRIPTION
When `CommandRunner` cannot find a valid executable for a task, it emits an error message which does not indicate the commands that have been searched.

While detailed information is available when using `debug` log level, it is wise to add the executable names to the default message.