### PR TITLE
feat: add more common props to field options

### DIFF
--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -363,8 +363,6 @@ export function AutoForm<M extends AbstractModel>({
 
   function createAutoFormField(propertyInfo: PropertyInfo): JSX.Element {
     const fieldOptionsForProperty = fieldOptions?.[propertyInfo.name] ?? {};
-    const colspanValue = fieldOptionsForProperty.colspan;
-    const colspan = colspanValue ? { colspan: colspanValue } : {};
 
     return (
       <AutoFormField
@@ -373,7 +371,6 @@ export function AutoForm<M extends AbstractModel>({
         form={form}
         disabled={disabled}
         options={fieldOptionsForProperty}
-        {...colspan}
       />
     );
   }

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -581,9 +581,11 @@ describe('@hilla/react-crud', () => {
 
       it('submits the form when enter key is pressed with custom layout renderer', async () => {
         const service = personService();
+
         function MyLayoutRenderer({ children }: AutoFormLayoutRendererProps<PersonModel>) {
           return <VerticalLayout>{children}</VerticalLayout>;
         }
+
         const form = await populatePersonForm(1, { layoutRenderer: MyLayoutRenderer }, undefined, undefined, service);
         const submitSpy = sinon.spy(service, 'save');
 
@@ -1071,22 +1073,43 @@ describe('@hilla/react-crud', () => {
         expect(field).to.exist;
       });
 
-      it('renders custom label from field options instead of the default one', () => {
+      it('allows customizing common field props', async () => {
         const result = render(
           <AutoForm
             service={personService()}
             model={PersonModel}
             fieldOptions={{
-              firstName: { label: 'Employee First Name' },
-              lastName: { label: 'Employee Last Name' },
+              firstName: {
+                id: 'first-name-id',
+                className: 'first-name-class',
+                style: {
+                  color: 'red',
+                },
+                label: 'Employee First Name',
+                placeholder: 'First Name Placeholder',
+                helperText: 'First Name Helper Text',
+                colspan: 3,
+                disabled: true,
+                readonly: true,
+              },
             }}
           />,
         );
+        const form = await FormController.init(user, result.container);
 
-        expect(within(result.container).queryByLabelText('Employee First Name')).to.exist;
-        expect(within(result.container).queryByLabelText('First name')).to.not.exist;
-        expect(within(result.container).queryByLabelText('Employee Last Name')).to.exist;
-        expect(within(result.container).queryByLabelText('Last name')).to.not.exist;
+        const field = form.queryField('Employee First Name');
+        expect(field).to.exist;
+        expect(form.queryField('First name')).to.not.exist;
+
+        const textField = field as TextFieldElement;
+        expect(textField.id).to.equal('first-name-id');
+        expect(textField.getAttribute('class')).to.equal('first-name-class');
+        expect(textField.style.color).to.equal('red');
+        expect(textField.placeholder).to.equal('First Name Placeholder');
+        expect(textField.helperText).to.equal('First Name Helper Text');
+        expect(textField.getAttribute('colspan')).to.equal('3');
+        expect(textField.disabled).to.be.true;
+        expect(textField.readonly).to.be.true;
       });
 
       it('passes colspan to fields', async () => {


### PR DESCRIPTION
Adds more common field properties to `fieldOptions`:
- `id`
- `className`
- `style`
- `readonly`
- `disabled`
- `placeholder`
- `helperText`

`placeholder` and `helperText` are not supported by component types, for example checkbox doesn't have either, and a select with a preselected value can never show a placeholder. Still think they are useful to have by default.

As for more specific properties that only apply to some components I think we are at a dead-end with this approach - there isn't any way how we could properly type the respective field options object so that it accepts props for the respective component. 

One idea I had was to allow passing a prerendered JSX element to `renderer` which we would then enhance with the other options and the form binding. That would be easier than writing a custom renderer function and still gives you component-specific type information:
```tsx
<AutoForm 
  fieldOptions: {
    firstName: {
      renderer: <TextField clearButtonVisible />
    }
  }
/>
```

Part of #1732 