### PR TITLE
test: fix hilla-maven-plugin groupId in signals IT

### DIFF
--- a/packages/java/tests/spring/react-signals/pom.xml
+++ b/packages/java/tests/spring/react-signals/pom.xml
@@ -46,7 +46,7 @@
         <defaultGoal>spring-boot:run</defaultGoal>
         <plugins>
             <plugin>
-                <groupId>com.vaadin.hilla</groupId>
+                <groupId>com.vaadin</groupId>
                 <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 


### PR DESCRIPTION
This enables Signals ITs to use the same config as the rest of the integration tests, 
especially to execute the IT app in production mode.