### PR TITLE
fix: use localized date format in date time field

### DIFF
--- a/packages/ts/react-crud/src/autoform-field.tsx
+++ b/packages/ts/react-crud/src/autoform-field.tsx
@@ -9,7 +9,7 @@ import { TextField, type TextFieldProps } from '@hilla/react-components/TextFiel
 import { TimePicker, type TimePickerProps } from '@hilla/react-components/TimePicker.js';
 import type { FieldDirectiveResult, UseFormResult } from '@hilla/react-form';
 import type { JSX } from 'react';
-import { useDatePickerI18n } from './locale.js';
+import { useDatePickerI18n, useDateTimePickerI18n } from './locale.js';
 import type { PropertyInfo } from './model-info.js';
 import { convertToTitleCase } from './util.js';
 
@@ -97,8 +97,9 @@ function AutoFormTimeField({ propertyInfo, form, label, ...other }: AutoFormTime
 type AutoFormDateTimeFieldProps = DateTimePickerProps & SharedFieldProps;
 
 function AutoFormDateTimeField({ propertyInfo, form, label, ...other }: AutoFormDateTimeFieldProps) {
+  const i18n = useDateTimePickerI18n();
   const model = getPropertyModel(form, propertyInfo);
-  return <DateTimePicker {...other} {...form.field(model)} label={label} />;
+  return <DateTimePicker i18n={i18n} {...other} {...form.field(model)} label={label} />;
 }
 
 type AutoFormEnumFieldProps = SelectProps & SharedFieldProps;

--- a/packages/ts/react-crud/src/locale.ts
+++ b/packages/ts/react-crud/src/locale.ts
@@ -1,4 +1,5 @@
 import { DatePickerElement, type DatePickerDate, type DatePickerI18n } from '@hilla/react-components/DatePicker.js';
+import { DateTimePickerElement, type DateTimePickerI18n } from '@hilla/react-components/DateTimePicker.js';
 import { createContext, useContext, useMemo } from 'react';
 
 export const LocaleContext = createContext(navigator.language);
@@ -116,14 +117,14 @@ export function useLocaleFormatter(): LocaleFormatter {
   return useMemo(() => new LocaleFormatter(locale), [locale]);
 }
 
-const datePickerI18n = new DatePickerElement().i18n;
+const defaultDatePickerI18n = new DatePickerElement().i18n;
 
 export function useDatePickerI18n(): DatePickerI18n {
   const formatter = useLocaleFormatter();
 
   return useMemo(
     () => ({
-      ...datePickerI18n,
+      ...defaultDatePickerI18n,
       formatDate(value) {
         return formatter.formatDate(value);
       },
@@ -132,5 +133,19 @@ export function useDatePickerI18n(): DatePickerI18n {
       },
     }),
     [formatter],
+  );
+}
+
+const defaultDateTimePickerI18n = new DateTimePickerElement().i18n;
+
+export function useDateTimePickerI18n(): DateTimePickerI18n {
+  const datePickerI18n = useDatePickerI18n();
+
+  return useMemo(
+    () => ({
+      ...defaultDateTimePickerI18n,
+      ...datePickerI18n,
+    }),
+    [datePickerI18n],
   );
 }


### PR DESCRIPTION
Make `AutoForm`'s `AutoDateTimeField` use the same localized date format that is used in other fields and renderers.