### PR TITLE
fix: add name property to Validator interface

### DIFF
--- a/packages/ts/form/src/Validation.ts
+++ b/packages/ts/form/src/Validation.ts
@@ -42,6 +42,7 @@ export type InterpolateMessageCallback<M extends AbstractModel> = (
 export interface Validator<T = unknown> {
   message: string;
   impliesRequired?: boolean;
+  name?: string;
   validate(
     value: T,
     binder: BinderRoot,
@@ -53,6 +54,7 @@ export interface Validator<T = unknown> {
 }
 
 export class ServerValidator implements Validator {
+  name = 'ServerValidator';
   message: string;
 
   constructor(message: string) {

--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -59,7 +59,7 @@ export class Required<T> extends AbstractValidator<T> {
     return value !== undefined;
   }
 
-  name = 'Required';
+  readonly name: string = 'Required';
 }
 
 function _asValidatorAttributes(attrs: PatternAttributes | RegExp | ValueNumberAttributes | number | string) {

--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -43,6 +43,7 @@ abstract class AbstractValidator<T> implements Validator<T> {
   }
 
   abstract validate(value: T): Promise<boolean> | boolean;
+  abstract get name(): string;
 }
 
 export class Required<T> extends AbstractValidator<T> {
@@ -57,6 +58,8 @@ export class Required<T> extends AbstractValidator<T> {
     }
     return value !== undefined;
   }
+
+  name = 'Required';
 }
 
 function _asValidatorAttributes(attrs: PatternAttributes | RegExp | ValueNumberAttributes | number | string) {
@@ -84,6 +87,8 @@ export class IsNumber extends NumberValidator<number | null | undefined> {
   override validate(value: number | null | undefined): boolean {
     return (this.optional && value == null) || super.validate(value);
   }
+
+  readonly name = 'IsNumber';
 }
 
 abstract class ValueNumberValidator<T> extends NumberValidator<T> {
@@ -105,7 +110,10 @@ export class Email extends AbstractValidator<string> {
   override validate(value: string | null | undefined): boolean {
     return !value || isEmail(value);
   }
+
+  readonly name = 'Email';
 }
+
 export class Null extends AbstractValidator<any> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be null', ...attrs });
@@ -114,7 +122,10 @@ export class Null extends AbstractValidator<any> {
   override validate(value: any): boolean {
     return value == null;
   }
+
+  readonly name = 'Null';
 }
+
 export class NotNull<T> extends Required<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must not be null', ...attrs });
@@ -123,7 +134,10 @@ export class NotNull<T> extends Required<T> {
   override validate(value: T): value is NonNullable<T> {
     return !new Null().validate(value);
   }
+
+  override readonly name = 'NotNull';
 }
+
 export class NotEmpty<T> extends Required<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must not be empty', ...attrs });
@@ -134,7 +148,10 @@ export class NotEmpty<T> extends Required<T> {
       super.validate(value) && new NotNull<T>().validate(value) && ((value as { length?: number }).length ?? 0) > 0
     );
   }
+
+  override readonly name = 'NotEmpty';
 }
+
 export class NotBlank<T> extends Required<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must not be blank', ...attrs });
@@ -143,7 +160,10 @@ export class NotBlank<T> extends Required<T> {
   override validate(value: T): boolean {
     return super.validate(value) && new NotNull<T>().validate(value) && String(value).trim().length > 0;
   }
+
+  override readonly name = 'NotBlank';
 }
+
 export class AssertTrue<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be true', ...attrs });
@@ -152,7 +172,10 @@ export class AssertTrue<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return isBoolean(String(value)) && String(value) === 'true';
   }
+
+  readonly name = 'AssertTrue';
 }
+
 export class AssertFalse<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be false', ...attrs });
@@ -161,6 +184,8 @@ export class AssertFalse<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return !new AssertTrue<T>().validate(value);
   }
