### PR TITLE
fix: Do not collect if views does not exist

### DIFF
--- a/packages/ts/file-router/src/vite-plugin/collectRoutesFromFS.ts
+++ b/packages/ts/file-router/src/vite-plugin/collectRoutesFromFS.ts
@@ -67,11 +67,8 @@ export default async function collectRoutesFromFS(
   dir: URL,
   { extensions, logger, parent = dir }: CollectRoutesOptions,
 ): Promise<readonly RouteMeta[]> {
-  let children: RouteMeta[] = [];
-  if (!existsSync(dir)) {
-    return children;
-  }
   const path = relative(fileURLToPath(parent), fileURLToPath(dir));
+  let children: RouteMeta[] = [];
   let layout: URL | undefined;
 
   for await (const d of await opendir(dir)) {

--- a/packages/ts/file-router/src/vite-plugin/collectRoutesFromFS.ts
+++ b/packages/ts/file-router/src/vite-plugin/collectRoutesFromFS.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { opendir, readFile } from 'node:fs/promises';
 import { basename, extname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -66,8 +67,11 @@ export default async function collectRoutesFromFS(
   dir: URL,
   { extensions, logger, parent = dir }: CollectRoutesOptions,
 ): Promise<readonly RouteMeta[]> {
-  const path = relative(fileURLToPath(parent), fileURLToPath(dir));
   let children: RouteMeta[] = [];
+  if (!existsSync(dir)) {
+    return children;
+  }
+  const path = relative(fileURLToPath(parent), fileURLToPath(dir));
   let layout: URL | undefined;
 
   for await (const d of await opendir(dir)) {

--- a/packages/ts/file-router/src/vite-plugin/collectRoutesFromFS.ts
+++ b/packages/ts/file-router/src/vite-plugin/collectRoutesFromFS.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs';
 import { opendir, readFile } from 'node:fs/promises';
 import { basename, extname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
+++ b/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { Logger } from 'vite';
 import collectRoutesFromFS from './collectRoutesFromFS.js';
@@ -56,7 +57,7 @@ export async function generateRuntimeFiles(
   extensions: readonly string[],
   logger: Logger,
 ): Promise<void> {
-  const routeMeta = await collectRoutesFromFS(viewsDir, { extensions, logger });
+  const routeMeta = existsSync(viewsDir) ? await collectRoutesFromFS(viewsDir, { extensions, logger }) : [];
   logger.info('Collected file-based routes');
   const runtimeRoutesCode = createRoutesFromMeta(routeMeta, urls);
   const viewConfigJson = await createViewConfigJson(routeMeta);

--- a/packages/ts/file-router/test/vite-plugin/generateRuntimeFiles.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/generateRuntimeFiles.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, watch } from 'node:fs';
+import { existsSync, rmSync, watch } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { expect, use } from '@esm-bundle/chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -53,6 +53,11 @@ describe('@vaadin/hilla-file-router', () => {
       });
       json.close();
       code.close();
+    });
+
+    it('should not throw if views does not exist', async () => {
+      rmSync(viewsDir, { force: true, recursive: true });
+      await generateRuntimeFiles(viewsDir, runtimeUrls, ['.tsx', '.jsx'], logger);
     });
   });
 });


### PR DESCRIPTION
Should eliminate errors like
```
Error: ENOENT: no such file or directory, opendir '/opt/agent/work/83e2cf1ab9bef258/frontend/views/'
```
for projects that has no `views` folder.