### PR TITLE
fix: mark as visited on change in addition to blur

### DIFF
--- a/packages/ts/react-form/src/index.ts
+++ b/packages/ts/react-form/src/index.ts
@@ -78,6 +78,7 @@ type FieldState<T = unknown> = {
   errorMessage: string;
   strategy?: FieldStrategy<T>;
   element?: HTMLElement;
+  changeBlurHandler(): void;
   updateValue(): void;
   markVisited(): void;
   ref(element: HTMLElement | null): void;
@@ -128,14 +129,18 @@ function useFields<M extends AbstractModel>(node: BinderNode<M>): FieldDirective
           element: undefined,
           errorMessage: '',
           invalid: false,
+          changeBlurHandler() {
+            fieldState!.updateValue();
+            fieldState!.markVisited();
+          },
           markVisited() {
             n.visited = true;
           },
           ref(element: HTMLElement | null) {
             if (!element) {
-              fieldState!.element?.removeEventListener('change', fieldState!.updateValue);
+              fieldState!.element?.removeEventListener('change', fieldState!.changeBlurHandler);
               fieldState!.element?.removeEventListener('input', fieldState!.updateValue);
-              fieldState!.element?.removeEventListener('blur', fieldState!.markVisited);
+              fieldState!.element?.removeEventListener('blur', fieldState!.changeBlurHandler);
               fieldState!.strategy?.removeEventListeners();
               fieldState!.element = undefined;
               fieldState!.strategy = undefined;
@@ -148,9 +153,9 @@ function useFields<M extends AbstractModel>(node: BinderNode<M>): FieldDirective
 
             if (fieldState!.element !== element) {
               fieldState!.element = element;
-              fieldState!.element.addEventListener('change', fieldState!.updateValue);
+              fieldState!.element.addEventListener('change', fieldState!.changeBlurHandler);
               fieldState!.element.addEventListener('input', fieldState!.updateValue);
-              fieldState!.element.addEventListener('blur', fieldState!.markVisited);
+              fieldState!.element.addEventListener('blur', fieldState!.changeBlurHandler);
               fieldState!.strategy = getDefaultFieldStrategy(element, model);
             }
           },

--- a/packages/ts/react-form/test/useForm.spec.tsx
+++ b/packages/ts/react-form/test/useForm.spec.tsx
@@ -350,7 +350,8 @@ describe('@vaadin/hilla-react-form', () => {
       await user.type(projectInput, '123');
       // Mimic change that happens without blur
       fireEvent.change(projectInput);
-      await expect(findByTestId('count')).to.eventually.have.property('textContent', '1');
+      const count = await findByTestId('count');
+      expect(count).to.have.text('1');
     });
   });
 });

--- a/packages/ts/react-form/test/useForm.spec.tsx
+++ b/packages/ts/react-form/test/useForm.spec.tsx
@@ -1,5 +1,5 @@
 import { expect, use } from '@esm-bundle/chai';
-import { act, render, type RenderResult, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, type RenderResult, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import chaiAsPromised from 'chai-as-promised';
 import chaiDom from 'chai-dom';
@@ -320,6 +320,37 @@ describe('@vaadin/hilla-react-form', () => {
       const loadFormBtn = await findByTestId('load');
       await user.click(loadFormBtn);
       await expect(findByTestId('contracts')).to.eventually.have.nested.property('selectedOptions.0.value', '202');
+    });
+
+    it('runs validators on change event', async () => {
+      function ProjectForm() {
+        const { addValidator, field, model } = useForm(EntityModel);
+        const [count, setCount] = useState(0);
+
+        useEffect(() => {
+          addValidator({
+            message: 'ID expected',
+            validate: (entity) => {
+              setCount(count + 1);
+              return !entity.projectId;
+            },
+          });
+        }, []);
+
+        return (
+          <>
+            <input type="number" data-testid="project" {...field(model.projectId)} />
+            <div data-testid="count">{count.toString()}</div>
+          </>
+        );
+      }
+
+      const { findByTestId } = render(<ProjectForm />);
+      const projectInput = await findByTestId('project');
+      await user.type(projectInput, '123');
+      // Mimic change that happens without blur
+      fireEvent.change(projectInput);
+      await expect(findByTestId('count')).to.eventually.have.property('textContent', '1');
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #2134

## Type of change

- Bugfix

Note: I'm not very happy with my approach to test this (like, I'd prefer to spy on validator). Suggestions are welcome.

Also, ideally we wouldn't need to use `fireEvent` manually, as native `<input type="number">` fires it on <kbd>Enter</kbd>.
But for some reason `user.type(projectInput, '123[Enter]')` didn't work this way, probably RTL doesn't handle this case.