### PR TITLE
fix: provide necessary dependency in plugin classpath

### DIFF
--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -58,6 +58,14 @@
       <artifactId>hilla-engine-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- The following dependency is required as some classes are used in CRUD services
+         and those can be needed by the generator in the plugin classpath -->
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-jpa</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.11.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -69,7 +68,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
When generating an endpoint that extends `ListRepositoryService`, for some reason that class is now loaded by a different class loader. That didn't happen in Hilla 2.5. That class loader uses the classpath of the plugin, not the one of the project.

This PR provides the necessary dependency at plugin level.

Fixes https://github.com/vaadin/hilla/issues/2117