### PR TITLE
feat: basic I18n class implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17423,8 +17423,11 @@
     },
     "packages/ts/react-i18n": {
       "name": "@vaadin/hilla-react-i18n",
-      "version": "24.4.0-alpha4",
+      "version": "24.4.0-alpha5",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@vaadin/hilla-react-signals": "24.4.0-alpha5"
+      },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
         "@testing-library/react": "^14.0.0",

--- a/packages/ts/react-i18n/package.json
+++ b/packages/ts/react-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-react-i18n",
-  "version": "24.4.0-alpha4",
+  "version": "24.4.0-alpha5",
   "description": "Hilla I18n utils for React",
   "main": "index.js",
   "module": "index.js",
@@ -44,6 +44,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@vaadin/hilla-react-signals": "24.4.0-alpha5"
   },
   "peerDependencies": {
     "react": "^18"

--- a/packages/ts/react-i18n/src/backend.ts
+++ b/packages/ts/react-i18n/src/backend.ts
@@ -1,0 +1,12 @@
+import type { Translations } from './types.js';
+
+export interface I18nBackend {
+  loadTranslations(language: string): Promise<Translations>;
+}
+
+export class DefaultBackend implements I18nBackend {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async loadTranslations(language: string): Promise<Translations> {
+    return {};
+  }
+}

--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -51,3 +51,7 @@ export class I18n {
 }
 
 export const i18n = new I18n();
+
+export function translate(key: string): string {
+  return i18n.translate(key);
+}

--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -1,4 +1,4 @@
-import { signal, type Signal } from '@vaadin/hilla-react-signals';
+import { batch, signal, type Signal } from '@vaadin/hilla-react-signals';
 import { DefaultBackend, type I18nBackend } from './backend.js';
 import type { I18nOptions, Translations } from './types.js';
 
@@ -27,8 +27,12 @@ export class I18n {
       return;
     }
 
-    this._translations.value = await this.loadTranslations(newLanguage);
-    this._language.value = newLanguage;
+    const newTranslations = await this.loadTranslations(newLanguage);
+    // Update all signals together to avoid triggering side effects multiple times
+    batch(() => {
+      this._translations.value = newTranslations;
+      this._language.value = newLanguage;
+    });
   }
 
   private async loadTranslations(newLanguage: string) {

--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -1,6 +1,46 @@
+import { DefaultBackend, type I18nBackend } from './backend.js';
+import type { I18nOptions, Translations } from './types.js';
+
+function determineInitialLanguage(options?: I18nOptions): string {
+  // Use explicitly configured language or browser language
+  return options?.language ?? navigator.language;
+}
+
 export class I18n {
-  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  private readonly _backend: I18nBackend = new DefaultBackend();
+
+  private _language: string | undefined;
+  private _translations: Translations = {};
+
+  get language(): string | undefined {
+    return this._language;
+  }
+
+  async configure(options?: I18nOptions): Promise<void> {
+    const initialLanguage = determineInitialLanguage(options);
+    await this.setLanguage(initialLanguage);
+  }
+
+  async setLanguage(newLanguage: string): Promise<void> {
+    if (this._language === newLanguage) {
+      return;
+    }
+
+    this._translations = await this.loadTranslations(newLanguage);
+    this._language = newLanguage;
+  }
+
+  private async loadTranslations(newLanguage: string) {
+    try {
+      return await this._backend.loadTranslations(newLanguage);
+    } catch (e) {
+      // TODO proper error handling, maybe allow developer to hook into this
+      console.error(`Failed to load translations for language: ${newLanguage}`, e);
+      return {};
+    }
+  }
+
   translate(key: string): string {
-    return key;
+    return this._translations[key] || key;
   }
 }

--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -49,3 +49,5 @@ export class I18n {
     return this._translations.value[key] || key;
   }
 }
+
+export const i18n = new I18n();

--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -1,3 +1,4 @@
+import { signal, type Signal } from '@vaadin/hilla-react-signals';
 import { DefaultBackend, type I18nBackend } from './backend.js';
 import type { I18nOptions, Translations } from './types.js';
 
