### PR TITLE
fix: remove spring-data-jpa from Maven Plugin deps

### DIFF
--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -57,14 +57,6 @@
       <artifactId>hilla-engine-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- The following dependency is required as some classes are used in CRUD services
-         and those can be needed by the generator in the plugin classpath -->
-    <dependency>
-      <groupId>org.springframework.data</groupId>
-      <artifactId>spring-data-jpa</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>


### PR DESCRIPTION
This will reintroduce https://github.com/vaadin/hilla/issues/2117, but https://github.com/vaadin/platform/pull/5121 should fix it.