### PR TITLE
chore: upgrade javaparser-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jakarta.activation.api.version>2.1.2</jakarta.activation.api.version>
     <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
     <jaxb.version>4.0.4</jaxb.version>
-    <github.javaparser.core.version>3.25.9</github.javaparser.core.version>
+    <github.javaparser.core.version>3.25.10</github.javaparser.core.version>
     <jetty.version>12.0.3</jetty.version>
     <atmosphere.version>3.0.5.slf4jvaadin1</atmosphere.version>
   </properties>


### PR DESCRIPTION
This fix the dependency convergence error in builds.

