### PR TITLE
chore: add hilla-dev dependency to tests so as they can be run in devmode

### DIFF
--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>engine-runtime</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin.hilla</groupId>
+            <artifactId>hilla-dev</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
This is needed in order not to make hilla tests depend on platform vaadin-dev 