### PR TITLE
fix: request full-reload only when file-routes.json is added/changed

### DIFF
--- a/packages/ts/file-router/src/vite-plugin.ts
+++ b/packages/ts/file-router/src/vite-plugin.ts
@@ -86,12 +86,15 @@ export default function vitePluginFileSystemRouter({
 
       const changeListener = (file: string): void => {
         if (!file.startsWith(dir)) {
+          if (file.endsWith('/generated/file-routes.json')) {
+            server.hot.send({ type: 'full-reload' });
+          }
           return;
         }
 
-        generateRuntimeFiles(_viewsDir, runtimeUrls, extensions, _logger)
-          .then(() => server.hot.send({ type: 'full-reload' }))
-          .catch((e: unknown) => _logger.error(String(e)));
+        generateRuntimeFiles(_viewsDir, runtimeUrls, extensions, _logger).catch((e: unknown) =>
+          _logger.error(String(e)),
+        );
       };
 
       server.watcher.on('add', changeListener);

--- a/packages/ts/file-router/test/vite-plugin/vite-plugin.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/vite-plugin.spec.ts
@@ -1,0 +1,58 @@
+import { use } from '@esm-bundle/chai';
+import chaiAsPromised from 'chai-as-promised';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { FSWatcher } from 'chokidar';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import vitePluginFileSystemRouter from '../../src/vite-plugin';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+describe('@vaadin/hilla-file-router', () => {
+  describe('vite-plugin', () => {
+    const watcher = new FSWatcher();
+    const mockServer = {
+      hot: {
+        send: sinon.spy(),
+      },
+      watcher,
+    };
+    const plugin = vitePluginFileSystemRouter({ isDevMode: true });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    plugin.configResolved({
+      logger: { info: sinon.spy() },
+      root: '/path/to/project',
+      build: { outDir: '/path/to/project/dist' },
+    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    plugin.configureServer(mockServer);
+
+    beforeEach(() => {
+      sinon.resetHistory();
+    });
+
+    it('should send full-reload only when file-routes.json is added', () => {
+      sinon.assert.notCalled(mockServer.hot.send);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      mockServer.watcher.emit('add', '/path/to/generated/file-routes.json');
+      sinon.assert.calledWith(mockServer.hot.send, { type: 'full-reload' });
+    });
+
+    it('should send full-reload only when file-routes.json changes', () => {
+      sinon.assert.notCalled(mockServer.hot.send);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      mockServer.watcher.emit('change', '/path/to/generated/file-routes.json');
+      sinon.assert.calledWith(mockServer.hot.send, { type: 'full-reload' });
+    });
+
+    it('should not send full-reload when other files change', () => {
+      sinon.assert.notCalled(mockServer.hot.send);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      mockServer.watcher.emit('change', '/path/to/views/file.tsx');
+      sinon.assert.notCalled(mockServer.hot.send);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Request for full-reloads in dev mode to only when file-router's vite-plugin ends up adding/updating the file-routes.json.
Other changes to the frontend/views directory should not result in full-reload.

Fixes: #2277

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
