### PR TITLE
chore: fix conflict in artifact name while uploading

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -297,7 +297,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: saved-outputs-gradle
+          name: saved-outputs-gradle-${{ matrix.os }}
           path: |
             packages/java/tests/**/target/*-reports/*
             packages/java/tests/**/error-screenshots/*.png


### PR DESCRIPTION
Since Gradle tests are executed on both ubuntu and window machines, uploading the artifact with the same name results in conflict, and the slower build (normally windows) fails to upload because of that.