### PR TITLE
feat(react-crud): support additional columns / fields from options

### DIFF
--- a/packages/java/tests/spring/react-grid-test/frontend/views/AutoFormView.tsx
+++ b/packages/java/tests/spring/react-grid-test/frontend/views/AutoFormView.tsx
@@ -3,9 +3,14 @@ import { useState } from 'react';
 import type Appointment from 'Frontend/generated/dev/hilla/test/reactgrid/Appointment.js';
 import AppointmentModel from 'Frontend/generated/dev/hilla/test/reactgrid/AppointmentModel.js';
 import { AppointmentService } from 'Frontend/generated/endpoints.js';
+import {
+  BinderRoot,
+  ValidationResult
+} from "@hilla/form";
 
 export function AutoFormView(): JSX.Element {
   const [submitted, setSubmitted] = useState<Appointment | undefined>(undefined);
+  const [count, setCount] = useState(0);
 
   function handleSubmit({ item }: SubmitEvent<Appointment>) {
     setSubmitted(item);
@@ -30,7 +35,9 @@ export function AutoFormView(): JSX.Element {
       ) : (
         <>
           <h1>Make a new appointment</h1>
+          <button onClick={() => setCount(count + 1)}>Count: {count}</button>
           <br />
+
           <AutoForm
             service={AppointmentService}
             model={AppointmentModel}
@@ -38,6 +45,13 @@ export function AutoFormView(): JSX.Element {
             onSubmitError={handleSubmitError}
             onDeleteSuccess={handleDelete}
             onDeleteError={handleDeleteError}
+            fieldOptions={{doctor: {validators: [
+                  {message: 'fail',
+                  validate(value: unknown, binder: BinderRoot): boolean {
+                    return (!value) || String(value).length < 3;
+                  }
+                  }
+                ]}}}
           />
         </>
       )}

--- a/packages/java/tests/spring/react-grid-test/frontend/views/GridWithEntityReferences.tsx
+++ b/packages/java/tests/spring/react-grid-test/frontend/views/GridWithEntityReferences.tsx
@@ -1,8 +1,19 @@
 import { AutoGrid } from '@hilla/react-crud';
+import type Employee from 'Frontend/generated/dev/hilla/test/reactgrid/entityreferences/Employee.js';
 import EmployeeModel from 'Frontend/generated/dev/hilla/test/reactgrid/entityreferences/EmployeeModel.js';
 import { EmployeeService } from 'Frontend/generated/endpoints.js';
 
+function DepartmentRenderer({item}: {item: Employee}) {
+  return <>{item.department.name}</>;
+}
+
 export function GridWithEntityReferences(): JSX.Element {
-  return <AutoGrid pageSize={10} service={EmployeeService} model={EmployeeModel} noHeaderFilters />;
+  return <AutoGrid pageSize={10} service={EmployeeService} model={EmployeeModel} noHeaderFilters
+   columnOptions={{
+     "department.name": {
+       renderer: DepartmentRenderer,
+       header: "Department"
+     },
+   }}/>;
   /* page size is defined only to make testing easier */
 }

--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -375,7 +375,13 @@ export function AutoForm<M extends AbstractModel>({
     );
   }
 
-  const visibleProperties = visibleFields ? modelInfo.getProperties(visibleFields) : getDefaultProperties(modelInfo);
+  const pathsWithRenderer = Object.entries(fieldOptions ?? {})
+    .filter(([path, options]: [string, FieldOptions]) => !!options.renderer)
+    .map(([path]: [string, unknown]) => path);
+
+  const visibleProperties = visibleFields
+    ? modelInfo.getProperties(visibleFields)
+    : getDefaultProperties(modelInfo, pathsWithRenderer);
 
   const fields = visibleProperties.map(createAutoFormField);
 

--- a/packages/ts/react-crud/src/autogrid.tsx
+++ b/packages/ts/react-crud/src/autogrid.tsx
@@ -492,7 +492,10 @@ function AutoGridInner<TItem>(
   };
 
   const modelInfo = useMemo(() => new ModelInfo(model, itemIdProperty), [model]);
-  const properties = visibleColumns ? modelInfo.getProperties(visibleColumns) : getDefaultProperties(modelInfo);
+  const pathsWithRenderer = Object.entries(columnOptions ?? {})
+    .filter(([path, options]: [string, ColumnOptions]) => !!options.renderer)
+    .map(([path]: [string, unknown]) => path);
+  const properties = visibleColumns ? modelInfo.getProperties(visibleColumns) : getDefaultProperties(modelInfo, pathsWithRenderer);
   const children = useColumns(properties, setHeaderPropertyFilter, {
     visibleColumns,
     noHeaderFilters,


### PR DESCRIPTION
Fixes #1743

This allows to go from this:

<img width="670" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBelZxQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--f4bc74f686e8b45d722e6dddb14d00a3411cf8e9/Screen%20Shot%202023-12-15%20at%2014.54.10.png" alt="Screen Shot 2023-12-15 at 14.54.10.png" />

... to this:

<img width="466" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBemxxQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--dcdfd37400cb67f1467830f08baac792e140d715/Screen%20Shot%202023-12-15%20at%2014.54.20.png" alt="Screen Shot 2023-12-15 at 14.54.20.png" />

by specifying the column renderer like so:

```tsx
function DepartmentRenderer({item}: {item: Employee}) {
  return <>{item.department.name}</>;
}

export function GridWithEntityReferences(): JSX.Element {
  return <AutoGrid service={EmployeeService} model={EmployeeModel} noHeaderFilters
   columnOptions={{
     "department.name": {
       renderer: DepartmentRenderer,
       header: "Department"
     },
   }}/>;
}
```