### PR TITLE
chore: Remove react router config parameter from tests

### DIFF
--- a/packages/java/tests/csrf-context/pom.xml
+++ b/packages/java/tests/csrf-context/pom.xml
@@ -38,6 +38,9 @@
       <plugin>
         <groupId>com.vaadin.hilla</groupId>
         <artifactId>hilla-maven-plugin</artifactId>
+        <configuration>
+          <reactRouterEnabled>false</reactRouterEnabled>
+        </configuration>        
       </plugin>
 
       <!-- This module is mapped to default web context -->

--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -285,15 +285,13 @@
             <id>it-modules-group-1</id>
             <modules>
                 <module>csrf</module>
-                <module>csrf-context</module>
-                <module>spring</module>
             </modules>
         </profile>
 
         <profile>
             <id>it-modules-group-2</id>
             <modules>
-                <module>spring</module>
+                <module>csrf-context</module>
             </modules>
         </profile>
 

--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -148,9 +148,6 @@
                     <groupId>com.vaadin.hilla</groupId>
                     <artifactId>hilla-maven-plugin</artifactId>
                     <version>${project.version}</version>
-                    <configuration>
-                        <reactRouterEnabled>false</reactRouterEnabled>
-                    </configuration>
                     <executions>
                         <execution>
                             <goals>
@@ -258,9 +255,6 @@
                             <groupId>com.vaadin.hilla</groupId>
                             <artifactId>hilla-maven-plugin</artifactId>
                             <version>${project.version}</version>
-                            <configuration>
-                                <reactRouterEnabled>false</reactRouterEnabled>
-                            </configuration>
                             <executions>
                                 <execution>
                                     <goals>

--- a/packages/java/tests/spring/react-grid-test/pom.xml
+++ b/packages/java/tests/spring/react-grid-test/pom.xml
@@ -61,9 +61,6 @@
             <plugin>
                 <groupId>com.vaadin.hilla</groupId>
                 <artifactId>hilla-maven-plugin</artifactId>
-                <configuration>
-                    <reactRouterEnabled>true</reactRouterEnabled>
-                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Removes `reactRouterEnabled` config parameter everywhere from test modules as now Flow has auto-detection and should manage to do it without this parameter.