### PR TITLE
feat(autoform): Add props to provide custom client-side validators

### DIFF
--- a/packages/ts/react-crud/src/autoform-field.tsx
+++ b/packages/ts/react-crud/src/autoform-field.tsx
@@ -1,4 +1,4 @@
-import { _enum, type EnumModel } from '@hilla/form';
+import { _enum, type EnumModel, type Validator } from '@hilla/form';
 import { Checkbox, type CheckboxProps } from '@hilla/react-components/Checkbox.js';
 import { DatePicker, type DatePickerProps } from '@hilla/react-components/DatePicker.js';
 import { DateTimePicker, type DateTimePickerProps } from '@hilla/react-components/DateTimePicker.js';
@@ -8,7 +8,9 @@ import { Select, type SelectProps } from '@hilla/react-components/Select.js';
 import { TextField, type TextFieldProps } from '@hilla/react-components/TextField.js';
 import { TimePicker, type TimePickerProps } from '@hilla/react-components/TimePicker.js';
 import type { FieldDirectiveResult, UseFormResult } from '@hilla/react-form';
+import { useFormPart } from '@hilla/react-form';
 import type { JSX } from 'react';
+import { useEffect } from 'react';
 import { useDatePickerI18n, useDateTimePickerI18n } from './locale.js';
 import type { PropertyInfo } from './model-info.js';
 import { convertToTitleCase } from './util.js';
@@ -50,6 +52,11 @@ export type FieldOptions = Readonly<{
    * ignored.
    */
   colspan?: number;
+  /**
+   * Validators to apply to the field. The validators are added to the form
+   * when the field is rendered.
+   */
+  validators?: Validator[];
 }>;
 
 function getPropertyModel(form: UseFormResult<any>, propertyInfo: PropertyInfo) {
@@ -133,6 +140,16 @@ export type AutoFormFieldProps = CheckboxProps &
 export function AutoFormField(props: AutoFormFieldProps): JSX.Element | null {
   const { form, propertyInfo, options } = props;
   const label = options?.label ?? propertyInfo.humanReadableName;
+
+  const formPart = useFormPart(getPropertyModel(form, propertyInfo));
+  useEffect(() => {
+    if (options?.validators) {
+      options.validators.forEach((validator) => {
+        formPart.addValidator(validator);
+      });
+    }
+  }, [formPart, options]);
+
   if (options?.renderer) {
     const customFieldProps = { ...form.field(getPropertyModel(form, propertyInfo)), disabled: props.disabled, label };
     return options.renderer({ field: customFieldProps });

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -6,6 +6,7 @@ import { ValidationError } from '@hilla/form';
 import { EndpointError } from '@hilla/frontend';
 import type { SelectElement } from '@hilla/react-components/Select.js';
 import { TextArea } from '@hilla/react-components/TextArea.js';
+import type { TextFieldElement } from '@hilla/react-components/TextField.js';
 import { VerticalLayout } from '@hilla/react-components/VerticalLayout.js';
 import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -1118,6 +1119,53 @@ describe('@hilla/react-crud', () => {
         expect(autoFormElement.id).to.equal('my-id');
         expect(autoFormElement.className.trim()).to.equal('auto-form custom-auto-form');
         expect(autoFormElement.getAttribute('style')).to.equal('background-color: blue;');
+      });
+    });
+
+    describe('custom client-side validators', () => {
+      it('validates form field with custom validator ', async () => {
+        const form = await populatePersonForm(1, {
+          fieldOptions: {
+            firstName: {
+              validators: [
+                {
+                  message: 'First name must longer than 3 characters',
+                  validate: (value: string) => value.length > 3,
+                },
+              ],
+            },
+          },
+        });
+        const firstNameField = (await form.getField('First name')) as TextFieldElement;
+        expect(firstNameField.invalid).to.be.false;
+        await form.typeInField('First name', 'Dan{enter}');
+        expect(firstNameField.invalid).to.be.true;
+        expect(firstNameField.errorMessage).to.equal('First name must longer than 3 characters');
+        await form.typeInField('First name', 'Daniel{enter}');
+        expect(firstNameField.invalid).to.be.false;
+      });
+
+      it('renders form field with multiple custom validators', async () => {
+        const form = await populatePersonForm(1, {
+          fieldOptions: {
+            firstName: {
+              validators: [
+                {
+                  message: 'First name must longer than 3 characters',
+                  validate: (value: string) => value.length > 3,
+                },
+                {
+                  message: 'First name must start with M',
+                  validate: (value: string) => value.startsWith('M'),
+                },
+              ],
+            },
+          },
+        });
+        await form.typeInField('First name', 'Dan{enter}');
+        const firstNameField = (await form.getField('First name')) as TextFieldElement;
+        expect(firstNameField.invalid).to.be.true;
+        expect(firstNameField.errorMessage).to.equal('First name must longer than 3 characters');
       });
     });
   });


### PR DESCRIPTION
Fixes #1797

Add functionality that users can set custom client-side validators to form by passing it to `fieldOptions`