### PR TITLE
feat: add customizable form header to auto crud

### DIFF
--- a/packages/ts/react-crud/src/autocrud-dialog.tsx
+++ b/packages/ts/react-crud/src/autocrud-dialog.tsx
@@ -7,6 +7,7 @@ import type { JSX } from 'react';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 
 interface AutoCrudDialogProps {
+  header: JSX.Element | null | undefined;
   children: React.ReactElement;
   opened: boolean;
   // eslint-disable-next-line @typescript-eslint/method-signature-style
@@ -14,16 +15,18 @@ interface AutoCrudDialogProps {
 }
 
 export function AutoCrudDialog(props: AutoCrudDialogProps): JSX.Element {
-  const { children, opened, onClose } = props;
+  const { header, children, opened, onClose } = props;
   return (
     <Dialog
       overlayClass="auto-crud-dialog"
       opened={opened}
-      headerTitle="Edit item"
       headerRenderer={() => (
-        <Button theme="tertiary" onClick={onClose} aria-label="Close">
-          <Icon icon="lumo:cross" style={{ height: 'var(--lumo-icon-size-l)', width: 'var(--lumo-icon-size-l)' }} />
-        </Button>
+        <div className="auto-crud-dialog-header">
+          {header}
+          <Button theme="tertiary" onClick={onClose} aria-label="Close">
+            <Icon icon="lumo:cross" style={{ height: 'var(--lumo-icon-size-l)', width: 'var(--lumo-icon-size-l)' }} />
+          </Button>
+        </div>
       )}
     >
       {children}

--- a/packages/ts/react-crud/src/autocrud.obj.css
+++ b/packages/ts/react-crud/src/autocrud.obj.css
@@ -35,21 +35,17 @@
   border-top: solid 1px var(--lumo-contrast-10pct);
 }
 
-.auto-crud .auto-form,
-.auto-crud-dialog .auto-form {
+.auto-crud-form {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-}
-
-.auto-crud .auto-form {
   width: 40%;
   min-width: 300px;
 }
 
 /* Move box shadow and required z-index modification into pseudo-element
    as it otherwise messes with the drag handle of the split layout */
-.auto-crud .auto-form::before {
+.auto-crud .auto-crud-form::before {
   content: "";
   pointer-events: none;
   position: absolute;
@@ -57,6 +53,18 @@
   height: 100%;
   z-index: 1;
   box-shadow: var(--lumo-box-shadow-s);
+}
+
+.auto-crud-form-header {
+  padding: var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-s) var(--lumo-space-m);
+}
+
+.auto-crud .auto-form,
+.auto-crud-dialog .auto-form {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex: 1 1 0;
 }
 
 .auto-crud .auto-form-fields,
@@ -90,6 +98,13 @@
 
 .auto-crud-dialog::part(content) {
   padding: 0;
+}
+
+.auto-crud-dialog .auto-crud-dialog-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .auto-crud-dialog .auto-form {


### PR DESCRIPTION
Adds a customizable header above the form in `AutoCrud`. By default it shows `New item` and `Create item` depending on whether a new item is created or an existing one edited. It's also possible to customize the header by providing a function that renders a custom JSX element based on the edited item and the disabled state of the form. The header is part of the `AutoCrud` for now instead of the `AutoForm`. Otherwise it would have been a challenge to move it into the header of the dialog that shows up on smaller screens.

Disabled:

<img width="607" alt="Bildschirmfoto 2023-12-22 um 09 33 18" src="https://github.com/vaadin/hilla/assets/357820/a0539b6d-3acd-4840-a89b-eebf32741026">

Editing:

<img width="599" alt="Bildschirmfoto 2023-12-22 um 09 33 25" src="https://github.com/vaadin/hilla/assets/357820/fdbea80d-8955-46fc-a0dd-0e2281f1589e">

Creating:

<img width="601" alt="Bildschirmfoto 2023-12-22 um 09 33 32" src="https://github.com/vaadin/hilla/assets/357820/da6f3c02-fef6-4d3f-86ee-51103f1b3e88">
