### PR TITLE
fix(fsrouter): remove check for file existence

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
@@ -82,6 +82,8 @@ public class RouteUnifyingServiceInitListener
 
                 clientRouteRegistry.clearRoutes();
                 clientViews.forEach(clientRouteRegistry::addRoute);
+            } else {
+                LOGGER.warn("Failed to find views.json");
             }
         } catch (IOException e) {
             LOGGER.warn("Failed extract client views from views.json", e);

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
@@ -73,24 +73,18 @@ public class RouteUnifyingServiceInitListener
     }
 
     protected void registerClientRoutes() {
-        try {
-            final URL source = getClass()
-                    .getResource("/META-INF/VAADIN/views.json");
+        try (var source = getClass()
+                .getResourceAsStream("/META-INF/VAADIN/views.json")) {
             if (source != null) {
-                final File file = new File(source.toURI());
-                if (file.exists()) {
-                    final Map<String, ClientViewConfig> clientViews = mapper
-                            .readValue(source, new TypeReference<>() {
-                            });
+                final Map<String, ClientViewConfig> clientViews = mapper
+                        .readValue(source, new TypeReference<>() {
+                        });
 
-                    clientRouteRegistry.clearRoutes();
-                    clientViews.forEach(clientRouteRegistry::addRoute);
-                }
+                clientRouteRegistry.clearRoutes();
+                clientViews.forEach(clientRouteRegistry::addRoute);
             }
         } catch (IOException e) {
             LOGGER.warn("Failed extract client views from views.json", e);
-        } catch (URISyntaxException e) {
-            LOGGER.warn("Incorrect URL syntax format", e);
         }
     }
 }


### PR DESCRIPTION
If the resource is valid, there's no need to check that the corresponding file is there, which is not true in production anyway, given that it's in a JAR.

Fixes #2203
