### PR TITLE
feat: make `RouteUtil` implement Flow interface

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUtil.java
@@ -1,5 +1,6 @@
 package com.vaadin.hilla.route;
 
+import com.vaadin.flow.internal.hilla.FileRouterRequestUtil;
 import com.vaadin.hilla.route.records.ClientViewConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ import org.springframework.http.server.RequestPath;
  * For internal use only. May be renamed or removed in a future release.
  */
 @Component
-public class RouteUtil {
+public class RouteUtil implements FileRouterRequestUtil {
 
     private final ClientRouteRegistry registry;
 
@@ -41,6 +42,7 @@ public class RouteUtil {
      * @return <code>true</code> if the request goes allowed route,
      *         <code>false</code> otherwise
      */
+    @Override
     public boolean isRouteAllowed(HttpServletRequest request) {
         var viewConfig = getRouteData(request);
         var isUserAuthenticated = request.getUserPrincipal() != null;

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUtilTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUtilTest.java
@@ -12,12 +12,12 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 public class RouteUtilTest {
 
-    private final RouteUtil endpointUtil;
+    private final RouteUtil routeUtil;
     private final ClientRouteRegistry registry;
 
     public RouteUtilTest() {
         registry = new ClientRouteRegistry();
-        this.endpointUtil = new RouteUtil(registry);
+        this.routeUtil = new RouteUtil(registry);
     }
 
     @Before
@@ -44,7 +44,7 @@ public class RouteUtilTest {
         config.setRouteParameters(null);
         registry.addRoute("/test", config);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertTrue(actual);
     }
 
@@ -67,7 +67,7 @@ public class RouteUtilTest {
         config.setRouteParameters(null);
         registry.addRoute("/test", config);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertFalse(actual);
     }
 
@@ -90,7 +90,7 @@ public class RouteUtilTest {
         config.setRouteParameters(null);
         registry.addRoute("/test", config);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertTrue(actual);
     }
 
@@ -113,7 +113,7 @@ public class RouteUtilTest {
         config.setRouteParameters(null);
         registry.addRoute("/test", config);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertFalse(actual);
     }
 
@@ -150,7 +150,7 @@ public class RouteUtilTest {
 
         registry.addRoute("/test", pageWithoutLogin);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertFalse(actual);
     }
 
@@ -187,7 +187,7 @@ public class RouteUtilTest {
 
         registry.addRoute("/test", pageWithLogin);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertFalse(actual);
     }
 
@@ -214,7 +214,7 @@ public class RouteUtilTest {
         config.setRouteParameters(null);
         registry.addRoute("", config);
 
-        boolean actual = endpointUtil.isRouteAllowed(request);
+        boolean actual = routeUtil.isRouteAllowed(request);
         Assert.assertTrue(actual);
     }
 }


### PR DESCRIPTION
`RouteUtil` becomes an optional bean that, when Hilla is used, is automatically taken into account in `VaadinWebSecurity`.

Needs https://github.com/vaadin/flow/pull/19257 to compile.

Closes #2357.