### PR TITLE
feat: Add better names for autogrid filter comparison date/time options

### DIFF
--- a/packages/ts/react-crud/src/header-filter.tsx
+++ b/packages/ts/react-crud/src/header-filter.tsx
@@ -134,7 +134,7 @@ function ComparationSelection({ onMatcherChanged, value, isDateTimeType }: Compa
             {isDateTimeType ? '< Before' : '< Less than'}
           </Item>
           <Item value={Matcher.EQUALS} {...{ label: '=' }}>
-            {isDateTimeType ? '= Equals ' : '= Equals'}
+            = Equals
           </Item>
         </ListBox>
       )}

--- a/packages/ts/react-crud/src/header-filter.tsx
+++ b/packages/ts/react-crud/src/header-filter.tsx
@@ -105,12 +105,13 @@ function useSelectInitWorkaround(selectRef: RefObject<SelectElement>) {
 }
 
 // extracted component (and type) to avoid code duplication
-type ComparationSelectionProps = {
+type ComparationSelectionProps = Readonly<{
   value: Matcher;
   onMatcherChanged(matcher: Matcher): void;
-};
+  isDateTimeType?: boolean;
+}>;
 
-function ComparationSelection({ onMatcherChanged, value }: ComparationSelectionProps): ReactElement {
+function ComparationSelection({ onMatcherChanged, value, isDateTimeType }: ComparationSelectionProps): ReactElement {
   const select = useRef<SelectElement>(null);
 
   useSelectInitWorkaround(select);
@@ -127,13 +128,13 @@ function ComparationSelection({ onMatcherChanged, value }: ComparationSelectionP
       renderer={() => (
         <ListBox>
           <Item value={Matcher.GREATER_THAN} {...{ label: '>' }}>
-            &gt; Greater than
+            {isDateTimeType ? '> After' : '> Greater than'}
           </Item>
           <Item value={Matcher.LESS_THAN} {...{ label: '<' }}>
-            &lt; Less than
+            {isDateTimeType ? '< Before' : '< Less than'}
           </Item>
           <Item value={Matcher.EQUALS} {...{ label: '=' }}>
-            = Equals
+            {isDateTimeType ? '= Equals ' : '= Equals'}
           </Item>
         </ListBox>
       )}
@@ -273,7 +274,11 @@ export function DateHeaderFilter(): ReactElement {
 
   return (
     <div className="auto-grid-date-filter">
-      <ComparationSelection value={matcher} onMatcherChanged={(m) => updateFilter(m, filterValue)} />
+      <ComparationSelection
+        value={matcher}
+        onMatcherChanged={(m) => updateFilter(m, filterValue)}
+        isDateTimeType={true}
+      />
       <DatePicker
         theme="small"
         value={filterValue}
@@ -299,7 +304,11 @@ export function TimeHeaderFilter(): ReactElement {
 
   return (
     <div className="auto-grid-time-filter">
-      <ComparationSelection value={matcher} onMatcherChanged={(m) => updateFilter(m, filterValue)} />
+      <ComparationSelection
+        value={matcher}
+        onMatcherChanged={(m) => updateFilter(m, filterValue)}
+        isDateTimeType={true}
+      />
       <TimePicker
         theme="small"
         value={filterValue}

--- a/packages/ts/react-crud/test/autogrid.spec.tsx
+++ b/packages/ts/react-crud/test/autogrid.spec.tsx
@@ -560,6 +560,34 @@ describe('@hilla/react-crud', () => {
           expect(cell.querySelector('vaadin-select')).to.exist;
         });
 
+        it('filter comparison options changes based on type', async () => {
+          const grid = await GridController.init(
+            render(<TestAutoGrid visibleColumns={['someInteger', 'someDecimal', 'birthDate', 'shiftStart']} />),
+            user,
+          );
+          // Number type
+          await user.click(grid.getHeaderCellContent(1, 0).querySelector('vaadin-select-value-button')!);
+          let filterOptions = document.querySelector('vaadin-select-overlay')!.querySelectorAll('vaadin-item');
+          expect(filterOptions).to.have.length(3);
+          expect(filterOptions[0]).to.have.rendered.text('> Greater than');
+
+          await user.keyboard('{Escape}');
+
+          // Date type
+          await user.click(grid.getHeaderCellContent(1, 2).querySelector('vaadin-select-value-button')!);
+          filterOptions = document.querySelector('vaadin-select-overlay')!.querySelectorAll('vaadin-item');
+          expect(filterOptions).to.have.length(3);
+          expect(filterOptions[0]).to.have.rendered.text('After');
+
+          await user.keyboard('{Escape}');
+
+          // Time type
+          await user.click(grid.getHeaderCellContent(1, 3).querySelector('vaadin-select-value-button')!);
+          filterOptions = document.querySelector('vaadin-select-overlay')!.querySelectorAll('vaadin-item');
+          expect(filterOptions).to.have.length(3);
+          expect(filterOptions[0]).to.have.rendered.text('After');
+        });
+
         it('filter when you type in the field for a string column', async () => {
           const service = personService();
           const grid = await GridController.init(render(<TestAutoGrid service={service} />), user);


### PR DESCRIPTION
Add better names for Autogrid filter comparison date/time options

Number type filter:
![image](https://github.com/vaadin/hilla/assets/101052651/0d4c086a-4e85-426e-a3a9-028dff1e342a)

Date/time type filter:
![image](https://github.com/vaadin/hilla/assets/101052651/7fa12ed6-1fb6-47eb-99a0-774af4a908d8)

Fixes https://github.com/vaadin/hilla/issues/1505