### PR TITLE
chore: reenable flow specific goals in hilla-maven-plugin

### DIFF
--- a/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/BuildFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/BuildFrontendMojo.java
@@ -9,16 +9,4 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Execute(goal = "configure")
 public class BuildFrontendMojo
         extends com.vaadin.flow.plugin.maven.BuildFrontendMojo {
-    /**
-     * Override this to not clean generated frontend files after the build. For
-     * Hilla, the generated files can still be useful for developers after the
-     * build. For example, a developer can use {@code vite.generated.ts} to run
-     * tests with vitest in CI.
-     *
-     * @return {@code false}
-     */
-    @Override
-    protected boolean cleanFrontendFiles() {
-        return false;
-    }
 }

--- a/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/CleanFrontendMojo.java
+++ b/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/CleanFrontendMojo.java
@@ -16,15 +16,4 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "clean-frontend", defaultPhase = LifecyclePhase.PRE_CLEAN)
 public class CleanFrontendMojo
         extends com.vaadin.flow.plugin.maven.CleanFrontendMojo {
-
-    @Override
-    public void execute() throws MojoFailureException {
-        getLog().warn(
-                """
-                        The 'clean-frontend' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
-                        Note: The 'clean-frontend' goal is deprecated and would be removed in future releases.
-                        """
-                        .stripIndent());
-        super.execute();
-    }
 }

--- a/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/ConvertPolymerMojo.java
+++ b/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/ConvertPolymerMojo.java
@@ -16,14 +16,4 @@ import org.apache.maven.plugins.annotations.Mojo;
 public class ConvertPolymerMojo
         extends com.vaadin.flow.plugin.maven.ConvertPolymerMojo {
 
-    @Override
-    public void execute() throws MojoFailureException {
-        getLog().warn(
-                """
-                        The 'convert-polymer' goal is not meant to be used in Hilla projects as polymer templates are not supported.
-                        Note: The 'convert-polymer' goal is deprecated and would be removed in future releases.
-                        """
-                        .stripIndent());
-        super.execute();
-    }
 }

--- a/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/FrontendDanceMojo.java
+++ b/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/FrontendDanceMojo.java
@@ -17,14 +17,4 @@ import org.apache.maven.plugins.annotations.Mojo;
 public class FrontendDanceMojo
         extends com.vaadin.flow.plugin.maven.FrontendDanceMojo {
 
-    @Override
-    public void execute() throws MojoFailureException {
-        getLog().warn(
-                """
-                        The 'dance' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
-                        Note: The 'dance' goal is deprecated and would be removed in future releases.
-                        """
-                        .stripIndent());
-        super.execute();
-    }
 }


### PR DESCRIPTION
Since platform repackages hilla-maven-plugin instead of flow-maven-plugin we should not disable flow specific goals
There should be code in flow or hilla skiping certain goals based on configured or computed flags

