### PR TITLE
feat: enable maven enforce-plugin-versions rule

### DIFF
--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -56,6 +56,13 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip> <!-- Skips the enforcer plugin's execution -->
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/packages/java/tests/spring/react-signals/pom.xml
+++ b/packages/java/tests/spring/react-signals/pom.xml
@@ -46,7 +46,7 @@
         <defaultGoal>spring-boot:run</defaultGoal>
         <plugins>
             <plugin>
-                <groupId>com.vaadin</groupId>
+                <groupId>com.vaadin.hilla</groupId>
                 <artifactId>hilla-maven-plugin</artifactId>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,22 @@
               <goal>enforce</goal>
             </goals>
           </execution>
+            <execution>
+              <id>enforce-plugin-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requirePluginVersions>
+                     <message>Some plugin versions are missing. Failing the build!</message>
+                     <banLatest>true</banLatest>
+                     <banRelease>true</banRelease>
+                  </requirePluginVersions>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
To prevent having old plugins accidentally
resolved by maven during the build. For
example, after renaming groupIds to
com.vaadin there was still hilla-maven-plugin
from `com.vaadin.hilla` being used during the
builds, and maven was resolving the last
existing version of the plugin instead of
only one version in use for the whole project.

NOTE: Enabling enforce-plugin-versions is not enough.