+
+  readonly name = 'AssertFalse';
 }
 
 function _asValueNumberAttributes(attrs: ValueNumberAttributes | number | string) {
@@ -178,7 +203,10 @@ export class Min<T> extends ValueNumberValidator<T> {
   override validate(value: T): boolean {
     return super.validate(value) && isFloat(String(value), { min: this.value });
   }
+
+  readonly name = 'Min';
 }
+
 export class Max<T> extends ValueNumberValidator<T> {
   constructor(attrs: ValueNumberAttributes | number | string) {
     super({
@@ -190,6 +218,8 @@ export class Max<T> extends ValueNumberValidator<T> {
   override validate(value: T): boolean {
     return super.validate(value) && isFloat(String(value), { max: this.value });
   }
+
+  readonly name = 'Max';
 }
 
 function _inclusive(attrs: DecimalAttributes | number | string) {
@@ -210,7 +240,10 @@ export class DecimalMin<T> extends ValueNumberValidator<T> {
   override validate(value: T): boolean {
     return super.validate(value) && isFloat(String(value), { [this.inclusive ? 'min' : 'gt']: this.value });
   }
+
+  readonly name = 'DecimalMin';
 }
+
 export class DecimalMax<T> extends ValueNumberValidator<T> {
   inclusive: boolean;
 
@@ -225,7 +258,10 @@ export class DecimalMax<T> extends ValueNumberValidator<T> {
   override validate(value: T): boolean {
     return super.validate(value) && isFloat(String(value), { [this.inclusive ? 'max' : 'lt']: this.value });
   }
+
+  readonly name = 'DecimalMax';
 }
+
 export class Negative<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be less than 0', ...attrs });
@@ -234,7 +270,10 @@ export class Negative<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return toFloat(String(value)) < 0;
   }
+
+  readonly name = 'Negative';
 }
+
 export class NegativeOrZero<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be less than or equal to 0', ...attrs });
@@ -243,7 +282,10 @@ export class NegativeOrZero<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return toFloat(String(value)) <= 0;
   }
+
+  readonly name = 'NegativeOrZero';
 }
+
 export class Positive<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be greater than 0', ...attrs });
@@ -252,7 +294,10 @@ export class Positive<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return toFloat(String(value)) > 0;
   }
+
+  readonly name = 'Positive';
 }
+
 export class PositiveOrZero<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be greater than or equal to 0', ...attrs });
@@ -261,6 +306,8 @@ export class PositiveOrZero<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return toFloat(String(value)) >= 0;
   }
