### PR TITLE
fix gradle plugin source jar

### DIFF
--- a/packages/java/gradle-plugin/build.gradle
+++ b/packages/java/gradle-plugin/build.gradle
@@ -105,9 +105,9 @@ jar {
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     archiveClassifier = 'sources'
-    include 'dev/**/*.groovy'
-    include 'dev/**/*.java'
-    include 'dev/**/*.kt'
+    include 'com/**/*.groovy'
+    include 'com/**/*.java'
+    include 'com/**/*.kt'
 }
 
 /**


### PR DESCRIPTION
After renaming the `dev.hilla` to `com.vaadin.hilla`
the config for sources-jar inclusion was still
pointing to `dev/**`
