### PR TITLE
feat: allow custom runner executable path

### DIFF
--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
@@ -76,8 +76,9 @@ public class GradleRunner implements CommandRunner {
         if (customExecutable != null) {
             executableList.add(customExecutable);
         }
-        executableList.addAll(IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat", "gradle")
-            : List.of("./gradlew", "gradle"));
+        executableList.addAll(
+                IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat", "gradle")
+                        : List.of("./gradlew", "gradle"));
         return List.copyOf(executableList);
     }
 }

--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
@@ -76,9 +76,14 @@ public class GradleRunner implements CommandRunner {
         if (customExecutable != null) {
             executableList.add(customExecutable);
         }
-        executableList.addAll(
-                IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat", "gradle")
-                        : List.of("./gradlew", "gradle"));
+        if (IS_WINDOWS) {
+            executableList.add(".\\gradlew.bat");
+            executableList.add("gradle.bat");
+            executableList.add("gradle");
+        } else {
+            executableList.add("./gradlew");
+            executableList.add("gradle");
+        }
         return List.copyOf(executableList);
     }
 }

--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/GradleRunner.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,7 @@ public class GradleRunner implements CommandRunner {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(GradleRunner.class);
 
+    static final String EXECUTABLE_PROPERTY = "hilla.gradleExecutable";
     private final File projectDir;
     private final String[] args;
 
@@ -69,7 +71,13 @@ public class GradleRunner implements CommandRunner {
 
     @Override
     public List<String> executables() {
-        return IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat", "gradle")
-                : List.of("./gradlew", "gradle");
+        List<String> executableList = new ArrayList<>();
+        String customExecutable = System.getProperty(EXECUTABLE_PROPERTY);
+        if (customExecutable != null) {
+            executableList.add(customExecutable);
+        }
+        executableList.addAll(IS_WINDOWS ? List.of(".\\gradlew.bat", "gradle.bat", "gradle")
+            : List.of("./gradlew", "gradle"));
+        return List.copyOf(executableList);
     }
 }

--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/MavenRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/MavenRunner.java
@@ -79,8 +79,13 @@ public class MavenRunner implements CommandRunner {
             executableList.add(customExecutable);
         }
         // Prefer the wrapper over a global installation
-        executableList.addAll(IS_WINDOWS ? List.of(".\\mvnw.cmd", "mvn.cmd")
-                : List.of("./mvnw", "mvn"));
+        if (IS_WINDOWS) {
+            executableList.add(".\\mvnw.cmd");
+            executableList.add("mvn.cmd");
+        } else {
+            executableList.add("./mvnw");
+            executableList.add("mvn");
+        }
         return List.copyOf(executableList);
     }
 }

