### PR TITLE
chore: upgrade atmosphere runtime to 3.0.5.slf4jvaadin1

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-runtime</artifactId>
-            <version>3.0.4.slf4jvaadin1</version>
+            <version>${atmosphere.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.google</groupId>

--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -12,6 +12,10 @@
     <version>24.4-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
+    <properties>
+        <enforcer.skip>true</enforcer.skip>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <jaxb.version>4.0.4</jaxb.version>
     <github.javaparser.core.version>3.25.9</github.javaparser.core.version>
     <jetty.version>12.0.3</jetty.version>
+    <atmosphere.version>3.0.5.slf4jvaadin1</atmosphere.version>
   </properties>
 
   <organization>


### PR DESCRIPTION
This also set the `enforcer.skip` for the hilla-bom module to skip the unnecessary execution of enforcer plugin in that module.
