### PR TITLE
refactor: separate data provider logic from auto grid

### DIFF
--- a/packages/ts/react-crud/src/autogrid-renderers.tsx
+++ b/packages/ts/react-crud/src/autogrid-renderers.tsx
@@ -1,23 +1,14 @@
 import type { GridItemModel } from '@hilla/react-components/Grid.js';
 import type { GridColumnElement } from '@hilla/react-components/GridColumn.js';
 import { Icon } from '@hilla/react-components/Icon.js';
-// eslint-disable-next-line
-import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
-import {
-  type ComponentType,
-  createContext,
-  type CSSProperties,
-  type Dispatch,
-  type JSX,
-  type MutableRefObject,
-  type SetStateAction,
-  useContext,
-  useState,
-} from 'react';
-import type { AutoGridItemCountHolder } from './autogrid';
+import { type ComponentType, createContext, type CSSProperties, type JSX, useContext } from 'react';
 import { ColumnContext } from './autogrid-column-context';
+import type { ItemCounts } from './data-provider';
 import { useLocaleFormatter } from './locale.js';
 import { convertToTitleCase } from './util';
+
+// eslint-disable-next-line
+import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 
 export type RendererOptions<TItem> = {
   item: TItem;
@@ -91,30 +82,30 @@ export function AutoGridRowNumberRenderer<TItem>({ model }: RendererOptions<TIte
 }
 
 export type FooterContextType = {
-  itemCountHolder: AutoGridItemCountHolder;
-  footerRef: MutableRefObject<Dispatch<SetStateAction<number>>>;
-  footerCountRenderer?: ComponentType<AutoGridItemCountHolder>;
+  totalCount?: boolean;
+  filteredCount?: boolean;
+  footerCountRenderer?: ComponentType<ItemCounts>;
+  itemCounts?: ItemCounts;
 };
+
 export const FooterContext = createContext<FooterContextType>(undefined!);
 
 export function AutoGridFooterItemCountRenderer(): JSX.Element {
-  const [, setReRender] = useState(-1); // Force re-render to update the footer
-  const { itemCountHolder, footerRef, footerCountRenderer: FooterRenderer } = useContext(FooterContext);
-  footerRef.current = setReRender;
+  const footerContext = useContext(FooterContext);
+  const { totalCount, filteredCount, itemCounts, footerCountRenderer: FooterRenderer } = footerContext;
 
   if (FooterRenderer) {
-    return <FooterRenderer {...itemCountHolder} />;
+    return <FooterRenderer {...itemCounts} />;
   }
 
   let filterCountText: string | undefined;
-  const { filteredCount, totalCount, filteredItemCount, totalItemCount } = itemCountHolder;
-  if (filteredCount && filteredItemCount.current >= 0) {
+  if (filteredCount && itemCounts?.filteredCount !== undefined) {
     filterCountText =
-      totalCount && totalItemCount.current >= 0
-        ? `Showing: ${filteredItemCount.current} out of ${totalItemCount.current}`
-        : `Showing: ${filteredItemCount.current}`;
-  } else if (totalCount && totalItemCount.current >= 0) {
-    filterCountText = `Total: ${totalItemCount.current}`;
+      totalCount && itemCounts.totalCount !== undefined
+        ? `Showing: ${itemCounts.filteredCount} out of ${itemCounts.totalCount}`
+        : `Showing: ${itemCounts.filteredCount}`;
+  } else if (totalCount && itemCounts?.totalCount !== undefined) {
+    filterCountText = `Total: ${itemCounts.totalCount}`;
   }
   if (filterCountText) {
     return <p>{filterCountText}</p>;

--- a/packages/ts/react-crud/src/autogrid.tsx
+++ b/packages/ts/react-crud/src/autogrid.tsx
@@ -347,15 +347,18 @@ function AutoGridInner<TItem>(
     // Wait for the sorting headers to be rendered so that the sorting state is correct for the first data provider call
     setTimeout(() => {
       let firstUpdate = true;
-      const initialFilter = experimentalFilter ?? internalFilter;
-      dataProviderRef.current = createDataProvider(grid, service, initialFilter, (newItemCounts: ItemCounts) => {
-        setItemCounts(newItemCounts);
+      dataProviderRef.current = createDataProvider(grid, service, {
+        initialFilter: experimentalFilter ?? internalFilter,
+        loadTotalCount: totalCount,
+        afterLoad(newItemCounts: ItemCounts) {
+          setItemCounts(newItemCounts);
 
-        if (firstUpdate) {
-          // Workaround for https://github.com/vaadin/react-components/issues/129
-          firstUpdate = false;
-          setTimeout(() => grid.recalculateColumnWidths(), 0);
-        }
+          if (firstUpdate) {
+            // Workaround for https://github.com/vaadin/react-components/issues/129
+            firstUpdate = false;
+            setTimeout(() => grid.recalculateColumnWidths(), 0);
+          }
+        },
       });
     }, 1);
   }, [model, service]);

--- a/packages/ts/react-crud/src/autogrid.tsx
+++ b/packages/ts/react-crud/src/autogrid.tsx
@@ -1,24 +1,13 @@
 import type { AbstractModel, DetachedModelConstructor } from '@hilla/form';
-import {
-  Grid,
-  type GridDataProvider,
-  type GridDataProviderCallback,
-  type GridDataProviderParams,
-  type GridDefaultItem,
-  type GridElement,
-  type GridProps,
-} from '@hilla/react-components/Grid.js';
+import { Grid, type GridElement, type GridProps } from '@hilla/react-components/Grid.js';
 import { GridColumn } from '@hilla/react-components/GridColumn.js';
 import { GridColumnGroup } from '@hilla/react-components/GridColumnGroup.js';
 import {
   cloneElement,
   type ComponentType,
-  type Dispatch,
   type ForwardedRef,
   forwardRef,
   type JSX,
-  type MutableRefObject,
-  type SetStateAction,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -29,42 +18,16 @@ import { ColumnContext, type SortState } from './autogrid-column-context.js';
 import { type ColumnOptions, getColumnOptions } from './autogrid-columns.js';
 import { AutoGridFooterItemCountRenderer, AutoGridRowNumberRenderer, FooterContext } from './autogrid-renderers.js';
 import css from './autogrid.obj.css';
-import type { CountService, ListService } from './crud';
+import type { ListService } from './crud';
+import { createDataProvider, type DataProvider, isCountService, type ItemCounts } from './data-provider.js';
 import { HeaderSorter } from './header-sorter';
 import { getDefaultProperties, ModelInfo, type PropertyInfo } from './model-info.js';
 import type AndFilter from './types/dev/hilla/crud/filter/AndFilter.js';
 import type FilterUnion from './types/dev/hilla/crud/filter/FilterUnion.js';
 import type PropertyStringFilter from './types/dev/hilla/crud/filter/PropertyStringFilter.js';
-import type Sort from './types/dev/hilla/mappedtypes/Sort.js';
-import Direction from './types/org/springframework/data/domain/Sort/Direction.js';
 import { registerStylesheet } from './util';
 
 registerStylesheet(css);
-
-export type AutoGridItemCountHolder = Readonly<{
-  /**
-   * Passed from AutoGrid to AutoGridFooterItemCountRenderer
-   * see: {@link AutoGrid#totalCount}
-   */
-  totalCount: boolean | undefined;
-  /**
-   * Passed from AutoGrid to AutoGridFooterItemCountRenderer
-   * see: {@link AutoGrid#filteredCount}
-   */
-  filteredCount: boolean | undefined;
-  /**
-   * Ref to the total item count, which is used to show the total count in the
-   * grid footer. This is updated when the grid is loaded for the first time.
-   * Only available when the service implements the `CountService` interface and
-   * the `totalCount` option is enabled.
-   */
-  totalItemCount: MutableRefObject<number>;
-  /**
-   * Ref to the filtered item count, which is used to show the filtered count in
-   * the grid footer. This is updated when the grid filter changes.
-   */
-  filteredItemCount: MutableRefObject<number>;
-}>;
 
 export interface AutoGridRef<TItem = any> {
   /**
@@ -166,148 +129,10 @@ interface AutoGridOwnProps<TItem> {
    * This requires the provided service to implement the CountService interface,
    * See {@link AutoGrid#totalCount} and {@link AutoGrid#filteredCount}.
    */
-  footerCountRenderer?: ComponentType<AutoGridItemCountHolder>;
+  footerCountRenderer?: ComponentType<ItemCounts>;
 }
 
 export type AutoGridProps<TItem> = GridProps<TItem> & Readonly<AutoGridOwnProps<TItem>>;
-
-type GridElementWithInternalAPI<TItem = GridDefaultItem> = GridElement<TItem> &
-  Readonly<{
-    _dataProviderController: {
-      rootCache: {
-        size?: number;
-      };
-    };
-  }>;
-
-function createSort<TItem>(params: GridDataProviderParams<TItem>): Sort {
-  return {
-    orders: params.sortOrders
-      .filter((order) => order.direction != null)
-      .map((order) => ({
-        property: order.path,
-        direction: order.direction === 'asc' ? Direction.ASC : Direction.DESC,
-        ignoreCase: false,
-      })),
-  };
-}
-
-type PageRequest = {
-  pageNumber: number;
-  pageSize: number;
-  sort: Sort;
-};
-
-type DataPage<TItem> = {
-  items: TItem[];
-  pageRequest: PageRequest;
-};
-
-async function fetchDataPage<TItem>(
-  params: GridDataProviderParams<TItem>,
-  service: ListService<TItem>,
-  filter: MutableRefObject<FilterUnion | undefined>,
-): Promise<DataPage<TItem>> {
-  const sort = createSort(params);
-
-  const pageNumber = params.page;
-  const { pageSize } = params;
-  const pageRequest = {
-    pageNumber,
-    pageSize,
-    sort,
-  };
-  const items = await service.list(pageRequest, filter.current);
-
-  return { items, pageRequest };
-}
-
-function createInfiniteDataProvider<TItem>(
-  service: ListService<TItem>,
-  filter: MutableRefObject<FilterUnion | undefined>,
-  grid: GridElement<TItem>,
-  afterPageLoaded: () => void,
-): GridDataProvider<TItem> {
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  return async (params: GridDataProviderParams<TItem>, callback: GridDataProviderCallback<TItem>) => {
-    const { items, pageRequest } = await fetchDataPage(params, service, filter);
-    const { pageNumber, pageSize } = pageRequest;
-    let infiniteScrollingSize;
-    if (items.length === pageSize) {
-      infiniteScrollingSize = (pageNumber + 1) * pageSize + 1;
-      const cacheSize = (grid as GridElementWithInternalAPI<TItem>)._dataProviderController.rootCache.size;
-      if (cacheSize !== undefined && infiniteScrollingSize < cacheSize) {
-        // Only allow size to grow here to avoid shrinking the size when scrolled down and sorting
-        infiniteScrollingSize = undefined;
-      }
-    } else {
-      infiniteScrollingSize = pageNumber * pageSize + items.length;
-    }
-
-    callback(items, infiniteScrollingSize);
-    afterPageLoaded();
-  };
-}
-
-function createFiniteDataProvider<TItem>(
-  service: CountService<TItem> & ListService<TItem>,
-  filter: MutableRefObject<FilterUnion | undefined>,
-  footerRef: MutableRefObject<Dispatch<SetStateAction<number>>>,
-  itemCountHolder: AutoGridItemCountHolder,
-  afterPageLoaded: () => void,
-): GridDataProvider<TItem> {
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  return async (params: GridDataProviderParams<TItem>, callback: GridDataProviderCallback<TItem>) => {
-    const { items } = await fetchDataPage(params, service, filter);
-
-    const { totalCount, totalItemCount, filteredItemCount } = itemCountHolder;
-
-    if (totalCount && totalItemCount.current < 0) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-      totalItemCount.current = await service.count(undefined);
-    }
-
-    let realSize = filteredItemCount.current;
-    if (realSize < 0) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
-      realSize = await service.count(filter.current);
-      filteredItemCount.current = realSize;
-      footerRef.current(realSize);
-    }
-
-    callback(items, realSize);
-    afterPageLoaded();
-  };
-}
-
-function createDataProvider<TItem>(
-  grid: GridElement<TItem>,
-  service: ListService<TItem>,
-  filter: MutableRefObject<FilterUnion | undefined>,
-  itemCountHolder: AutoGridItemCountHolder,
-  footerRef: MutableRefObject<Dispatch<SetStateAction<number>>>,
-): GridDataProvider<TItem> {
-  let first = true;
-  const afterPageLoaded = () => {
-    if (first) {
-      // Workaround for https://github.com/vaadin/react-components/issues/129
-      first = false;
-      setTimeout(() => grid.recalculateColumnWidths(), 0);
-    }
-  };
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (!(service as any).count) {
-    if (itemCountHolder.totalCount ?? itemCountHolder.filteredCount) {
-      console.error(
-        '"totalCount" and "filteredCount" props require the provided service to implement the CountService interface.',
-      );
-    }
-    return createInfiniteDataProvider(service, filter, grid, afterPageLoaded);
-  }
-  const countService = service as unknown as CountService<TItem> & ListService<TItem>;
-  return createFiniteDataProvider(countService, filter, footerRef, itemCountHolder, afterPageLoaded);
-}
 
 interface ColumnConfigurationOptions {
   visibleColumns?: string[];
@@ -315,9 +140,10 @@ interface ColumnConfigurationOptions {
   customColumns?: JSX.Element[];
   columnOptions?: Record<string, ColumnOptions>;
   rowNumbers?: boolean;
-  itemCountHolder: AutoGridItemCountHolder;
-  footerCountRenderer?: ComponentType<AutoGridItemCountHolder>;
-  footerRef: MutableRefObject<Dispatch<SetStateAction<number>>>;
+  totalCount?: boolean;
+  filteredCount?: boolean;
+  footerCountRenderer?: ComponentType<ItemCounts>;
+  itemCounts?: ItemCounts;
 }
 
 function addCustomColumns(columns: JSX.Element[], options: ColumnConfigurationOptions): JSX.Element[] {
@@ -408,10 +234,18 @@ function useColumns(
       ...columns,
     ];
   }
-  const { itemCountHolder, footerRef, footerCountRenderer } = options;
-  if (itemCountHolder.totalCount ?? itemCountHolder.filteredCount) {
+  const { totalCount, filteredCount, itemCounts, footerCountRenderer } = options;
+  if (totalCount ?? filteredCount) {
     const col = (
-      <FooterContext.Provider key="grid-footer" value={{ itemCountHolder, footerRef, footerCountRenderer }}>
+      <FooterContext.Provider
+        key="grid-footer"
+        value={{
+          totalCount,
+          filteredCount,
+          footerCountRenderer,
+          itemCounts,
+        }}
+      >
         <GridColumnGroup footerRenderer={AutoGridFooterItemCountRenderer}>{columns}</GridColumnGroup>
       </FooterContext.Provider>
     );
@@ -440,11 +274,9 @@ function AutoGridInner<TItem>(
   ref: ForwardedRef<AutoGridRef<TItem>>,
 ): JSX.Element {
   const [internalFilter, setInternalFilter] = useState<AndFilter>({ '@type': 'and', children: [] });
+  const [itemCounts, setItemCounts] = useState<ItemCounts | undefined>();
   const gridRef = useRef<GridElement<TItem>>(null);
-  const dataProviderFilter = useRef<FilterUnion | undefined>(undefined);
-  const totalItemCount = useRef(-1);
-  const filteredItemCount = useRef(-1);
-  const footerRef = useRef<Dispatch<SetStateAction<number>>>(() => {});
+  const dataProviderRef = useRef<DataProvider<TItem>>();
 
   useImperativeHandle(
     ref,
@@ -453,9 +285,7 @@ function AutoGridInner<TItem>(
         return gridRef.current;
       },
       refresh() {
-        filteredItemCount.current = -1;
-        totalItemCount.current = -1;
-        gridRef.current?.clearCache();
+        dataProviderRef.current?.refresh();
       },
     }),
     [],
@@ -484,13 +314,6 @@ function AutoGridInner<TItem>(
     }
   };
 
-  const itemCountHolder: AutoGridItemCountHolder = {
-    totalCount,
-    filteredCount,
-    totalItemCount,
-    filteredItemCount,
-  };
-
   const modelInfo = useMemo(() => new ModelInfo(model, itemIdProperty), [model]);
   const properties = visibleColumns ? modelInfo.getProperties(visibleColumns) : getDefaultProperties(modelInfo);
   const children = useColumns(properties, setHeaderPropertyFilter, {
@@ -499,9 +322,10 @@ function AutoGridInner<TItem>(
     customColumns,
     columnOptions,
     rowNumbers,
-    itemCountHolder,
+    totalCount,
+    filteredCount,
     footerCountRenderer,
-    footerRef,
+    itemCounts,
   });
 
   useEffect(() => {
@@ -514,19 +338,26 @@ function AutoGridInner<TItem>(
   useEffect(() => {
     // Sets the data provider, should be done only once
     const grid = gridRef.current!;
+    // Log an error if totalCount or filteredCount is enabled but the service doesn't implement CountService
+    if ((!isCountService(service) && totalCount) ?? filteredCount) {
+      console.error(
+        '"totalCount" and "filteredCount" props require the provided service to implement the CountService interface.',
+      );
+    }
+    // Wait for the sorting headers to be rendered so that the sorting state is correct for the first data provider call
     setTimeout(() => {
-      // Wait for the sorting headers to be rendered so that the sorting state is correct for the first data provider call
-      grid.dataProvider = createDataProvider(grid, service, dataProviderFilter, itemCountHolder, footerRef);
+      const initialFilter = experimentalFilter ?? internalFilter;
+      dataProviderRef.current = createDataProvider(grid, service, initialFilter, (newItemCounts: ItemCounts) => {
+        setItemCounts(newItemCounts);
+      });
     }, 1);
   }, [model, service]);
 
   useEffect(() => {
     // Update the filtering, whenever the filter changes
-    const grid = gridRef.current;
-    if (grid) {
-      dataProviderFilter.current = experimentalFilter ?? internalFilter;
-      filteredItemCount.current = -1;
-      grid.clearCache();
+    const dataProvider = dataProviderRef.current;
+    if (dataProvider) {
+      dataProvider.setFilter(experimentalFilter ?? internalFilter);
     }
   }, [experimentalFilter, internalFilter]);
 

--- a/packages/ts/react-crud/src/autogrid.tsx
+++ b/packages/ts/react-crud/src/autogrid.tsx
@@ -346,9 +346,16 @@ function AutoGridInner<TItem>(
     }
     // Wait for the sorting headers to be rendered so that the sorting state is correct for the first data provider call
     setTimeout(() => {
+      let firstUpdate = true;
       const initialFilter = experimentalFilter ?? internalFilter;
       dataProviderRef.current = createDataProvider(grid, service, initialFilter, (newItemCounts: ItemCounts) => {
         setItemCounts(newItemCounts);
+
+        if (firstUpdate) {
+          // Workaround for https://github.com/vaadin/react-components/issues/129
+          firstUpdate = false;
+          setTimeout(() => grid.recalculateColumnWidths(), 0);
+        }
       });
     }, 1);
   }, [model, service]);

--- a/packages/ts/react-crud/src/data-provider.ts
+++ b/packages/ts/react-crud/src/data-provider.ts
@@ -1,0 +1,192 @@
+import type {
+  GridDataProviderCallback,
+  GridDataProviderParams,
+  GridDefaultItem,
+  GridElement,
+} from '@hilla/react-components/Grid';
+import type { CountService, ListService } from './crud';
+import type FilterUnion from './types/dev/hilla/crud/filter/FilterUnion';
+import type Sort from './types/dev/hilla/mappedtypes/Sort';
+import Direction from './types/org/springframework/data/domain/Sort/Direction';
+
+type GridElementWithInternalAPI<TItem = GridDefaultItem> = GridElement<TItem> &
+  Readonly<{
+    _dataProviderController: {
+      rootCache: {
+        size?: number;
+      };
+    };
+  }>;
+
+type MaybeCountService<TItem> = Partial<CountService<TItem>>;
+type ListAndMaybeCountService<TItem> = ListService<TItem> & MaybeCountService<TItem>;
+
+type PageRequest = {
+  pageNumber: number;
+  pageSize: number;
+  sort: Sort;
+};
+
+type DataPage<TItem> = {
+  items: TItem[];
+  pageRequest: PageRequest;
+};
+
+export type ItemCounts = {
+  totalCount?: number;
+  filteredCount?: number;
+};
+
+type LoadCallback = (result: ItemCounts) => void;
+
+function createSort<TItem>(params: GridDataProviderParams<TItem>): Sort {
+  return {
+    orders: params.sortOrders
+      .filter((order) => order.direction != null)
+      .map((order) => ({
+        property: order.path,
+        direction: order.direction === 'asc' ? Direction.ASC : Direction.DESC,
+        ignoreCase: false,
+      })),
+  };
+}
+
+export function isCountService<TItem>(
+  service: ListAndMaybeCountService<TItem>,
+): service is CountService<TItem> & ListService<TItem> {
+  return !!service.count;
+}
+
+export abstract class DataProvider<TItem> {
+  protected readonly grid: GridElement;
+  protected readonly service: ListAndMaybeCountService<TItem>;
+  protected readonly loadCallback?: LoadCallback;
+
+  protected firstUpdate = true;
+  protected filter: FilterUnion | undefined;
+  protected totalCount: number | undefined;
+  protected filteredCount: number | undefined;
+
+  constructor(
+    grid: GridElement,
+    service: ListAndMaybeCountService<TItem>,
+    filter: FilterUnion | undefined,
+    loadCallback?: LoadCallback,
+  ) {
+    this.grid = grid;
+    this.service = service;
+    this.filter = filter;
+    this.loadCallback = loadCallback;
+
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    this.grid.dataProvider = this.load.bind(this);
+  }
+
+  private async load(params: GridDataProviderParams<TItem>, callback: GridDataProviderCallback<TItem>) {
+    const page = await this.fetchPage(params);
+    if (this.totalCount === undefined) {
+      this.totalCount = await this.fetchTotalCount(page);
+    }
+    if (this.filteredCount === undefined) {
+      this.filteredCount = await this.fetchFilteredCount(page);
+    }
+
+    callback(page.items, this.filteredCount);
+    if (this.loadCallback) {
+      this.loadCallback({
+        totalCount: this.totalCount,
+        filteredCount: this.filteredCount,
+      });
+    }
+
+    if (this.firstUpdate) {
+      // Workaround for https://github.com/vaadin/react-components/issues/129
+      this.firstUpdate = false;
+      setTimeout(() => this.grid.recalculateColumnWidths(), 0);
+    }
+  }
+
+  private async fetchPage(params: GridDataProviderParams<TItem>): Promise<DataPage<TItem>> {
+    const sort = createSort(params);
+    const pageNumber = params.page;
+    const { pageSize } = params;
+    const pageRequest = {
+      pageNumber,
+      pageSize,
+      sort,
+    };
+    const items = await this.service.list(pageRequest, this.filter);
+
+    return { items, pageRequest };
+  }
+
+  abstract fetchTotalCount(page: DataPage<TItem>): Promise<number | undefined>;
+
+  abstract fetchFilteredCount(page: DataPage<TItem>): Promise<number | undefined>;
+
+  refresh(): void {
+    this.totalCount = undefined;
+    this.filteredCount = undefined;
+    this.grid.clearCache();
+  }
+
+  setFilter(filter: FilterUnion | undefined): void {
+    this.filter = filter;
+    this.refresh();
+  }
+}
+
+class InfiniteDataProvider<TItem> extends DataProvider<TItem> {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async fetchTotalCount(): Promise<number | undefined> {
+    return undefined;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async fetchFilteredCount(page: DataPage<TItem>): Promise<number | undefined> {
+    const { items, pageRequest } = page;
+    const { pageNumber, pageSize } = pageRequest;
+    let infiniteScrollingSize;
+
+    if (items.length === pageSize) {
+      infiniteScrollingSize = (pageNumber + 1) * pageSize + 1;
+      const cacheSize = (this.grid as GridElementWithInternalAPI<TItem>)._dataProviderController.rootCache.size;
+      if (cacheSize !== undefined && infiniteScrollingSize < cacheSize) {
+        // Only allow size to grow here to avoid shrinking the size when scrolled down and sorting
+        infiniteScrollingSize = undefined;
+      }
+    } else {
+      infiniteScrollingSize = pageNumber * pageSize + items.length;
+    }
+
+    return Promise.resolve(infiniteScrollingSize);
+  }
+}
+
+class FixedSizeDataProvider<TItem> extends DataProvider<TItem> {
+  async fetchTotalCount(): Promise<number | undefined> {
+    if (!isCountService(this.service)) {
+      throw new Error('The provided service does not implement the CountService interface.');
+    }
+    return this.service.count(undefined);
+  }
+
+  async fetchFilteredCount(): Promise<number | undefined> {
+    if (!isCountService(this.service)) {
+      throw new Error('The provided service does not implement the CountService interface.');
+    }
+    return this.service.count(this.filter);
+  }
+}
+
+export function createDataProvider<TItem>(
+  grid: GridElement,
+  service: ListAndMaybeCountService<TItem>,
+  filter: FilterUnion | undefined,
+  loadCallback: LoadCallback,
+): DataProvider<TItem> {
+  if (isCountService(service)) {
+    return new FixedSizeDataProvider(grid, service, filter, loadCallback);
+  }
+  return new InfiniteDataProvider(grid, service, filter, loadCallback);
+}

--- a/packages/ts/react-crud/src/data-provider.ts
+++ b/packages/ts/react-crud/src/data-provider.ts
@@ -62,7 +62,6 @@ export abstract class DataProvider<TItem> {
   protected readonly service: ListAndMaybeCountService<TItem>;
   protected readonly loadCallback?: LoadCallback;
 
-  protected firstUpdate = true;
   protected filter: FilterUnion | undefined;
   protected totalCount: number | undefined;
   protected filteredCount: number | undefined;
@@ -83,6 +82,7 @@ export abstract class DataProvider<TItem> {
   }
 
   private async load(params: GridDataProviderParams<TItem>, callback: GridDataProviderCallback<TItem>) {
+    // Fetch page, total count and filtered count
     const page = await this.fetchPage(params);
     if (this.totalCount === undefined) {
       this.totalCount = await this.fetchTotalCount(page);
@@ -91,18 +91,15 @@ export abstract class DataProvider<TItem> {
       this.filteredCount = await this.fetchFilteredCount(page);
     }
 
+    // Pass results to grid
     callback(page.items, this.filteredCount);
+
+    // Pass results to callback
     if (this.loadCallback) {
       this.loadCallback({
         totalCount: this.totalCount,
         filteredCount: this.filteredCount,
       });
-    }
-
-    if (this.firstUpdate) {
-      // Workaround for https://github.com/vaadin/react-components/issues/129
-      this.firstUpdate = false;
-      setTimeout(() => this.grid.recalculateColumnWidths(), 0);
     }
   }
 

--- a/packages/ts/react-crud/test/autogrid.spec.tsx
+++ b/packages/ts/react-crud/test/autogrid.spec.tsx
@@ -399,9 +399,9 @@ describe('@hilla/react-crud', () => {
               service={service}
               filteredCount
               totalCount
-              footerCountRenderer={({ filteredItemCount, totalItemCount }) => (
+              footerCountRenderer={({ filteredCount, totalCount }) => (
                 <p>
-                  Custom: {filteredItemCount.current} / {totalItemCount.current}
+                  Custom: {filteredCount} / {totalCount}
                 </p>
               )}
             />,

--- a/packages/ts/react-crud/test/dataprovider.spec.ts
+++ b/packages/ts/react-crud/test/dataprovider.spec.ts
@@ -1,0 +1,397 @@
+import { expect, use } from '@esm-bundle/chai';
+import type { GridDataProvider, GridElement, GridSorterDefinition } from '@hilla/react-components/Grid.js';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import type { CountService, ListService } from '../crud';
+import { createDataProvider, FixedSizeDataProvider, InfiniteDataProvider, type ItemCounts } from '../src/data-provider';
+import type AndFilter from '../types/dev/hilla/crud/filter/AndFilter';
+import type FilterUnion from '../types/dev/hilla/crud/filter/FilterUnion';
+import type PropertyStringFilter from '../types/dev/hilla/crud/filter/PropertyStringFilter';
+import Matcher from '../types/dev/hilla/crud/filter/PropertyStringFilter/Matcher';
+import type Pageable from '../types/dev/hilla/mappedtypes/Pageable';
+
+use(sinonChai);
+
+class MockGrid {
+  pageSize = 10;
+  loadSpy = sinon.spy();
+  clearCacheSpy = sinon.spy();
+
+  private _dataProvider: GridDataProvider<any> | undefined;
+  readonly _dataProviderController = {
+    rootCache: {
+      size: 0,
+    },
+  };
+
+  get dataProvider(): GridDataProvider<any> | undefined {
+    return this._dataProvider;
+  }
+
+  set dataProvider(dataProvider: GridDataProvider<any> | undefined) {
+    if (!dataProvider) {
+      throw new Error('Invalid test setup, dataProvider not set');
+    }
+    // Install spy to expose the loaded items and total size from callback
+    this.loadSpy = sinon.spy();
+    this._dataProvider = (params, callback) => {
+      dataProvider(params, (items, size) => {
+        this.loadSpy(items, size);
+        callback(items, size);
+      });
+    };
+  }
+
+  clearCache() {
+    this._dataProviderController.rootCache.size = 0;
+    this.clearCacheSpy();
+  }
+
+  async requestPage(page: number, sortOrders: GridSorterDefinition[] = []): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.dataProvider) {
+        throw new Error('Invalid test setup, dataProvider not set');
+      }
+      this.dataProvider({ page, pageSize: this.pageSize, sortOrders, filters: [] }, (_, size) => {
+        this._dataProviderController.rootCache.size = size!;
+        resolve();
+      });
+    });
+  }
+}
+
+function mockGrid() {
+  return new MockGrid() as unknown as GridElement & MockGrid;
+}
+
+const data = Array.from({ length: 25 }, (_, i) => i);
+
+const listService: ListService<number> = {
+  async list(request: Pageable, filter: FilterUnion | undefined): Promise<number[]> {
+    const offset = request.pageNumber * request.pageSize;
+    return Promise.resolve(data.slice(offset, offset + request.pageSize));
+  },
+};
+
+const listAndCountService: CountService<number> & ListService<number> = {
+  async list(request: Pageable, filter: FilterUnion | undefined): Promise<number[]> {
+    const offset = request.pageNumber * request.pageSize;
+    return Promise.resolve(data.slice(offset, offset + request.pageSize));
+  },
+  async count(filter: FilterUnion | undefined): Promise<number> {
+    // If there is a filter, just return a different number than the total size
+    if (filter) {
+      return Promise.resolve(10);
+    }
+    return Promise.resolve(data.length);
+  },
+};
+
+function createTestFilter(): FilterUnion {
+  const filter1: PropertyStringFilter = {
+    '@type': 'propertyString',
+    propertyId: 'foo',
+    filterValue: 'fooValue',
+    matcher: Matcher.CONTAINS,
+  };
+  const filter2: PropertyStringFilter = {
+    '@type': 'propertyString',
+    propertyId: 'bar',
+    filterValue: 'barValue',
+    matcher: Matcher.CONTAINS,
+  };
+  const andFilter: AndFilter = {
+    '@type': 'and',
+    children: [filter1, filter2],
+  };
+  return andFilter;
+}
+
+async function testPageLoad(
+  grid: GridElement & MockGrid,
+  listSpy: sinon.SinonSpy<[request: Pageable, filter: FilterUnion | undefined], Promise<number[]>>,
+  pageNumber: number,
+  expectedItems: number[],
+  expectedSize: number,
+) {
+  listSpy.resetHistory();
+  grid.loadSpy.resetHistory();
+
+  await grid.requestPage(pageNumber);
+
+  expect(grid.loadSpy).to.have.been.calledOnce;
+  expect(grid.loadSpy).to.have.been.calledWith(expectedItems, expectedSize);
+
+  expect(listSpy).to.have.been.calledOnce;
+  const pageable = listSpy.lastCall.args[0];
+  expect(pageable.pageNumber).to.equal(pageNumber);
+  expect(pageable.pageSize).to.equal(grid.pageSize);
+}
+
+describe('@hilla/react-crud', () => {
+  describe('createDataProvider', () => {
+    it('creates InfiniteDataProvider for list service', () => {
+      const grid = mockGrid();
+      const dataProvider = createDataProvider(grid, listService);
+      expect(dataProvider).to.be.instanceOf(InfiniteDataProvider);
+    });
+
+    it('creates FixedSizeDataProvider for list and count service', () => {
+      const grid = mockGrid();
+      const dataProvider = createDataProvider(grid, listAndCountService);
+      expect(dataProvider).to.be.instanceOf(FixedSizeDataProvider);
+    });
+  });
+
+  describe('InfiniteDataProvider', () => {
+    let listSpy: sinon.SinonSpy<[request: Pageable, filter: FilterUnion | undefined], Promise<number[]>>;
+
+    beforeEach(() => {
+      listSpy = sinon.spy(listService, 'list');
+    });
+
+    afterEach(() => {
+      listSpy.restore();
+    });
+
+    it('loads pages', async () => {
+      const grid = mockGrid();
+      const dataProvider = new InfiniteDataProvider(grid, listService);
+
+      // First page
+      // Total size is page size + 1
+      await testPageLoad(grid, listSpy, 0, data.slice(0, 10), 11);
+
+      // Second page
+      // Total size is cache size + page size + 1
+      await testPageLoad(grid, listSpy, 1, data.slice(10, 20), 21);
+
+      // Last page
+      // Total size is cache size + page size
+      await testPageLoad(grid, listSpy, 2, data.slice(20, 25), 25);
+    });
+
+    it('returns correct item counts', async () => {
+      const grid = mockGrid();
+      const afterLoadSpy = sinon.spy() as sinon.SinonSpy<[result: ItemCounts], void>;
+      const dataProvider = new InfiniteDataProvider(grid, listService, {
+        afterLoad: afterLoadSpy,
+      });
+
+      await grid.requestPage(0);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: undefined, filteredCount: 11 });
+
+      await grid.requestPage(1);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: undefined, filteredCount: 21 });
+
+      await grid.requestPage(2);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: undefined, filteredCount: 25 });
+    });
+
+    it('passes sort to service', async () => {
+      let pageable: Pageable;
+      const grid = mockGrid();
+      const dataProvider = new InfiniteDataProvider(grid, listService);
+
+      await grid.requestPage(0, [{ path: 'foo', direction: 'asc' }]);
+      pageable = listSpy.lastCall.args[0];
+      expect(pageable.sort).to.eql({ orders: [{ property: 'foo', direction: 'ASC', ignoreCase: false }] });
+
+      await grid.requestPage(0, [{ path: 'bar', direction: 'desc' }]);
+      pageable = listSpy.lastCall.args[0];
+      expect(pageable.sort).to.eql({ orders: [{ property: 'bar', direction: 'DESC', ignoreCase: false }] });
+    });
+
+    it('passes filter to service', async () => {
+      const grid = mockGrid();
+      const filter = createTestFilter();
+      const dataProvider = new InfiniteDataProvider(grid, listService, {
+        initialFilter: filter,
+      });
+
+      await grid.requestPage(0);
+      const passedFilter = listSpy.lastCall.args[1];
+      expect(passedFilter).to.equal(filter);
+    });
+
+    it('refreshes when refresh is called', async () => {
+      const grid = mockGrid();
+      const dataProvider = new InfiniteDataProvider(grid, listService);
+
+      await grid.requestPage(0);
+      await grid.requestPage(1);
+      await grid.requestPage(2);
+      expect(grid._dataProviderController.rootCache.size).to.equal(25);
+
+      dataProvider.refresh();
+      expect(grid.clearCacheSpy).to.have.been.calledOnce;
+
+      await grid.requestPage(0);
+      expect(grid._dataProviderController.rootCache.size).to.equal(11);
+    });
+
+    it('refreshes when filter is changed', async () => {
+      const grid = mockGrid();
+      const dataProvider = new InfiniteDataProvider(grid, listService);
+
+      await grid.requestPage(0);
+      await grid.requestPage(1);
+      await grid.requestPage(2);
+      expect(grid._dataProviderController.rootCache.size).to.equal(25);
+
+      const filter = createTestFilter();
+      dataProvider.setFilter(filter);
+      expect(grid.clearCacheSpy).to.have.been.calledOnce;
+
+      await grid.requestPage(0);
+      expect(grid._dataProviderController.rootCache.size).to.equal(11);
+      expect(listSpy.lastCall.args[1]).to.equal(filter);
+    });
+  });
+
+  describe('FixedSizeDataProvider', () => {
+    let listSpy: sinon.SinonSpy<[request: Pageable, filter: FilterUnion | undefined], Promise<number[]>>;
+    let countSpy: sinon.SinonSpy<[filter: FilterUnion | undefined], Promise<number>>;
+
+    beforeEach(() => {
+      listSpy = sinon.spy(listAndCountService, 'list');
+      countSpy = sinon.spy(listAndCountService, 'count');
+    });
+
+    afterEach(() => {
+      listSpy.restore();
+      countSpy.restore();
+    });
+
+    it('does not work with a ListService', () => {
+      const grid = mockGrid();
+
+      expect(() => {
+        const dataProvider = new FixedSizeDataProvider(grid, listService);
+      }).to.throw('The provided service does not implement the CountService interface.');
+    });
+
+    it('loads pages', async () => {
+      const grid = mockGrid();
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService);
+
+      // First page
+      await testPageLoad(grid, listSpy, 0, data.slice(0, 10), 25);
+
+      // Second page
+      await testPageLoad(grid, listSpy, 1, data.slice(10, 20), 25);
+
+      // Last page
+      await testPageLoad(grid, listSpy, 2, data.slice(20, 25), 25);
+    });
+
+    it('returns correct item counts', async () => {
+      const grid = mockGrid();
+      const afterLoadSpy = sinon.spy() as sinon.SinonSpy<[result: ItemCounts], void>;
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService, {
+        afterLoad: afterLoadSpy,
+      });
+
+      await grid.requestPage(0);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: undefined, filteredCount: 25 });
+
+      await grid.requestPage(1);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: undefined, filteredCount: 25 });
+
+      await grid.requestPage(2);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: undefined, filteredCount: 25 });
+
+      // Verify count was only called once for getting filtered count
+      expect(countSpy).to.have.been.calledOnce;
+      expect(countSpy).to.have.been.calledWith(undefined);
+    });
+
+    it('also returns total count when enabling it in options', async () => {
+      const grid = mockGrid();
+      const afterLoadSpy = sinon.spy() as sinon.SinonSpy<[result: ItemCounts], void>;
+      // Use filter to get different filtered count than total count
+      const filter = createTestFilter();
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService, {
+        afterLoad: afterLoadSpy,
+        loadTotalCount: true,
+        initialFilter: filter,
+      });
+
+      await grid.requestPage(0);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: 25, filteredCount: 10 });
+
+      await grid.requestPage(1);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: 25, filteredCount: 10 });
+
+      await grid.requestPage(2);
+      expect(afterLoadSpy.lastCall.args[0]).to.eql({ totalCount: 25, filteredCount: 10 });
+
+      // Verify count was only called once for each the filtered count and total count
+      expect(countSpy).to.have.been.calledTwice;
+      expect(countSpy).to.have.been.calledWith(undefined);
+      expect(countSpy).to.have.been.calledWith(filter);
+    });
+
+    it('passes sort to service', async () => {
+      let pageable: Pageable;
+      const grid = mockGrid();
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService);
+
+      await grid.requestPage(0, [{ path: 'foo', direction: 'asc' }]);
+      pageable = listSpy.lastCall.args[0];
+      expect(pageable.sort).to.eql({ orders: [{ property: 'foo', direction: 'ASC', ignoreCase: false }] });
+
+      await grid.requestPage(0, [{ path: 'bar', direction: 'desc' }]);
+      pageable = listSpy.lastCall.args[0];
+      expect(pageable.sort).to.eql({ orders: [{ property: 'bar', direction: 'DESC', ignoreCase: false }] });
+    });
+
+    it('passes filter to service', async () => {
+      const grid = mockGrid();
+      const filter = createTestFilter();
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService, {
+        initialFilter: filter,
+      });
+
+      await grid.requestPage(0);
+      const passedFilter = listSpy.lastCall.args[1];
+      expect(passedFilter).to.equal(filter);
+      expect(countSpy).to.have.been.calledOnceWithExactly(filter);
+    });
+
+    it('refreshes when refresh is called', async () => {
+      const grid = mockGrid();
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService);
+
+      await grid.requestPage(0);
+      await grid.requestPage(1);
+      await grid.requestPage(2);
+      expect(countSpy).to.have.been.calledOnce;
+
+      dataProvider.refresh();
+      expect(grid.clearCacheSpy).to.have.been.calledOnce;
+
+      await grid.requestPage(0);
+      expect(countSpy).to.have.been.calledTwice;
+    });
+
+    it('refreshes when filter is changed', async () => {
+      const grid = mockGrid();
+      const dataProvider = new FixedSizeDataProvider(grid, listAndCountService);
+
+      await grid.requestPage(0);
+      await grid.requestPage(1);
+      await grid.requestPage(2);
+      expect(countSpy).to.have.been.calledOnceWith(undefined);
+
+      const filter = createTestFilter();
+      dataProvider.setFilter(filter);
+      expect(grid.clearCacheSpy).to.have.been.calledOnce;
+
+      await grid.requestPage(0);
+      expect(countSpy).to.have.been.calledTwice;
+      expect(countSpy).to.have.been.calledWith(filter);
+      expect(listSpy.lastCall.args[1]).to.equal(filter);
+    });
+  });
+});


### PR DESCRIPTION
Separates the data provider implementation from `AutoGrid` specific logic:
- Moves the DP implementation into a separate module
- Refactored the data providers to be class based, with specific implementations for infinite and fixed-size data providers.
- Moves the `recalculateColumnWidths` workaround back to the `AutoGrid`
- Removes the item count holder and footer ref, and instead provides a callback that returns the total and filtered item counts
- Adds test coverage for the DP implementation itself

Also refactors the footer item count logic a bit:
- The footer ref has been removed. Instead the `AutoGrid` now has a state for the item counts, which is passed down into the footer column context to trigger a re-render when the item counts change.
- Changed the signature of the custom footer renderer to only receive the item counts, and not the options which counts should be displayed. The renderer can decide on its own whether to render a count or not.