### PR TITLE
fix: use the new default value for frontend/generated

### DIFF
--- a/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/EngineConfigureMojo.java
+++ b/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/EngineConfigureMojo.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.LinkedHashSet;
 
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -37,7 +38,7 @@ public final class EngineConfigureMojo extends AbstractMojo {
     /**
      * The folder where TypeScript endpoints are generated.
      */
-    @Parameter(defaultValue = "${project.basedir}/frontend/generated")
+    @Parameter(defaultValue = "${project.basedir}/" + FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR)
     private File generatedTsFolder;
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;

--- a/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/EngineConfigureMojo.java
+++ b/packages/java/maven-plugin/src/main/java/com/vaadin/hilla/maven/EngineConfigureMojo.java
@@ -38,7 +38,8 @@ public final class EngineConfigureMojo extends AbstractMojo {
     /**
      * The folder where TypeScript endpoints are generated.
      */
-    @Parameter(defaultValue = "${project.basedir}/" + FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR)
+    @Parameter(defaultValue = "${project.basedir}/"
+            + FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR)
     private File generatedTsFolder;
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;


### PR DESCRIPTION
## Description

Use `FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR` instead of the literal value of frontend/generated.

Fixes #2167

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
