### PR TITLE
feat(crud): add `hiddenFields` to AutoForm

### DIFF
--- a/packages/ts/react-crud/src/autoform.tsx
+++ b/packages/ts/react-crud/src/autoform.tsx
@@ -171,6 +171,10 @@ export type AutoFormProps<M extends AbstractModel = AbstractModel> = ComponentSt
      */
     visibleFields?: string[];
     /**
+     * Allows to customize which fields to hide. This takes an array of property names.
+     */
+    hiddenFields?: string[];
+    /**
      * Allows to customize the FormLayout used by default. This is especially useful
      * to define the `responsiveSteps`. See the
      * {@link https://hilla.dev/docs/react/components/form-layout | FormLayout documentation}
@@ -258,6 +262,7 @@ export function AutoForm<M extends AbstractModel>({
   disabled,
   layoutRenderer: LayoutRenderer,
   visibleFields,
+  hiddenFields,
   formLayoutProps,
   fieldOptions,
   style,
@@ -391,7 +396,11 @@ export function AutoForm<M extends AbstractModel>({
     );
   }
 
-  const visibleProperties = visibleFields ? modelInfo.getProperties(visibleFields) : getDefaultProperties(modelInfo);
+  let visibleProperties = visibleFields ? modelInfo.getProperties(visibleFields) : getDefaultProperties(modelInfo);
+
+  if (hiddenFields) {
+    visibleProperties = visibleProperties.filter((property) => !hiddenFields.includes(property.name));
+  }
 
   const fields = visibleProperties.map(createAutoFormField);
 

--- a/packages/ts/react-crud/test/autoform.spec.tsx
+++ b/packages/ts/react-crud/test/autoform.spec.tsx
@@ -724,6 +724,22 @@ describe('@vaadin/hilla-react-crud', () => {
       });
     });
 
+    describe('hiddenFields', () => {
+      it('does not render fields for the specified properties', async () => {
+        const form = await populatePersonForm(1, { hiddenFields: ['firstName', 'lastName', 'id'] });
+        expect(form.queryField('First name')).to.be.undefined;
+        expect(form.queryField('Last name')).to.be.undefined;
+        expect(form.queryField('Id')).to.be.undefined;
+        expect(form.queryField('Gender')).to.exist;
+      });
+
+      it('should ignore unknown columns when using hiddenFields', async () => {
+        const form = await populatePersonForm(1, { hiddenFields: ['lastName', 'foo'] });
+        expect(form.queryField('First name')).to.exist;
+        expect(form.queryField('Last name')).to.be.undefined;
+      });
+    });
+
     describe('Delete button', () => {
       let service: CrudService<Person> & HasTestInfo;
       let person: Person;


### PR DESCRIPTION
Just like `hiddenColumns` was added to AutoGrid, let's add `hiddenFields` to AutoForm.

Closes #2290.