+
+  readonly name = 'PositiveOrZero';
 }
 
 function _min(attrs: SizeAttributes) {
@@ -273,7 +320,6 @@ function _max(attrs: SizeAttributes) {
 
 export class Size extends AbstractValidator<string> {
   min: number;
-
   max: number;
 
   constructor(attrs: SizeAttributes = {}) {
@@ -292,11 +338,12 @@ export class Size extends AbstractValidator<string> {
     // eslint-disable-next-line sort-keys
     return isLength(value, { min: this.min, max: this.max });
   }
+
+  readonly name = 'Size';
 }
 
 export class Digits<T> extends AbstractValidator<T> {
   integer: number;
-
   fraction: number;
 
   constructor(attrs: DigitAttributes) {
@@ -315,6 +362,8 @@ export class Digits<T> extends AbstractValidator<T> {
       isDecimal(String(value), { decimal_digits: `0,${this.fraction}` })
     );
   }
+
+  readonly name = 'Digits';
 }
 
 export class Past<T> extends AbstractValidator<T> {
@@ -325,7 +374,10 @@ export class Past<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return isBefore(String(value));
   }
+
+  readonly name = 'Past';
 }
+
 /*
   @PastOrPresent has no client-side implementation yet.
   It would consider any input valid and let the server-side to do validation.
@@ -340,6 +392,7 @@ export class Past<T> extends AbstractValidator<T> {
 //     return true;
 //   }
 // }
+
 export class Future<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be a future date', ...attrs });
@@ -348,6 +401,8 @@ export class Future<T> extends AbstractValidator<T> {
   override validate(value: T): boolean {
     return isAfter(String(value));
   }
+
+  readonly name = 'Future';
 }
 
 /*
@@ -393,6 +448,8 @@ export class Pattern extends AbstractValidator<string> {
   override validate(value: any): boolean {
     return matches(value, this.regexp);
   }
+
+  readonly name = 'Pattern';
 }
 
 /**
@@ -410,4 +467,6 @@ export class ValidityStateValidator<T> extends AbstractValidator<T> {
   override validate(): boolean {
     return false;
   }
+
+  readonly name = 'ValidityStateValidator';
 }

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -46,6 +46,7 @@ describe('@hilla/form', () => {
     it('Required', () => {
       const validator = new Required();
       assert.isTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Required');
       assert.isTrue(validator.validate('foo'));
       assert.isFalse(validator.validate(''));
       assert.isFalse(validator.validate(undefined));
@@ -55,6 +56,7 @@ describe('@hilla/form', () => {
     it('Email', () => {
       const validator = new Email();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Email');
       assert.isTrue(validator.validate(undefined));
       assert.isTrue(validator.validate(null));
       assert.isTrue(validator.validate('foo@vaadin.com'));
@@ -67,6 +69,7 @@ describe('@hilla/form', () => {
     it('Null', () => {
       const validator = new Null();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Null');
       assert.isTrue(validator.validate(null));
       assert.isTrue(validator.validate(undefined));
       assert.isFalse(validator.validate(''));
@@ -75,6 +78,7 @@ describe('@hilla/form', () => {
     it('NotNull', () => {
       const validator = new NotNull();
       assert.isTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'NotNull');
       assert.isTrue(validator.validate(''));
       assert.isFalse(validator.validate(null));
       assert.isFalse(validator.validate(undefined));
@@ -83,6 +87,7 @@ describe('@hilla/form', () => {
     it('NotEmpty', () => {
       const validator = new NotEmpty();
       assert.isTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'NotEmpty');
       assert.isTrue(validator.validate('a'));
       assert.isTrue(validator.validate(['a']));
       assert.isFalse(validator.validate(''));
@@ -93,6 +98,7 @@ describe('@hilla/form', () => {
     it('NotBlank', () => {
       const validator = new NotBlank();
       assert.isTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'NotBlank');
       assert.isTrue(validator.validate('a'));
       assert.isFalse(validator.validate(''));
       assert.isFalse(validator.validate(undefined));
@@ -103,6 +109,7 @@ describe('@hilla/form', () => {
     it('AssertTrue', () => {
       const validator = new AssertTrue();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'AssertTrue');
       assert.isTrue(validator.validate('true'));
       assert.isTrue(validator.validate(true));
       assert.isFalse(validator.validate('a'));
@@ -118,6 +125,7 @@ describe('@hilla/form', () => {
     it('AssertFalse', () => {
       const validator = new AssertFalse();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'AssertFalse');
       assert.isTrue(validator.validate('false'));
       assert.isTrue(validator.validate(false));
       assert.isTrue(validator.validate('a'));
@@ -132,6 +140,7 @@ describe('@hilla/form', () => {
     it('IsNumber', () => {
       let validator = new IsNumber(false);
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'IsNumber');
       assert.isTrue(validator.validate(0));
       assert.isTrue(validator.validate(1));
       assert.isTrue(validator.validate(1.2));
@@ -148,6 +157,7 @@ describe('@hilla/form', () => {
     it('Min', () => {
       let validator = new Min(1);
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Min');
       assert.isTrue(validator.validate(1));
       assert.isTrue(validator.validate(1.1));
       assert.isFalse(validator.validate(0.9));
@@ -160,6 +170,7 @@ describe('@hilla/form', () => {
     it('Max', () => {
       const validator = new Max(1);
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Max');
       assert.isTrue(validator.validate(1));
       assert.isTrue(validator.validate(0.9));
       assert.isFalse(validator.validate(1.1));
@@ -168,6 +179,7 @@ describe('@hilla/form', () => {
     it('DecimalMin', () => {
       let validator = new DecimalMin('30.1');
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'DecimalMin');
       assert.isFalse(validator.validate(1));
       assert.isTrue(validator.validate(30.1));
       assert.isTrue(validator.validate(30.2));
@@ -180,17 +192,19 @@ describe('@hilla/form', () => {
     it('DecimalMax', () => {
       let validator = new DecimalMax('30.1');
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'DecimalMax');
       assert.isTrue(validator.validate(30));
       assert.isTrue(validator.validate(30.1));
       assert.isFalse(validator.validate(30.2));
       // eslint-disable-next-line sort-keys
-      validator = new DecimalMin({ value: '30.1', inclusive: false });
+      validator = new DecimalMax({ value: '30.1', inclusive: false });
       assert.isFalse(validator.validate(30.1));
     });
 
     it('Negative', () => {
       const validator = new Negative();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Negative');
       assert.isTrue(validator.validate(-1));
       assert.isTrue(validator.validate(-0.01));
       assert.isFalse(validator.validate(0));
@@ -200,6 +214,7 @@ describe('@hilla/form', () => {
     it('NegativeOrZero', () => {
       const validator = new NegativeOrZero();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'NegativeOrZero');
       assert.isTrue(validator.validate(-1));
       assert.isTrue(validator.validate(-0.01));
       assert.isTrue(validator.validate(0));
@@ -209,6 +224,7 @@ describe('@hilla/form', () => {
     it('Positive', () => {
       const validator = new Positive();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Positive');
       assert.isFalse(validator.validate(-1));
       assert.isFalse(validator.validate(-0.01));
       assert.isFalse(validator.validate(0));
@@ -218,6 +234,7 @@ describe('@hilla/form', () => {
     it('PositiveOrZero', () => {
       const validator = new PositiveOrZero();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'PositiveOrZero');
       assert.isFalse(validator.validate(-1));
       assert.isFalse(validator.validate(-0.01));
       assert.isTrue(validator.validate(0));
@@ -228,6 +245,7 @@ describe('@hilla/form', () => {
       // eslint-disable-next-line sort-keys
       const validator = new Size({ min: 2, max: 4 });
       assert.isTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Size');
       assert.isFalse(validator.validate(''));
       assert.isFalse(validator.validate('a'));
       assert.isTrue(validator.validate('aa'));
@@ -251,6 +269,7 @@ describe('@hilla/form', () => {
       // eslint-disable-next-line sort-keys
       const validator = new Digits({ integer: 2, fraction: 3 });
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Digits');
       assert.isTrue(validator.validate('11.111'), 'Exact number of digits');
       assert.isTrue(validator.validate('1.1'), 'Less digits');
       assert.isTrue(validator.validate('1'), 'Less digits and no fraction');
@@ -270,6 +289,7 @@ describe('@hilla/form', () => {
     it('Past', () => {
       const validator = new Past();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Past');
       assert.isTrue(validator.validate('2019-12-31'), 'past');
       assert.isFalse(validator.validate(String(new Date())), 'present');
       assert.isFalse(validator.validate('3000-01-01'), 'future');
@@ -286,6 +306,7 @@ describe('@hilla/form', () => {
     it('Future', () => {
       const validator = new Future();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Future');
       assert.isFalse(validator.validate('2019-12-31'), 'past');
       assert.isFalse(validator.validate(String(new Date())), 'present');
       assert.isTrue(validator.validate('3000-01-01'), 'future');
@@ -302,6 +323,7 @@ describe('@hilla/form', () => {
     it('Pattern', () => {
       let validator = new Pattern(/^\+?\d(?:[ -]?\d){3,13}$/u);
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'Pattern');
       assert.isFalse(validator.validate(''));
       assert.isFalse(validator.validate('123'));
       assert.isFalse(validator.validate('abcdefghijk'));
@@ -327,6 +349,7 @@ describe('@hilla/form', () => {
     it('ValidityStateValidator', () => {
       const validator = new ValidityStateValidator();
       assert.isNotTrue(validator.impliesRequired);
+      assert.equal(validator.name, 'ValidityStateValidator');
       assert.equal(validator.validate(), false);
       assert.equal(validator.message, '');
     });


### PR DESCRIPTION
## Description
This adds the possibility of defining a name
for all the validators implementing this
interface, which helps to preserve validator's
name in production mode, which is needed when
interpolating messages for client-side validators
(including those added to the binder based on the
existence of JSR380 jakarta validation annotations 
on the endpoints transfer types).

Fixes #1840

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
