### PR TITLE
fix: register RouteUnifyingIndexHtmlRequestListener only when React is enabled

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
@@ -54,15 +54,17 @@ public class RouteUnifyingServiceInitListener
     public void serviceInit(ServiceInitEvent event) {
         var deploymentConfiguration = event.getSource()
                 .getDeploymentConfiguration();
-        var routeExtractionIndexHtmlRequestListener = new RouteUnifyingIndexHtmlRequestListener(
-                clientRouteRegistry, deploymentConfiguration);
-        var deploymentMode = deploymentConfiguration.isProductionMode()
-                ? "PRODUCTION"
-                : "DEVELOPMENT";
-        event.addIndexHtmlRequestListener(
-                routeExtractionIndexHtmlRequestListener);
-        LOGGER.debug(
-                "{} mode: Registered RouteUnifyingIndexHtmlRequestListener.",
-                deploymentMode);
+        if (deploymentConfiguration.isReactEnabled()) {
+            var routeUnifyingIndexHtmlRequestListener = new RouteUnifyingIndexHtmlRequestListener(
+                    clientRouteRegistry, deploymentConfiguration);
+            var deploymentMode = deploymentConfiguration.isProductionMode()
+                    ? "PRODUCTION"
+                    : "DEVELOPMENT";
+            event.addIndexHtmlRequestListener(
+                    routeUnifyingIndexHtmlRequestListener);
+            LOGGER.debug(
+                    "{} mode: Registered RouteUnifyingIndexHtmlRequestListener.",
+                    deploymentMode);
+        }
     }
 }

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListenerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListenerTest.java
@@ -41,16 +41,30 @@ public class RouteUnifyingServiceInitListenerTest {
     }
 
     @Test
-    public void should_addRouteIndexHtmlRequestListener() {
-        Assert.assertFalse("Unexpected RouteIndexHtmlRequestListener added",
-                eventHasAddedRouteIndexHtmlRequestListener(event));
+    public void should_addRouteIndexHtmlRequestListener_when_react_is_enabled() {
+        Mockito.when(mockDeploymentConfiguration.isReactEnabled())
+                .thenReturn(true);
+
+        Assert.assertFalse("Unexpected RouteUnifyingServiceInitListener added",
+                hasRouteUnifyingIndexHtmlRequestListenerAdded(event));
         routeUnifyingServiceInitListener.serviceInit(event);
         Assert.assertTrue(
-                "Expected event to have RouteIndexHtmlRequestListener added",
-                eventHasAddedRouteIndexHtmlRequestListener(event));
+                "Expected to have RouteUnifyingServiceInitListener added",
+                hasRouteUnifyingIndexHtmlRequestListenerAdded(event));
     }
 
-    private boolean eventHasAddedRouteIndexHtmlRequestListener(
+    @Test
+    public void should_not_addRouteIndexHtmlRequestListener_when_react_is_not_enabled() {
+        Mockito.when(mockDeploymentConfiguration.isReactEnabled())
+                .thenReturn(false);
+
+        routeUnifyingServiceInitListener.serviceInit(event);
+        Assert.assertFalse(
+                "RouteIndexHtmlRequestListener added unexpectedly when React is not enabled",
+                hasRouteUnifyingIndexHtmlRequestListenerAdded(event));
+    }
+
+    private boolean hasRouteUnifyingIndexHtmlRequestListenerAdded(
             ServiceInitEvent event) {
         return event.getAddedIndexHtmlRequestListeners().anyMatch(
                 indexHtmlRequestListener -> indexHtmlRequestListener instanceof RouteUnifyingIndexHtmlRequestListener);


### PR DESCRIPTION
Also, this changes the behavior of client route registration so that when the views.json is not found, it only logs its absence, and it gracefully skips client route registration. This is necessary as an application might have React enabled, but it is not necessarily using the FS Router.
