### PR TITLE
chore: Remove workarounds for server-side routes

### DIFF
--- a/packages/java/tests/gradle/single-module-tests/frontend/routes.tsx
+++ b/packages/java/tests/gradle/single-module-tests/frontend/routes.tsx
@@ -2,7 +2,6 @@ import HelloReactView from 'Frontend/views/helloreact/HelloReactView.js';
 import MainLayout from 'Frontend/views/MainLayout.js';
 import { lazy } from 'react';
 import { createBrowserRouter, IndexRouteObject, NonIndexRouteObject, useMatches } from 'react-router-dom';
-import { serverSideRoutes } from "Frontend/generated/flow/Flow";
 
 const AboutView = lazy(async () => import('Frontend/views/about/AboutView.js'));
 export type MenuProps = Readonly<{
@@ -35,9 +34,7 @@ export const routes: ViewRouteObject[] = [
     handle: { icon: 'null', title: 'Main' },
     children: [
       { path: '/', element: <HelloReactView />, handle: { icon: 'globe-solid', title: 'Hello React' } },
-      { path: '/about', element: <AboutView />, handle: { icon: 'file', title: 'About' } },
-      // workaround for https://github.com/vaadin/flow/issues/18539
-      ...serverSideRoutes
+      { path: '/about', element: <AboutView />, handle: { icon: 'file', title: 'About' } }
     ],
   },
 ];

--- a/packages/java/tests/gradle/single-module/frontend/routes.tsx
+++ b/packages/java/tests/gradle/single-module/frontend/routes.tsx
@@ -2,7 +2,6 @@ import HelloReactView from 'Frontend/views/helloreact/HelloReactView.js';
 import MainLayout from 'Frontend/views/MainLayout.js';
 import { lazy } from 'react';
 import { createBrowserRouter, IndexRouteObject, NonIndexRouteObject, useMatches } from 'react-router-dom';
-import { serverSideRoutes } from "Frontend/generated/flow/Flow";
 
 const AboutView = lazy(async () => import('Frontend/views/about/AboutView.js'));
 export type MenuProps = Readonly<{
@@ -35,9 +34,7 @@ export const routes: ViewRouteObject[] = [
     handle: { icon: 'null', title: 'Main' },
     children: [
       { path: '/', element: <HelloReactView />, handle: { icon: 'globe-solid', title: 'Hello React' } },
-      { path: '/about', element: <AboutView />, handle: { icon: 'file', title: 'About' } },
-      // workaround for https://github.com/vaadin/flow/issues/18539
-      ...serverSideRoutes
+      { path: '/about', element: <AboutView />, handle: { icon: 'file', title: 'About' } }
     ],
   },
 ];

--- a/packages/java/tests/spring/react-grid-test/frontend/routes.tsx
+++ b/packages/java/tests/spring/react-grid-test/frontend/routes.tsx
@@ -8,7 +8,6 @@ import { ReadOnlyGridOrFilter } from './views/ReadOnlyGridOrFilter.js';
 import { ReadOnlyGridSinglePropertyFilter } from './views/ReadOnlyGridSinglePropertyFilter.js';
 import { ReadOnlyGridWithHeaderFilters } from './views/ReadOnlyGridWithHeaderFilter.js';
 import { ReadOnlyGridCustomFilter } from 'Frontend/views/ReadOnlyGridCustomFilter';
-import { serverSideRoutes } from "Frontend/generated/flow/Flow";
 
 export const routes = [
   {
@@ -46,9 +45,7 @@ export const routes = [
       {
         path: '/auto-crud',
         element: <AutoCrudView />,
-      },
-      // workaround for https://github.com/vaadin/flow/issues/18539
-      ...serverSideRoutes
+      }
     ],
   },
 ];


### PR DESCRIPTION
Removes unnecessary imports and route entries as this isn't required by Flow now.