### PR TITLE
feat: utilize access control when populating client-side routes in menu

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -151,14 +151,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-web</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -151,6 +151,14 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
@@ -3,7 +3,6 @@ package com.vaadin.hilla.route;
 import com.vaadin.hilla.route.records.ClientViewConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -22,8 +21,6 @@ public class RouteUtil {
 
     private final ClientRouteRegistry registry;
 
-    private boolean hillaViewProtectionEnabled = false;
-
     /**
      * Initializes a new instance of the RouteUtil class with the given
      * registry.
@@ -37,21 +34,6 @@ public class RouteUtil {
     }
 
     /**
-     * Enables http level protection of detected Hilla views by
-     * hilla-file-router from unauthorized access.
-     *
-     * @param http
-     *            the HTTP security configuration to use
-     * @throws Exception
-     *             if the protection fails
-     */
-    public void protectHillaViews(HttpSecurity http) throws Exception {
-        hillaViewProtectionEnabled = true;
-        http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers(this::isRouteAllowed).permitAll());
-    }
-
-    /**
      * Checks if the given request is allowed route to the user.
      *
      * @param request
@@ -60,9 +42,6 @@ public class RouteUtil {
      *         <code>false</code> otherwise
      */
     public boolean isRouteAllowed(HttpServletRequest request) {
-        if (!hillaViewProtectionEnabled) {
-            return true;
-        }
         var viewConfig = getRouteData(request);
         var isUserAuthenticated = request.getUserPrincipal() != null;
         return viewConfig.filter(
@@ -73,9 +52,6 @@ public class RouteUtil {
 
     boolean isRouteAllowed(Predicate<? super String> isUserInRole,
             boolean isUserAuthenticated, ClientViewConfig viewConfig) {
-        if (!hillaViewProtectionEnabled) {
-            return true;
-        }
         boolean isAllowed;
 
         if (viewConfig.isLoginRequired() && !isUserAuthenticated) {

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
@@ -3,10 +3,13 @@ package com.vaadin.hilla.route;
 import com.vaadin.hilla.route.records.ClientViewConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Predicate;
+
 import org.springframework.http.server.RequestPath;
 
 /**
@@ -18,6 +21,8 @@ import org.springframework.http.server.RequestPath;
 public class RouteUtil {
 
     private final ClientRouteRegistry registry;
+
+    private boolean hillaViewProtectionEnabled = false;
 
     /**
      * Initializes a new instance of the RouteUtil class with the given
@@ -32,6 +37,21 @@ public class RouteUtil {
     }
 
     /**
+     * Enables http level protection of detected Hilla views by
+     * hilla-file-router from unauthorized access.
+     *
+     * @param http
+     *            the HTTP security configuration to use
+     * @throws Exception
+     *             if the protection fails
+     */
+    public void protectHillaViews(HttpSecurity http) throws Exception {
+        hillaViewProtectionEnabled = true;
+        http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(this::isRouteAllowed).permitAll());
+    }
+
+    /**
      * Checks if the given request is allowed route to the user.
      *
      * @param request
@@ -40,32 +60,39 @@ public class RouteUtil {
      *         <code>false</code> otherwise
      */
     public boolean isRouteAllowed(HttpServletRequest request) {
+        if (!hillaViewProtectionEnabled) {
+            return true;
+        }
         var viewConfig = getRouteData(request);
+        var isUserAuthenticated = request.getUserPrincipal() != null;
         return viewConfig.filter(
-                clientViewConfig -> isRouteAllowed(request, clientViewConfig))
+                clientViewConfig -> isRouteAllowed(request::isUserInRole,
+                        isUserAuthenticated, clientViewConfig))
                 .isPresent();
     }
 
-    private boolean isRouteAllowed(HttpServletRequest request,
-            ClientViewConfig viewConfig) {
+    boolean isRouteAllowed(Predicate<? super String> isUserInRole,
+            boolean isUserAuthenticated, ClientViewConfig viewConfig) {
+        if (!hillaViewProtectionEnabled) {
+            return true;
+        }
         boolean isAllowed;
 
-        if (viewConfig.isLoginRequired()
-                && request.getUserPrincipal() == null) {
+        if (viewConfig.isLoginRequired() && !isUserAuthenticated) {
             isAllowed = false;
         } else {
             var rolesAllowed = viewConfig.getRolesAllowed();
 
             if (rolesAllowed != null) {
-                isAllowed = Arrays.stream(rolesAllowed)
-                        .anyMatch(request::isUserInRole);
+                isAllowed = Arrays.stream(rolesAllowed).anyMatch(isUserInRole);
             } else {
                 isAllowed = true;
             }
         }
 
         if (isAllowed && viewConfig.getParent() != null) {
-            isAllowed = isRouteAllowed(request, viewConfig.getParent());
+            isAllowed = isRouteAllowed(isUserInRole, isUserAuthenticated,
+                    viewConfig.getParent());
         }
 
         return isAllowed;

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.hilla.route.ClientRouteRegistry;
 import com.vaadin.hilla.route.RouteUnifyingIndexHtmlRequestListener;
 import com.vaadin.hilla.route.RouteUnifyingConfigurationProperties;
+import com.vaadin.hilla.route.RouteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,8 @@ public class RouteUnifyingServiceInitListener
 
     private final ClientRouteRegistry clientRouteRegistry;
 
+    private final RouteUtil routeUtil;
+
     private final RouteUnifyingConfigurationProperties routeUnifyingConfigurationProperties;
 
     /**
@@ -46,14 +49,18 @@ public class RouteUnifyingServiceInitListener
      *
      * @param clientRouteRegistry
      *            the registry to add the client routes to
+     * @param routeUtil
+     *            the ClientRouteRegistry aware utility for checking if user is
+     *            allowed to access a route
      * @param routeUnifyingConfigurationProperties
      *            the configuration properties instance
      */
     @Autowired
     public RouteUnifyingServiceInitListener(
-            ClientRouteRegistry clientRouteRegistry,
+            ClientRouteRegistry clientRouteRegistry, RouteUtil routeUtil,
             RouteUnifyingConfigurationProperties routeUnifyingConfigurationProperties) {
         this.clientRouteRegistry = clientRouteRegistry;
+        this.routeUtil = routeUtil;
         this.routeUnifyingConfigurationProperties = routeUnifyingConfigurationProperties;
     }
 
@@ -65,7 +72,7 @@ public class RouteUnifyingServiceInitListener
                 deploymentConfiguration.isReactEnabled());
         if (deploymentConfiguration.isReactEnabled()) {
             var routeUnifyingIndexHtmlRequestListener = new RouteUnifyingIndexHtmlRequestListener(
-                    clientRouteRegistry, deploymentConfiguration,
+                    clientRouteRegistry, deploymentConfiguration, routeUtil,
                     routeUnifyingConfigurationProperties
                             .isExposeServerRoutesToClient());
             var deploymentMode = deploymentConfiguration.isProductionMode()

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListenerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListenerTest.java
@@ -1,14 +1,16 @@
 package com.vaadin.hilla.route;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinRequest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.nodes.DataNode;
@@ -34,6 +36,7 @@ import com.vaadin.flow.server.communication.IndexHtmlResponse;
 import com.vaadin.hilla.route.records.AvailableViewInfo;
 import com.vaadin.hilla.route.records.ClientViewConfig;
 import com.vaadin.hilla.route.records.RouteParamType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 public class RouteUnifyingIndexHtmlRequestListenerTest {
 
@@ -45,21 +48,33 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
     private RouteUnifyingIndexHtmlRequestListener requestListener;
     private IndexHtmlResponse indexHtmlResponse;
     private VaadinService vaadinService;
+    private VaadinRequest vaadinRequest;
     private DeploymentConfiguration deploymentConfiguration;
+    private RouteUtil routeUtil;
 
     @Rule
     public TemporaryFolder projectRoot = new TemporaryFolder();
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         vaadinService = Mockito.mock(VaadinService.class);
         deploymentConfiguration = Mockito.mock(DeploymentConfiguration.class);
         Mockito.when(vaadinService.getDeploymentConfiguration())
                 .thenReturn(deploymentConfiguration);
+        Mockito.when(clientRouteRegistry.getAllRoutes())
+                .thenReturn(prepareClientRoutes());
+        routeUtil = new RouteUtil(clientRouteRegistry);
+        routeUtil.protectHillaViews(Mockito.mock(HttpSecurity.class));
         requestListener = new RouteUnifyingIndexHtmlRequestListener(
-                clientRouteRegistry, deploymentConfiguration, true);
+                clientRouteRegistry, deploymentConfiguration, routeUtil, true);
 
         indexHtmlResponse = Mockito.mock(IndexHtmlResponse.class);
+        vaadinRequest = Mockito.mock(VaadinRequest.class);
+        Mockito.when(indexHtmlResponse.getVaadinRequest())
+                .thenReturn(vaadinRequest);
+        var userPrincipal = Mockito.mock(Principal.class);
+        Mockito.when(vaadinRequest.getUserPrincipal())
+                .thenReturn(userPrincipal);
 
         final Document document = Mockito.mock(Document.class);
         final Element element = new Element("head");
@@ -98,7 +113,8 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
 
         ClientViewConfig profileConfig = new ClientViewConfig();
         profileConfig.setTitle("Profile");
-        profileConfig.setRolesAllowed(new String[] { "ROLE_USER" });
+        profileConfig
+                .setRolesAllowed(new String[] { "ROLE_USER", "ROLE_ADMIN" });
         profileConfig.setLoginRequired(true);
         profileConfig.setRoute("/profile");
         profileConfig.setLazy(false);
@@ -159,12 +175,49 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
     }
 
     @Test
-    public void when_productionMode_should_modifyIndexHtmlResponse()
+    public void when_productionMode_anonymous_user_should_modifyIndexHtmlResponse_with_anonymously_allowed_routes()
             throws IOException {
         try (MockedStatic<VaadinService> mocked = Mockito
                 .mockStatic(VaadinService.class)) {
             mocked.when(VaadinService::getCurrent).thenReturn(vaadinService);
             Mockito.when(deploymentConfiguration.isProductionMode())
+                    .thenReturn(true);
+            Mockito.when(vaadinRequest.getUserPrincipal()).thenReturn(null);
+
+            requestListener.modifyIndexHtmlResponse(indexHtmlResponse);
+        }
+        Mockito.verify(indexHtmlResponse, Mockito.times(1)).getDocument();
+        MatcherAssert.assertThat(
+                indexHtmlResponse.getDocument().head().select("script"),
+                Matchers.notNullValue());
+
+        DataNode script = indexHtmlResponse.getDocument().head()
+                .select("script").dataNodes().get(0);
+
+        final String scriptText = script.getWholeData();
+        MatcherAssert.assertThat(scriptText,
+                Matchers.startsWith(SCRIPT_STRING));
+
+        final String views = scriptText.substring(SCRIPT_STRING.length());
+
+        final var mapper = new ObjectMapper();
+
+        var actual = mapper.readTree(views);
+        var expected = mapper.readTree(getClass().getResource(
+                "/META-INF/VAADIN/available-views-anonymous.json"));
+
+        MatcherAssert.assertThat(actual, Matchers.is(expected));
+    }
+
+    @Test
+    public void when_productionMode_authenticated_user_should_modifyIndexHtmlResponse_with_user_allowed_routes()
+            throws IOException {
+        try (MockedStatic<VaadinService> mocked = Mockito
+                .mockStatic(VaadinService.class)) {
+            mocked.when(VaadinService::getCurrent).thenReturn(vaadinService);
+            Mockito.when(deploymentConfiguration.isProductionMode())
+                    .thenReturn(true);
+            Mockito.when(vaadinRequest.isUserInRole("ROLE_USER"))
                     .thenReturn(true);
             requestListener.modifyIndexHtmlResponse(indexHtmlResponse);
         }
@@ -186,7 +239,84 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
 
         var actual = mapper.readTree(views);
         var expected = mapper.readTree(getClass()
-                .getResource("/META-INF/VAADIN/available-views.json"));
+                .getResource("/META-INF/VAADIN/available-views-user.json"));
+
+        MatcherAssert.assertThat(actual, Matchers.is(expected));
+    }
+
+    @Test
+    public void when_productionMode_admin_user_should_modifyIndexHtmlResponse_with_anonymous_and_admin_allowed_routes()
+            throws IOException {
+        try (MockedStatic<VaadinService> mocked = Mockito
+                .mockStatic(VaadinService.class)) {
+            mocked.when(VaadinService::getCurrent).thenReturn(vaadinService);
+            Mockito.when(deploymentConfiguration.isProductionMode())
+                    .thenReturn(true);
+            Mockito.when(vaadinRequest.isUserInRole("ROLE_ADMIN"))
+                    .thenReturn(true);
+            requestListener.modifyIndexHtmlResponse(indexHtmlResponse);
+        }
+        Mockito.verify(indexHtmlResponse, Mockito.times(1)).getDocument();
+        MatcherAssert.assertThat(
+                indexHtmlResponse.getDocument().head().select("script"),
+                Matchers.notNullValue());
+
+        DataNode script = indexHtmlResponse.getDocument().head()
+                .select("script").dataNodes().get(0);
+
+        final String scriptText = script.getWholeData();
+        MatcherAssert.assertThat(scriptText,
+                Matchers.startsWith(SCRIPT_STRING));
+
+        final String views = scriptText.substring(SCRIPT_STRING.length());
+
+        final var mapper = new ObjectMapper();
+
+        var actual = mapper.readTree(views);
+        var expected = mapper.readTree(getClass()
+                .getResource("/META-INF/VAADIN/available-views-admin.json"));
+
+        MatcherAssert.assertThat(actual, Matchers.is(expected));
+    }
+
+    @Test
+    public void when_productionMode_hillaViewProtection_not_enabled_anonymous_user_should_modifyIndexHtmlResponse_with_all_routes()
+            throws IOException {
+        try (MockedStatic<VaadinService> mocked = Mockito
+                .mockStatic(VaadinService.class)) {
+            mocked.when(VaadinService::getCurrent).thenReturn(vaadinService);
+            Mockito.when(deploymentConfiguration.isProductionMode())
+                    .thenReturn(true);
+            Mockito.when(vaadinRequest.getUserPrincipal()).thenReturn(null); // anonymous
+                                                                             // user
+            routeUtil = new RouteUtil(clientRouteRegistry); // no protection
+                                                            // since
+                                                            // protectHillaViews
+                                                            // is not called
+            requestListener = new RouteUnifyingIndexHtmlRequestListener(
+                    clientRouteRegistry, deploymentConfiguration, routeUtil,
+                    true);
+            requestListener.modifyIndexHtmlResponse(indexHtmlResponse);
+        }
+        Mockito.verify(indexHtmlResponse, Mockito.times(1)).getDocument();
+        MatcherAssert.assertThat(
+                indexHtmlResponse.getDocument().head().select("script"),
+                Matchers.notNullValue());
+
+        DataNode script = indexHtmlResponse.getDocument().head()
+                .select("script").dataNodes().get(0);
+
+        final String scriptText = script.getWholeData();
+        MatcherAssert.assertThat(scriptText,
+                Matchers.startsWith(SCRIPT_STRING));
+
+        final String views = scriptText.substring(SCRIPT_STRING.length());
+
+        final var mapper = new ObjectMapper();
+
+        var actual = mapper.readTree(views);
+        var expected = mapper.readTree(getClass()
+                .getResource("/META-INF/VAADIN/available-views-admin.json"));
 
         MatcherAssert.assertThat(actual, Matchers.is(expected));
     }
@@ -197,6 +327,8 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
         try (MockedStatic<VaadinService> mocked = Mockito
                 .mockStatic(VaadinService.class)) {
             mocked.when(VaadinService::getCurrent).thenReturn(vaadinService);
+            Mockito.when(vaadinRequest.isUserInRole(Mockito.anyString()))
+                    .thenReturn(true);
             mockDevelopmentMode();
             requestListener.modifyIndexHtmlResponse(indexHtmlResponse);
         }
@@ -218,20 +350,20 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
 
         var actual = mapper.readTree(views);
         var expected = mapper.readTree(getClass()
-                .getResource("/META-INF/VAADIN/available-views.json"));
+                .getResource("/META-INF/VAADIN/available-views-admin.json"));
 
         MatcherAssert.assertThat(actual, Matchers.is(expected));
     }
 
     @Test
     public void should_collectServerViews() {
-        final Map<String, AvailableViewInfo> views = new LinkedHashMap<>();
+        final Map<String, AvailableViewInfo> views;
 
         try (MockedStatic<VaadinService> mocked = Mockito
                 .mockStatic(VaadinService.class)) {
             mocked.when(VaadinService::getCurrent).thenReturn(vaadinService);
 
-            requestListener.collectServerViews(views);
+            views = requestListener.collectServerViews();
         }
         MatcherAssert.assertThat(views, Matchers.aMapWithSize(5));
         MatcherAssert.assertThat(views.get("/bar").title(),
@@ -254,19 +386,23 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
 
     @Test
     public void when_productionMode_should_collectClientViews() {
-        final Map<String, AvailableViewInfo> views = new LinkedHashMap<>();
         Mockito.when(deploymentConfiguration.isProductionMode())
                 .thenReturn(true);
-        requestListener.collectClientViews(views);
+        Predicate<? super String> isUserInRole = role -> true;
+        boolean isAuthenticated = true;
+        var views = requestListener.collectClientViews(isUserInRole,
+                isAuthenticated);
         MatcherAssert.assertThat(views, Matchers.aMapWithSize(3));
     }
 
     @Test
     public void when_developmentMode_should_collectClientViews()
             throws IOException {
-        final Map<String, AvailableViewInfo> views = new LinkedHashMap<>();
         mockDevelopmentMode();
-        requestListener.collectClientViews(views);
+        boolean isUserAuthenticated = true;
+        Predicate<? super String> isUserInRole = role -> true;
+        var views = requestListener.collectClientViews(isUserInRole,
+                isUserAuthenticated);
         MatcherAssert.assertThat(views, Matchers.aMapWithSize(3));
     }
 
@@ -275,8 +411,11 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
             throws IOException {
         Mockito.when(deploymentConfiguration.isProductionMode())
                 .thenReturn(true);
+        Mockito.when(vaadinRequest.isUserInRole(Mockito.anyString()))
+                .thenReturn(true);
         var requestListener = new RouteUnifyingIndexHtmlRequestListener(
-                clientRouteRegistry, deploymentConfiguration, false);
+                clientRouteRegistry, deploymentConfiguration, routeUtil, false);
+
         requestListener.modifyIndexHtmlResponse(indexHtmlResponse);
 
         MatcherAssert.assertThat(

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListenerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListenerTest.java
@@ -3,6 +3,7 @@ package com.vaadin.hilla.startup;
 import java.io.IOException;
 
 import com.vaadin.hilla.route.RouteUnifyingConfigurationProperties;
+import com.vaadin.hilla.route.RouteUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,6 +23,7 @@ public class RouteUnifyingServiceInitListenerTest {
     private ServiceInitEvent event;
     private ClientRouteRegistry clientRouteRegistry;
     private DeploymentConfiguration mockDeploymentConfiguration;
+    private RouteUtil routeUtil;
     private final RouteUnifyingConfigurationProperties routeUnifyingConfigurationProperties = new RouteUnifyingConfigurationProperties();
 
     @Rule
@@ -32,8 +34,10 @@ public class RouteUnifyingServiceInitListenerTest {
         clientRouteRegistry = new ClientRouteRegistry();
         routeUnifyingConfigurationProperties
                 .setExposeServerRoutesToClient(true);
+        routeUtil = Mockito.mock(RouteUtil.class);
         routeUnifyingServiceInitListener = new RouteUnifyingServiceInitListener(
-                clientRouteRegistry, routeUnifyingConfigurationProperties);
+                clientRouteRegistry, routeUtil,
+                routeUnifyingConfigurationProperties);
         VaadinService mockVaadinService = Mockito.mock(VaadinService.class);
         mockDeploymentConfiguration = Mockito
                 .mock(DeploymentConfiguration.class);

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-admin.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-admin.json
@@ -11,7 +11,7 @@
   },
   "/profile": {
     "title": "Profile",
-    "rolesAllowed": ["ROLE_USER"],
+    "rolesAllowed": ["ROLE_USER", "ROLE_ADMIN"],
     "requiresLogin": true,
     "route": "/profile",
     "lazy": false,

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-anonymous.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-anonymous.json
@@ -1,0 +1,68 @@
+{
+  "/home": {
+    "title": "Home",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/home",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/bar": {
+    "title": "Component",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/bar",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/foo": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/foo",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/wildcard/:___wildcard*": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/wildcard/:___wildcard*",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {
+      ":___wildcard*": "*"
+    }
+  },
+  "//:___userId/edit": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "//:___userId/edit",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {
+      ":___userId": "req"
+    }
+  },
+  "/comments/:___commentId?": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/comments/:___commentId?",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {
+      ":___commentId?": "opt"
+    }
+  }
+}

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-user.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-user.json
@@ -1,0 +1,78 @@
+{
+  "/home": {
+    "title": "Home",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/home",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/profile": {
+    "title": "Profile",
+    "rolesAllowed": ["ROLE_USER", "ROLE_ADMIN"],
+    "requiresLogin": true,
+    "route": "/profile",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/bar": {
+    "title": "Component",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/bar",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/foo": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/foo",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {}
+  },
+  "/wildcard/:___wildcard*": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/wildcard/:___wildcard*",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {
+      ":___wildcard*": "*"
+    }
+  },
+  "//:___userId/edit": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "//:___userId/edit",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {
+      ":___userId": "req"
+    }
+  },
+  "/comments/:___commentId?": {
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "requiresLogin": false,
+    "route": "/comments/:___commentId?",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "params": {
+      ":___commentId?": "opt"
+    }
+  }
+}

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/only-client-views.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/only-client-views.json
@@ -11,7 +11,7 @@
   },
   "/profile": {
     "title": "Profile",
-    "rolesAllowed": ["ROLE_USER"],
+    "rolesAllowed": ["ROLE_USER", "ROLE_ADMIN"],
     "requiresLogin": true,
     "route": "/profile",
     "lazy": false,


### PR DESCRIPTION
This enables filtering of Hilla views based on the security configurations exported from views, and uses the same access control API that could be optionally used Spring Security configuration for http level security.

It is important to note that filtering Hilla views in the menu is a usability feature not a security one.