### PR TITLE
fix: Avoid using decorators

### DIFF
--- a/packages/java/hilla-dev-mode/src/main/resources/META-INF/resources/frontend/dev-tools-database.ts
+++ b/packages/java/hilla-dev-mode/src/main/resources/META-INF/resources/frontend/dev-tools-database.ts
@@ -1,5 +1,5 @@
 import { LitElement, type TemplateResult, html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { loginUsingUrl, waitForConsole } from './h2-util';
 import type {
   DevToolsInterface,
@@ -16,11 +16,11 @@ type H2Data = {
 };
 @customElement('devtools-database')
 export class DevToolsDatabase extends LitElement implements MessageHandler {
-  @state()
   declare h2path?: string;
 
-  @state()
   declare h2jdbcUrl?: string;
+
+  static properties = { h2path: { type: String }, h2jdbcUrl: { type: String } };
 
   connectedCallback(): void {
     super.connectedCallback();

--- a/packages/java/hilla-dev-mode/src/main/resources/META-INF/resources/frontend/dev-tools-database.ts
+++ b/packages/java/hilla-dev-mode/src/main/resources/META-INF/resources/frontend/dev-tools-database.ts
@@ -1,5 +1,4 @@
 import { LitElement, type TemplateResult, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import { loginUsingUrl, waitForConsole } from './h2-util';
 import type {
   DevToolsInterface,
@@ -14,7 +13,6 @@ type H2Data = {
   path: string;
   jdbcUrl: string;
 };
-@customElement('devtools-database')
 export class DevToolsDatabase extends LitElement implements MessageHandler {
   declare h2path?: string;
 
@@ -64,3 +62,5 @@ const plugin: DevToolsPlugin = {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 (window as any).Vaadin.devToolsPlugins.push(plugin);
+
+customElements.define('devtools-database', DevToolsDatabase);


### PR DESCRIPTION
field decorators are currently problematic when projects can use useDefineForClassFields true or false
