### PR TITLE
feat: expose grid element from auto grid ref

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -5,7 +5,7 @@ import { type JSX, useRef, useState } from 'react';
 import { AutoCrudDialog } from './autocrud-dialog.js';
 import css from './autocrud.obj.css';
 import { type AutoFormProps, emptyItem, AutoForm } from './autoform.js';
-import { type AutoGridProps, AutoGrid } from './autogrid.js';
+import { type AutoGridProps, AutoGrid, type AutoGridRef } from './autogrid.js';
 import type { CrudService } from './crud.js';
 import { useMediaQuery } from './media-query.js';
 import { type ComponentStyleProps, registerStylesheet } from './util.js';
@@ -97,7 +97,7 @@ export function AutoCrud<TModel extends AbstractModel>({
   const [item, setItem] = useState<Value<TModel> | typeof emptyItem | undefined>(undefined);
   const fullScreen = useMediaQuery('(max-width: 600px), (max-height: 600px)');
 
-  const autoGridRef = useRef<{ refresh(): void }>(null);
+  const autoGridRef = useRef<AutoGridRef>(null);
 
   function refreshGrid() {
     autoGridRef.current?.refresh();

--- a/packages/ts/react-crud/src/autogrid.tsx
+++ b/packages/ts/react-crud/src/autogrid.tsx
@@ -38,7 +38,15 @@ import { registerStylesheet } from './util';
 
 registerStylesheet(css);
 
-export interface AutoGridRef {
+export interface AutoGridRef<TItem = any> {
+  /**
+   * The underlying vaadin-grid DOM element.
+   */
+  grid: GridElement<TItem> | null;
+
+  /**
+   * Refreshes the grid by reloading the data from the backend.
+   */
   refresh(): void;
 }
 
@@ -288,7 +296,7 @@ function AutoGridInner<TItem>(
     rowNumbers,
     ...gridProps
   }: AutoGridProps<TItem>,
-  ref: ForwardedRef<AutoGridRef>,
+  ref: ForwardedRef<AutoGridRef<TItem>>,
 ): JSX.Element {
   const [internalFilter, setInternalFilter] = useState<AndFilter>({ '@type': 'and', children: [] });
   const gridRef = useRef<GridElement<TItem>>(null);
@@ -297,6 +305,9 @@ function AutoGridInner<TItem>(
   useImperativeHandle(
     ref,
     () => ({
+      get grid() {
+        return gridRef.current;
+      },
       refresh() {
         gridRef.current?.clearCache();
       },
@@ -370,7 +381,7 @@ function AutoGridInner<TItem>(
 }
 
 type AutoGrid = <TItem>(
-  props: AutoGridProps<TItem> & { ref?: ForwardedRef<AutoGridRef> },
+  props: AutoGridProps<TItem> & { ref?: ForwardedRef<AutoGridRef<TItem>> },
 ) => ReturnType<typeof AutoGridInner>;
 
 /**

--- a/packages/ts/react-crud/test/autogrid.spec.tsx
+++ b/packages/ts/react-crud/test/autogrid.spec.tsx
@@ -1118,7 +1118,7 @@ describe('@hilla/react-crud', () => {
       });
     });
 
-    describe('grid refresh', () => {
+    describe('auto grid ref', () => {
       let autoGridRef: AutoGridRef;
 
       const AutoGridRefreshTestWrapper = ({ service }: { service: ListService<any> }) => {
@@ -1135,7 +1135,7 @@ describe('@hilla/react-crud', () => {
         );
       };
 
-      it('reloads data when refresh is called', async () => {
+      it('reloads data when refresh is called on ref', async () => {
         const service = personService();
         const listSpy = sinon.spy(service, 'list');
         render(<AutoGridRefreshTestWrapper service={service} />);
@@ -1144,6 +1144,12 @@ describe('@hilla/react-crud', () => {
         expect(listSpy).to.have.been.calledOnce;
         autoGridRef.refresh();
         expect(listSpy).to.have.been.calledTwice;
+      });
+
+      it('exposes vaadin-grid element on ref', () => {
+        render(<AutoGridRefreshTestWrapper service={personService()} />);
+        expect(autoGridRef.grid).to.exist;
+        expect(autoGridRef.grid!.localName).to.equal('vaadin-grid');
       });
     });
 


### PR DESCRIPTION
Exposes the underlying `vaadin-grid` DOM element on the `AutoGridRef`. That allows using other imperative API of the grid, for example `getEventContext` to get details about an item in a context menu.