### PR TITLE
fix!: require at least one role in `rolesAllowed`

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
@@ -54,7 +54,6 @@ public class RouteUtil {
                 && request.getUserPrincipal() == null) {
             isAllowed = false;
         } else {
-            // current logic means that an empty array denies access to all
             var rolesAllowed = viewConfig.getRolesAllowed();
 
             if (rolesAllowed != null) {

--- a/packages/ts/file-router/src/types.d.ts
+++ b/packages/ts/file-router/src/types.d.ts
@@ -9,7 +9,7 @@ export type ViewConfig = Readonly<{
   /**
    * Same as in the explicit React Router configuration.
    */
-  rolesAllowed?: readonly string[];
+  rolesAllowed?: readonly [string, ...string[]];
 
   /**
    * Set to true to require the user to be logged in to access the view.

--- a/packages/ts/react-auth/src/useAuth.tsx
+++ b/packages/ts/react-auth/src/useAuth.tsx
@@ -132,7 +132,7 @@ export type AccessProps = Readonly<{
   /**
    * The list of roles that are allowed to access the route.
    */
-  rolesAllowed?: readonly string[];
+  rolesAllowed?: readonly [string, ...string[]];
 }>;
 
 /**


### PR DESCRIPTION
As `jakarta.annotation.security.RolesAllowed` does not allow to specify an empty list of roles (compilation error), let's adopt the same behavior in Hilla.

This is a breaking change in the unlikely case that someone has used an empty list of roles, as now his TypeScript code won't compile anymore.

Fixes #2246.