### PR TITLE
fix: produce package-info.java file in scaffolded application

### DIFF
--- a/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
+++ b/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
@@ -21,7 +21,8 @@ public class HillaAppInitUtility {
             "package-lock.json", "types.d.ts", "vite.config.ts",
             "frontend/App.tsx", "frontend/index.ts", "frontend/routes.tsx",
             "frontend/views/MainView.tsx",
-            "src/main/java/org/vaadin/example/endpoints/HelloEndpoint.java");
+            "src/main/java/org/vaadin/example/endpoints/HelloEndpoint.java",
+            "src/main/java/org/vaadin/example/endpoints/package-info.java");
 
     private static final String LIT_SKELETON = "https://github.com/vaadin/skeleton-starter-hilla-lit/archive/refs/heads/v2.zip";
 
@@ -72,7 +73,7 @@ public class HillaAppInitUtility {
                     var item = entry.getName().split("/", 2)[1];
 
                     if (framework.getItems().contains(item)) {
-                        if (item.endsWith("Endpoint.java")) {
+                        if (item.endsWith("Endpoint.java") || item.endsWith("package-info.java")) {
                             var applicationPackage = findSpringBootApplicationPackage(
                                     projectDirectory);
                             var applicationPath = applicationPackage
@@ -94,7 +95,7 @@ public class HillaAppInitUtility {
                                 Files.createDirectories(parent);
                             }
 
-                            LOGGER.info("Adding endpoint {}", item);
+                            LOGGER.info("Adding endpoint source {}", item);
                             Files.writeString(path, content);
                         } else {
                             LOGGER.info("Extracting {}", item);

--- a/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
+++ b/packages/java/plugin-base/src/main/java/dev/hilla/plugin/base/HillaAppInitUtility.java
@@ -73,7 +73,8 @@ public class HillaAppInitUtility {
                     var item = entry.getName().split("/", 2)[1];
 
                     if (framework.getItems().contains(item)) {
-                        if (item.endsWith("Endpoint.java") || item.endsWith("package-info.java")) {
+                        if (item.endsWith("Endpoint.java")
+                                || item.endsWith("package-info.java")) {
                             var applicationPackage = findSpringBootApplicationPackage(
                                     projectDirectory);
                             var applicationPath = applicationPackage

--- a/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
+++ b/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
@@ -76,6 +76,9 @@ public class HillaAppInitUtilityTest {
         Assertions.assertTrue(projectDirectory
                 .resolve("src/main/java/my/endpoints/HelloEndpoint.java")
                 .toFile().exists());
+        Assertions.assertTrue(projectDirectory
+            .resolve("src/main/java/my/endpoints/package-info.java")
+            .toFile().exists());
         Assertions.assertTrue(
                 projectDirectory.resolve("package.json").toFile().exists());
         Assertions.assertTrue(projectDirectory.resolve("package-lock.json")
@@ -112,6 +115,9 @@ public class HillaAppInitUtilityTest {
         Assertions.assertTrue(projectDirectory
                 .resolve("src/main/java/my/endpoints/HelloEndpoint.java")
                 .toFile().exists());
+        Assertions.assertTrue(projectDirectory
+            .resolve("src/main/java/my/endpoints/package-info.java")
+            .toFile().exists());
         Assertions.assertTrue(
                 projectDirectory.resolve("package.json").toFile().exists());
         Assertions.assertTrue(projectDirectory.resolve("package-lock.json")

--- a/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
+++ b/packages/java/plugin-base/src/test/java/dev/hilla/plugin/base/HillaAppInitUtilityTest.java
@@ -77,8 +77,8 @@ public class HillaAppInitUtilityTest {
                 .resolve("src/main/java/my/endpoints/HelloEndpoint.java")
                 .toFile().exists());
         Assertions.assertTrue(projectDirectory
-            .resolve("src/main/java/my/endpoints/package-info.java")
-            .toFile().exists());
+                .resolve("src/main/java/my/endpoints/package-info.java")
+                .toFile().exists());
         Assertions.assertTrue(
                 projectDirectory.resolve("package.json").toFile().exists());
         Assertions.assertTrue(projectDirectory.resolve("package-lock.json")
@@ -116,8 +116,8 @@ public class HillaAppInitUtilityTest {
                 .resolve("src/main/java/my/endpoints/HelloEndpoint.java")
                 .toFile().exists());
         Assertions.assertTrue(projectDirectory
-            .resolve("src/main/java/my/endpoints/package-info.java")
-            .toFile().exists());
+                .resolve("src/main/java/my/endpoints/package-info.java")
+                .toFile().exists());
         Assertions.assertTrue(
                 projectDirectory.resolve("package.json").toFile().exists());
         Assertions.assertTrue(projectDirectory.resolve("package-lock.json")


### PR DESCRIPTION
## Description

Currently, React applications that are initialized with HillaAppInitUtility don't have a package-info.java file, which causes typescript errors at startup because of missing nullable annotation.
This change adds handling of package-info.java file during the scaffolding process.

Fixes #1935

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