@@ -9,10 +10,10 @@ function determineInitialLanguage(options?: I18nOptions): string {
 export class I18n {
   private readonly _backend: I18nBackend = new DefaultBackend();
 
-  private _language: string | undefined;
-  private _translations: Translations = {};
+  private readonly _language: Signal<string | undefined> = signal(undefined);
+  private readonly _translations: Signal<Translations> = signal({});
 
-  get language(): string | undefined {
+  get language(): Signal<string | undefined> {
     return this._language;
   }
 
@@ -22,12 +23,12 @@ export class I18n {
   }
 
   async setLanguage(newLanguage: string): Promise<void> {
-    if (this._language === newLanguage) {
+    if (this._language.value === newLanguage) {
       return;
     }
 
-    this._translations = await this.loadTranslations(newLanguage);
-    this._language = newLanguage;
+    this._translations.value = await this.loadTranslations(newLanguage);
+    this._language.value = newLanguage;
   }
 
   private async loadTranslations(newLanguage: string) {
@@ -41,6 +42,6 @@ export class I18n {
   }
 
   translate(key: string): string {
-    return this._translations[key] || key;
+    return this._translations.value[key] || key;
   }
 }

--- a/packages/ts/react-i18n/src/types.ts
+++ b/packages/ts/react-i18n/src/types.ts
@@ -1,0 +1,5 @@
+export type Translations = Record<string, string>;
+
+export interface I18nOptions {
+  language?: string;
+}

--- a/packages/ts/react-i18n/test/i18n.spec.ts
+++ b/packages/ts/react-i18n/test/i18n.spec.ts
@@ -3,7 +3,7 @@ import { effect } from '@vaadin/hilla-react-signals';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import type { I18nBackend } from '../src/backend.js';
-import { I18n } from '../src/index.js';
+import { i18n as globalI18n, I18n } from '../src/index.js';
 
 use(sinonChai);
 
@@ -25,6 +25,13 @@ describe('@vaadin/hilla-react-i18n', () => {
       loadStub.withArgs('de-DE').resolves({
         'addresses.form.city.label': 'Stadt',
         'addresses.form.street.label': 'Strasse',
+      });
+    });
+
+    describe('global instance', () => {
+      it('should expose a global I18n instance', () => {
+        expect(globalI18n).to.exist;
+        expect(globalI18n).to.be.instanceof(I18n);
       });
     });
 

--- a/packages/ts/react-i18n/test/i18n.spec.ts
+++ b/packages/ts/react-i18n/test/i18n.spec.ts
@@ -7,110 +7,114 @@ import { I18n } from '../src/index.js';
 
 use(sinonChai);
 
-describe('i18n', () => {
-  let i18n: I18n;
-  let backend: I18nBackend;
-  let loadStub: sinon.SinonStub;
-
-  function mockTranslations() {
-    loadStub.resolves({ 'addresses.form.name.label': 'Name', 'addresses.form.street.label': 'Street' });
-  }
-
-  beforeEach(() => {
-    i18n = new I18n();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    backend = (i18n as any)._backend;
-    loadStub = sinon.stub(backend, 'loadTranslations');
-    mockTranslations();
-  });
-
-  describe('configure', () => {
-    it('should use browser language by default', async () => {
-      await i18n.configure();
-
-      expect(i18n.language.value).to.equal(navigator.language);
-      expect(loadStub).to.have.been.calledOnceWith(navigator.language);
-    });
-
-    it('should use explicitly configured language', async () => {
-      await i18n.configure({ language: 'zh-Hant' });
-
-      expect(i18n.language.value).to.equal('zh-Hant');
-      expect(loadStub).to.have.been.calledOnceWith('zh-Hant');
-    });
-
-    it('should not throw when loading translations fails', async () => {
-      loadStub.rejects(new Error('Failed to load translations'));
-
-      await i18n.configure();
-
-      expect(i18n.language.value).to.equal(navigator.language);
-    });
-  });
-
-  describe('language', () => {
-    const initialLanguage = 'en-US';
-
-    beforeEach(async () => {
-      await i18n.configure({ language: initialLanguage });
-      loadStub.resetHistory();
-    });
-
-    it('should return current language', () => {
-      expect(i18n.language.value).to.equal(initialLanguage);
-    });
-
-    it('should set language and load translations', async () => {
-      await i18n.setLanguage('de-DE');
-
-      expect(i18n.language.value).to.equal('de-DE');
-      expect(loadStub).to.have.been.calledOnceWith('de-DE');
-    });
-
-    it('should not load translations if language is unchanged', async () => {
-      await i18n.setLanguage(initialLanguage);
-
-      expect(i18n.language.value).to.equal(initialLanguage);
-      expect(loadStub).not.to.have.been.called;
-    });
-  });
-
-  describe('translate', () => {
-    beforeEach(async () => {
-      await i18n.configure();
-    });
-
-    it('should return translated string', () => {
-      expect(i18n.translate('addresses.form.name.label')).to.equal('Name');
-      expect(i18n.translate('addresses.form.street.label')).to.equal('Street');
-    });
-
-    it('should return key when there is no translation', () => {
-      expect(i18n.translate('unknown.key')).to.equal('unknown.key');
-    });
-  });
-
-  describe('global side effects', () => {
-    let effectSpy: sinon.SinonSpy;
+describe('@vaadin/hilla-react-i18n', () => {
+  describe('i18n', () => {
+    let i18n: I18n;
+    let backend: I18nBackend;
+    let loadStub: sinon.SinonStub;
 
     beforeEach(() => {
-      effectSpy = sinon.spy();
-      effect(() => {
-        effectSpy(i18n.translate('addresses.form.name.label'));
+      i18n = new I18n();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      backend = (i18n as any)._backend;
+      loadStub = sinon.stub(backend, 'loadTranslations');
+      loadStub.resolves({
+        'addresses.form.city.label': 'City',
+        'addresses.form.street.label': 'Street',
+      });
+      loadStub.withArgs('de-DE').resolves({
+        'addresses.form.city.label': 'Stadt',
+        'addresses.form.street.label': 'Strasse',
       });
     });
 
-    it('should run effects when language changes', async () => {
-      // Runs once initially
-      expect(effectSpy.calledOnce).to.be.true;
+    describe('configure', () => {
+      it('should use browser language by default', async () => {
+        await i18n.configure();
 
-      // Configure initial language
-      await i18n.configure({ language: 'en-US' });
-      expect(effectSpy.calledTwice).to.be.true;
+        expect(i18n.language.value).to.equal(navigator.language);
+        expect(loadStub).to.have.been.calledOnceWith(navigator.language);
+      });
 
-      // Change language
-      // await i18n.setLanguage('de-DE');
-      // expect(effectSpy.calledThrice).to.be.true;
+      it('should use explicitly configured language', async () => {
+        await i18n.configure({ language: 'zh-Hant' });
+
+        expect(i18n.language.value).to.equal('zh-Hant');
+        expect(loadStub).to.have.been.calledOnceWith('zh-Hant');
+      });
+
+      it('should not throw when loading translations fails', async () => {
+        loadStub.rejects(new Error('Failed to load translations'));
+
+        await i18n.configure();
+
+        expect(i18n.language.value).to.equal(navigator.language);
+      });
+    });
+
+    describe('language', () => {
+      const initialLanguage = 'en-US';
+
+      beforeEach(async () => {
+        await i18n.configure({ language: initialLanguage });
+        loadStub.resetHistory();
+      });
+
+      it('should return current language', () => {
+        expect(i18n.language.value).to.equal(initialLanguage);
+      });
+
+      it('should set language and load translations', async () => {
+        await i18n.setLanguage('de-DE');
+
+        expect(i18n.language.value).to.equal('de-DE');
+        expect(loadStub).to.have.been.calledOnceWith('de-DE');
+      });
+
+      it('should not load translations if language is unchanged', async () => {
+        await i18n.setLanguage(initialLanguage);
+
+        expect(i18n.language.value).to.equal(initialLanguage);
+        expect(loadStub).not.to.have.been.called;
+      });
+    });
+
+    describe('translate', () => {
+      beforeEach(async () => {
+        await i18n.configure();
+      });
+
+      it('should return translated string', () => {
+        expect(i18n.translate('addresses.form.city.label')).to.equal('City');
+        expect(i18n.translate('addresses.form.street.label')).to.equal('Street');
+      });
+
+      it('should return key when there is no translation', () => {
+        expect(i18n.translate('unknown.key')).to.equal('unknown.key');
+      });
+    });
+
+    describe('global side effects', () => {
+      it('should run effects when language changes', async () => {
+        const effectSpy = sinon.spy();
+        effect(() => {
+          // Use multiple signals in the effect to verify signals are updated in batch
+          effectSpy(i18n.language.value, i18n.translate('addresses.form.city.label'));
+        });
+
+        // Runs once initially
+        expect(effectSpy.calledOnceWith(undefined, 'addresses.form.city.label')).to.be.true;
+        effectSpy.resetHistory();
+
+        // Configure initial language
+        await i18n.configure({ language: 'en-US' });
+        expect(effectSpy.calledOnceWith('en-US', 'City')).to.be.true;
+        effectSpy.resetHistory();
+
+        // Change language
+        await i18n.setLanguage('de-DE');
+        expect(effectSpy.calledOnceWith('de-DE', 'Stadt')).to.be.true;
+      });
     });
   });
 });

--- a/packages/ts/react-i18n/test/i18n.spec.ts
+++ b/packages/ts/react-i18n/test/i18n.spec.ts
@@ -1,14 +1,91 @@
-import { expect } from '@esm-bundle/chai';
+import { expect, use } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import type { I18nBackend } from '../src/backend.js';
 import { I18n } from '../src/index.js';
+
+use(sinonChai);
 
 describe('i18n', () => {
   let i18n: I18n;
+  let backend: I18nBackend;
+  let loadSpy: sinon.SinonStub;
+
+  function mockTranslations() {
+    loadSpy.resolves({ 'addresses.form.name.label': 'Name', 'addresses.form.street.label': 'Street' });
+  }
 
   beforeEach(() => {
     i18n = new I18n();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    backend = (i18n as any)._backend;
+    loadSpy = sinon.stub(backend, 'loadTranslations');
+    mockTranslations();
   });
 
-  it('should translate', () => {
-    expect(i18n.translate('foo')).to.equal('foo');
+  describe('configure', () => {
+    it('should use browser language by default', async () => {
+      await i18n.configure();
+
+      expect(i18n.language).to.equal(navigator.language);
+      expect(loadSpy).to.have.been.calledOnceWith(navigator.language);
+    });
+
+    it('should use explicitly configured language', async () => {
+      await i18n.configure({ language: 'zh-Hant' });
+
+      expect(i18n.language).to.equal('zh-Hant');
+      expect(loadSpy).to.have.been.calledOnceWith('zh-Hant');
+    });
+
+    it('should not throw when loading translations fails', async () => {
+      loadSpy.rejects(new Error('Failed to load translations'));
+
+      await i18n.configure();
+
+      expect(i18n.language).to.equal(navigator.language);
+    });
+  });
+
+  describe('language', () => {
+    const initialLanguage = 'en-US';
+
+    beforeEach(async () => {
+      await i18n.configure({ language: initialLanguage });
+      loadSpy.resetHistory();
+    });
+
+    it('should return current language', () => {
+      expect(i18n.language).to.equal(initialLanguage);
+    });
+
+    it('should set language and load translations', async () => {
+      await i18n.setLanguage('de-DE');
+
+      expect(i18n.language).to.equal('de-DE');
+      expect(loadSpy).to.have.been.calledOnceWith('de-DE');
+    });
+
+    it('should not load translations if language is unchanged', async () => {
+      await i18n.setLanguage(initialLanguage);
+
+      expect(i18n.language).to.equal(initialLanguage);
+      expect(loadSpy).not.to.have.been.called;
+    });
+  });
+
+  describe('translate', () => {
+    beforeEach(async () => {
+      await i18n.configure();
+    });
+
+    it('should return translated string', () => {
+      expect(i18n.translate('addresses.form.name.label')).to.equal('Name');
+      expect(i18n.translate('addresses.form.street.label')).to.equal('Street');
+    });
+
+    it('should return key when there is no translation', () => {
+      expect(i18n.translate('unknown.key')).to.equal('unknown.key');
+    });
   });
 });

--- a/packages/ts/react-i18n/test/i18n.spec.ts
+++ b/packages/ts/react-i18n/test/i18n.spec.ts
@@ -1,4 +1,5 @@
 import { expect, use } from '@esm-bundle/chai';
+import { effect } from '@vaadin/hilla-react-signals';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import type { I18nBackend } from '../src/backend.js';
@@ -9,17 +10,17 @@ use(sinonChai);
 describe('i18n', () => {
   let i18n: I18n;
   let backend: I18nBackend;
-  let loadSpy: sinon.SinonStub;
+  let loadStub: sinon.SinonStub;
 
   function mockTranslations() {
-    loadSpy.resolves({ 'addresses.form.name.label': 'Name', 'addresses.form.street.label': 'Street' });
+    loadStub.resolves({ 'addresses.form.name.label': 'Name', 'addresses.form.street.label': 'Street' });
   }
 
   beforeEach(() => {
     i18n = new I18n();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     backend = (i18n as any)._backend;
-    loadSpy = sinon.stub(backend, 'loadTranslations');
+    loadStub = sinon.stub(backend, 'loadTranslations');
     mockTranslations();
   });
 
@@ -27,23 +28,23 @@ describe('i18n', () => {
     it('should use browser language by default', async () => {
       await i18n.configure();
 
-      expect(i18n.language).to.equal(navigator.language);
-      expect(loadSpy).to.have.been.calledOnceWith(navigator.language);
+      expect(i18n.language.value).to.equal(navigator.language);
+      expect(loadStub).to.have.been.calledOnceWith(navigator.language);
     });
 
     it('should use explicitly configured language', async () => {
       await i18n.configure({ language: 'zh-Hant' });
 
-      expect(i18n.language).to.equal('zh-Hant');
-      expect(loadSpy).to.have.been.calledOnceWith('zh-Hant');
+      expect(i18n.language.value).to.equal('zh-Hant');
+      expect(loadStub).to.have.been.calledOnceWith('zh-Hant');
     });
 
     it('should not throw when loading translations fails', async () => {
-      loadSpy.rejects(new Error('Failed to load translations'));
+      loadStub.rejects(new Error('Failed to load translations'));
 
       await i18n.configure();
 
-      expect(i18n.language).to.equal(navigator.language);
+      expect(i18n.language.value).to.equal(navigator.language);
     });
   });
 
@@ -52,25 +53,25 @@ describe('i18n', () => {
 
     beforeEach(async () => {
       await i18n.configure({ language: initialLanguage });
-      loadSpy.resetHistory();
+      loadStub.resetHistory();
     });
 
     it('should return current language', () => {
-      expect(i18n.language).to.equal(initialLanguage);
+      expect(i18n.language.value).to.equal(initialLanguage);
     });
 
     it('should set language and load translations', async () => {
       await i18n.setLanguage('de-DE');
 
-      expect(i18n.language).to.equal('de-DE');
-      expect(loadSpy).to.have.been.calledOnceWith('de-DE');
+      expect(i18n.language.value).to.equal('de-DE');
+      expect(loadStub).to.have.been.calledOnceWith('de-DE');
     });
 
     it('should not load translations if language is unchanged', async () => {
       await i18n.setLanguage(initialLanguage);
 
-      expect(i18n.language).to.equal(initialLanguage);
-      expect(loadSpy).not.to.have.been.called;
+      expect(i18n.language.value).to.equal(initialLanguage);
+      expect(loadStub).not.to.have.been.called;
     });
   });
 
@@ -86,6 +87,30 @@ describe('i18n', () => {
 
     it('should return key when there is no translation', () => {
       expect(i18n.translate('unknown.key')).to.equal('unknown.key');
+    });
+  });
+
+  describe('global side effects', () => {
+    let effectSpy: sinon.SinonSpy;
+
+    beforeEach(() => {
+      effectSpy = sinon.spy();
+      effect(() => {
+        effectSpy(i18n.translate('addresses.form.name.label'));
+      });
+    });
+
+    it('should run effects when language changes', async () => {
+      // Runs once initially
+      expect(effectSpy.calledOnce).to.be.true;
+
+      // Configure initial language
+      await i18n.configure({ language: 'en-US' });
+      expect(effectSpy.calledTwice).to.be.true;
+
+      // Change language
+      // await i18n.setLanguage('de-DE');
+      // expect(effectSpy.calledThrice).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Adds a basic implementation for an I18n class which covers:
- Configuring an initial language
- Changing the language
- Translating strings
- Exposing a global instance
- Running global side effects when the language changes

Backend integration, React integration and several other things will be done in follow-up PRs, see the epic for a list of tasks: https://github.com/vaadin/hilla/issues/2101

Fixes https://github.com/vaadin/hilla/issues/2107