--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/MavenRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/MavenRunner.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,7 @@ public class MavenRunner implements CommandRunner {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(MavenRunner.class);
 
+    static final String EXECUTABLE_PROPERTY = "hilla.mavenExecutable";
     private final File projectDir;
     private final String[] args;
 
@@ -71,8 +73,14 @@ public class MavenRunner implements CommandRunner {
 
     @Override
     public List<String> executables() {
+        List<String> executableList = new ArrayList<>();
+        String customExecutable = System.getProperty(EXECUTABLE_PROPERTY);
+        if (customExecutable != null) {
+            executableList.add(customExecutable);
+        }
         // Prefer the wrapper over a global installation
-        return IS_WINDOWS ? List.of(".\\mvnw.cmd", "mvn.cmd")
-                : List.of("./mvnw", "mvn");
+        executableList.addAll(IS_WINDOWS ? List.of(".\\mvnw.cmd", "mvn.cmd")
+            : List.of("./mvnw", "mvn"));
+        return List.copyOf(executableList);
     }
 }

--- a/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/MavenRunner.java
+++ b/packages/java/engine-core/src/main/java/dev/hilla/engine/commandrunner/MavenRunner.java
@@ -80,7 +80,7 @@ public class MavenRunner implements CommandRunner {
         }
         // Prefer the wrapper over a global installation
         executableList.addAll(IS_WINDOWS ? List.of(".\\mvnw.cmd", "mvn.cmd")
-            : List.of("./mvnw", "mvn"));
+                : List.of("./mvnw", "mvn"));
         return List.copyOf(executableList);
     }
 }

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/GradleRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/GradleRunnerTest.java
@@ -45,19 +45,24 @@ public class GradleRunnerTest {
 
     @Test
     void shouldListProvidedExecutable() {
-        String originalValue = System.getProperty(GradleRunner.EXECUTABLE_PROPERTY);
+        String originalValue = System
+                .getProperty(GradleRunner.EXECUTABLE_PROPERTY);
         try {
             String customMavenPath = "/path/to/gradle/bin/gradle";
-            System.setProperty(GradleRunner.EXECUTABLE_PROPERTY, customMavenPath);
+            System.setProperty(GradleRunner.EXECUTABLE_PROPERTY,
+                    customMavenPath);
             var runner = new GradleRunner(tmpDir.toFile(), "-v");
             if (CommandRunner.IS_WINDOWS) {
-                assertEquals(List.of(customMavenPath, ".\\gradlew.bat", "gradle.bat", "gradle"), runner.executables());
+                assertEquals(List.of(customMavenPath, ".\\gradlew.bat",
+                        "gradle.bat", "gradle"), runner.executables());
             } else {
-                assertEquals(List.of(customMavenPath, "./gradlew", "gradle"), runner.executables());
+                assertEquals(List.of(customMavenPath, "./gradlew", "gradle"),
+                        runner.executables());
             }
         } finally {
             if (originalValue != null) {
-                System.setProperty(GradleRunner.EXECUTABLE_PROPERTY, originalValue);
+                System.setProperty(GradleRunner.EXECUTABLE_PROPERTY,
+                        originalValue);
             } else {
                 System.clearProperty(MavenRunner.EXECUTABLE_PROPERTY);
             }

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/GradleRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/GradleRunnerTest.java
@@ -1,66 +1,65 @@
 package dev.hilla.engine.commandrunner;
 
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GradleRunnerTest {
 
+    @TempDir
+    Path tmpDir;
+
     @Test
     void shouldRunIfBuildGradleIsAvailable() throws IOException {
-        Path tmpDir = null;
-
-        try {
-            tmpDir = Files.createTempDirectory("prepareCommandGradle");
-            Files.createFile(tmpDir.resolve("build.gradle"));
-            var opt = GradleRunner.forProject(tmpDir.toFile(), "-v");
-            assertTrue(opt.isPresent());
-            var runner = opt.orElseThrow();
-            assertEquals(1, runner.arguments().length);
-            assertDoesNotThrow(() -> runner.run(null));
-        } finally {
-            if (tmpDir != null) {
-                Files.deleteIfExists(tmpDir.resolve("build.gradle"));
-                Files.deleteIfExists(tmpDir);
-            }
-        }
+        Files.createFile(tmpDir.resolve("build.gradle"));
+        var opt = GradleRunner.forProject(tmpDir.toFile(), "-v");
+        assertTrue(opt.isPresent());
+        var runner = opt.orElseThrow();
+        assertEquals(1, runner.arguments().length);
+        assertDoesNotThrow(() -> runner.run(null));
     }
 
     @Test
     void shouldRunIfBuildGradleKtsIsAvailable() throws IOException {
-        Path tmpDir = null;
-
-        try {
-            tmpDir = Files.createTempDirectory("prepareCommandGradle");
-            Files.createFile(tmpDir.resolve("build.gradle.kts"));
-            var opt = GradleRunner.forProject(tmpDir.toFile(), "-v");
-            assertTrue(opt.isPresent());
-            var runner = opt.orElseThrow();
-            assertEquals(1, runner.arguments().length);
-            assertDoesNotThrow(() -> runner.run(null));
-        } finally {
-            if (tmpDir != null) {
-                Files.deleteIfExists(tmpDir.resolve("build.gradle.kts"));
-                Files.deleteIfExists(tmpDir);
-            }
-        }
+        Files.createFile(tmpDir.resolve("build.gradle.kts"));
+        var opt = GradleRunner.forProject(tmpDir.toFile(), "-v");
+        assertTrue(opt.isPresent());
+        var runner = opt.orElseThrow();
+        assertEquals(1, runner.arguments().length);
+        assertDoesNotThrow(() -> runner.run(null));
     }
 
     @Test
-    void shouldNotCreateRunnerForUnknownProjectType() throws IOException {
-        Path tmpDir = null;
+    void shouldNotCreateRunnerForUnknownProjectType() {
+        var runner = GradleRunner.forProject(tmpDir.toFile());
+        assertTrue(runner.isEmpty());
+    }
 
+    @Test
+    void shouldListProvidedExecutable() {
+        String originalValue = System.getProperty(GradleRunner.EXECUTABLE_PROPERTY);
         try {
-            tmpDir = Files.createTempDirectory("prepareCommandGradle");
-            var runner = GradleRunner.forProject(tmpDir.toFile());
-            assertTrue(runner.isEmpty());
+            String customMavenPath = "/path/to/gradle/bin/gradle";
+            System.setProperty(GradleRunner.EXECUTABLE_PROPERTY, customMavenPath);
+            var runner = new GradleRunner(tmpDir.toFile(), "-v");
+            if (CommandRunner.IS_WINDOWS) {
+                assertEquals(List.of(customMavenPath, ".\\gradlew.bat", "gradle.bat", "gradle"), runner.executables());
+            } else {
+                assertEquals(List.of(customMavenPath, "./gradlew", "gradle"), runner.executables());
+            }
         } finally {
-            if (tmpDir != null) {
-                Files.deleteIfExists(tmpDir);
+            if (originalValue != null) {
+                System.setProperty(GradleRunner.EXECUTABLE_PROPERTY, originalValue);
+            } else {
+                System.clearProperty(MavenRunner.EXECUTABLE_PROPERTY);
             }
         }
     }

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/MavenRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/MavenRunnerTest.java
@@ -35,19 +35,24 @@ public class MavenRunnerTest {
 
     @Test
     void shouldListProvidedExecutable() {
-        String originalValue = System.getProperty(MavenRunner.EXECUTABLE_PROPERTY);
+        String originalValue = System
+                .getProperty(MavenRunner.EXECUTABLE_PROPERTY);
         try {
             String customMavenPath = "/path/to/maven/bin/mvn";
-            System.setProperty(MavenRunner.EXECUTABLE_PROPERTY, customMavenPath);
+            System.setProperty(MavenRunner.EXECUTABLE_PROPERTY,
+                    customMavenPath);
             var runner = new MavenRunner(tmpDir.toFile(), "-v");
             if (CommandRunner.IS_WINDOWS) {
-                assertEquals(List.of(customMavenPath, ".\\mvnw.cmd", "mvn.cmd"), runner.executables());
+                assertEquals(List.of(customMavenPath, ".\\mvnw.cmd", "mvn.cmd"),
+                        runner.executables());
             } else {
-                assertEquals(List.of(customMavenPath, "./mvnw", "mvn"), runner.executables());
+                assertEquals(List.of(customMavenPath, "./mvnw", "mvn"),
+                        runner.executables());
             }
         } finally {
             if (originalValue != null) {
-                System.setProperty(MavenRunner.EXECUTABLE_PROPERTY, originalValue);
+                System.setProperty(MavenRunner.EXECUTABLE_PROPERTY,
+                        originalValue);
             } else {
                 System.clearProperty(MavenRunner.EXECUTABLE_PROPERTY);
             }

--- a/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/MavenRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/dev/hilla/engine/commandrunner/MavenRunnerTest.java
@@ -1,45 +1,55 @@
 package dev.hilla.engine.commandrunner;
 
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MavenRunnerTest {
+
+    @TempDir
+    Path tmpDir;
+
     @Test
     void shouldRunIfPOMAvailable() throws IOException {
-        Path tmpDir = null;
-
-        try {
-            tmpDir = Files.createTempDirectory("prepareCommandMaven");
-            Files.createFile(tmpDir.resolve("pom.xml"));
-            var opt = MavenRunner.forProject(tmpDir.toFile(), "-v");
-            assertTrue(opt.isPresent());
-            var runner = opt.orElseThrow();
-            assertEquals(1, runner.arguments().length);
-            assertDoesNotThrow(() -> runner.run(null));
-        } finally {
-            if (tmpDir != null) {
-                Files.deleteIfExists(tmpDir.resolve("pom.xml"));
-                Files.deleteIfExists(tmpDir);
-            }
-        }
+        Files.createFile(tmpDir.resolve("pom.xml"));
+        var opt = MavenRunner.forProject(tmpDir.toFile(), "-v");
+        assertTrue(opt.isPresent());
+        var runner = opt.orElseThrow();
+        assertEquals(1, runner.arguments().length);
+        assertDoesNotThrow(() -> runner.run(null));
     }
 
     @Test
-    void shouldNotCreateRunnerForUnknownProjectType() throws IOException {
-        Path tmpDir = null;
+    void shouldNotCreateRunnerForUnknownProjectType() {
+        var runner = MavenRunner.forProject(tmpDir.toFile());
+        assertTrue(runner.isEmpty());
+    }
 
+    @Test
+    void shouldListProvidedExecutable() {
+        String originalValue = System.getProperty(MavenRunner.EXECUTABLE_PROPERTY);
         try {
-            tmpDir = Files.createTempDirectory("prepareCommandMaven");
-            var runner = MavenRunner.forProject(tmpDir.toFile());
-            assertTrue(runner.isEmpty());
+            String customMavenPath = "/path/to/maven/bin/mvn";
+            System.setProperty(MavenRunner.EXECUTABLE_PROPERTY, customMavenPath);
+            var runner = new MavenRunner(tmpDir.toFile(), "-v");
+            if (CommandRunner.IS_WINDOWS) {
+                assertEquals(List.of(customMavenPath, ".\\mvnw.cmd", "mvn.cmd"), runner.executables());
+            } else {
+                assertEquals(List.of(customMavenPath, "./mvnw", "mvn"), runner.executables());
+            }
         } finally {
-            if (tmpDir != null) {
-                Files.deleteIfExists(tmpDir);
+            if (originalValue != null) {
+                System.setProperty(MavenRunner.EXECUTABLE_PROPERTY, originalValue);
+            } else {
+                System.clearProperty(MavenRunner.EXECUTABLE_PROPERTY);
             }
         }
     }


### PR DESCRIPTION
## Description

Allows to specify a custom executable path for maven and gradle runners that takes priority over default hard-coded executables.

Fixes #1749

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
