### PR TITLE
refactor!: rename Vaadin.server.views object to Vaadin.views

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListener.java
@@ -59,8 +59,7 @@ public class RouteUnifyingIndexHtmlRequestListener
         implements IndexHtmlRequestListener {
     protected static final String SCRIPT_STRING = """
             window.Vaadin = window.Vaadin ?? {};
-            window.Vaadin.server = window.Vaadin.server ?? {};
-            window.Vaadin.server.views = %s;""";
+            window.Vaadin.views = %s;""";
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(RouteUnifyingIndexHtmlRequestListener.class);

--- a/packages/ts/file-router/src/runtime/createMenuItems.ts
+++ b/packages/ts/file-router/src/runtime/createMenuItems.ts
@@ -13,8 +13,8 @@ import type { MenuItem, ViewConfig } from '../types.js';
  */
 export function createMenuItems(vaadinObject = (window as VaadinWindow).Vaadin): readonly MenuItem[] {
   const collator = new Intl.Collator('en-US');
-  return vaadinObject?.server?.views
-    ? Object.entries(vaadinObject.server.views)
+  return vaadinObject?.views
+    ? Object.entries(vaadinObject.views)
         // Filter out the views that are explicitly excluded from the menu.
         .filter(
           ([_key, value]) =>

--- a/packages/ts/file-router/src/shared/internal.d.ts
+++ b/packages/ts/file-router/src/shared/internal.d.ts
@@ -16,12 +16,8 @@ export type ServerViewMapItem = Readonly<{
 }> &
   ViewConfig;
 
-export type VaadinServer = Readonly<{
-  views: Readonly<Record<string, ServerViewMapItem>>;
-}>;
-
 export type VaadinObject = Readonly<{
-  server?: VaadinServer;
+  views: Readonly<Record<string, ServerViewMapItem>>;
 }>;
 
 export type VaadinWindow = Readonly<{

--- a/packages/ts/file-router/test/runtime/createMenuItems.spec.ts
+++ b/packages/ts/file-router/test/runtime/createMenuItems.spec.ts
@@ -27,19 +27,17 @@ describe('@vaadin/hilla-file-router', () => {
   describe('createMenuItems', () => {
     it('should generate a set of menu items', () => {
       const items = createMenuItems({
-        server: {
-          views: {
-            '/about': { route: 'about', title: 'About' },
-            '/profile/': { title: 'Profile' },
-            '/profile/account/security/password': { title: 'Password' },
-            '/profile/account/security/two-factor-auth': { title: 'Two Factor Auth' },
-            '/profile/friends/list': { title: 'List' },
-            '/profile/friends/:user': { title: 'User', params: { ':user': RouteParamType.Required } },
-            '/test/empty': {},
-            '/test/:optional?': { title: 'Optional', params: { ':optional?': RouteParamType.Optional } },
-            '/test/*': { title: 'Wildcard', params: { '*': RouteParamType.Wildcard } },
-            '/test/no-default-export': { title: 'No Default Export' },
-          },
+        views: {
+          '/about': { route: 'about', title: 'About' },
+          '/profile/': { title: 'Profile' },
+          '/profile/account/security/password': { title: 'Password' },
+          '/profile/account/security/two-factor-auth': { title: 'Two Factor Auth' },
+          '/profile/friends/list': { title: 'List' },
+          '/profile/friends/:user': { title: 'User', params: { ':user': RouteParamType.Required } },
+          '/test/empty': {},
+          '/test/:optional?': { title: 'Optional', params: { ':optional?': RouteParamType.Optional } },
+          '/test/*': { title: 'Wildcard', params: { '*': RouteParamType.Wildcard } },
+          '/test/no-default-export': { title: 'No Default Export' },
         },
       });
       cleanup(items as Array<Writable<MenuItem>>);
@@ -88,20 +86,18 @@ describe('@vaadin/hilla-file-router', () => {
 
     it('should sort menu items by order then by natural string comparison based on path', () => {
       const items = createMenuItems({
-        server: {
-          views: {
-            '/a/b': { route: 'about', title: 'About' },
-            '': { title: 'Profile' },
-            '/profile/account/security/password': { title: 'Password', menu: { order: 20 } },
-            '/profile/account/security/two-factor-auth': { title: 'Two Factor Auth', menu: { order: 20 } },
-            '/b': { title: 'List' },
-            '/profile/friends/:user': { title: 'User', params: { ':user': RouteParamType.Required } },
-            '/': { title: 'Root' },
-            '/test/empty': { title: 'empty', menu: { order: 5 } },
-            '/test/:optional?': { title: 'Optional', params: { ':optional?': RouteParamType.Optional } },
-            '/a/*': { title: 'Wildcard', params: { '*': RouteParamType.Wildcard } },
-            '/test/no-default-export': { title: 'No Default Export', menu: { order: 10 } },
-          },
+        views: {
+          '/a/b': { route: 'about', title: 'About' },
+          '': { title: 'Profile' },
+          '/profile/account/security/password': { title: 'Password', menu: { order: 20 } },
+          '/profile/account/security/two-factor-auth': { title: 'Two Factor Auth', menu: { order: 20 } },
+          '/b': { title: 'List' },
+          '/profile/friends/:user': { title: 'User', params: { ':user': RouteParamType.Required } },
+          '/': { title: 'Root' },
+          '/test/empty': { title: 'empty', menu: { order: 5 } },
+          '/test/:optional?': { title: 'Optional', params: { ':optional?': RouteParamType.Optional } },
+          '/a/*': { title: 'Wildcard', params: { '*': RouteParamType.Wildcard } },
+          '/test/no-default-export': { title: 'No Default Export', menu: { order: 10 } },
         },
       });
       const cleanedUp = (items as Array<Writable<MenuItem>>).map((item) => ({


### PR DESCRIPTION
## Description

As `Vaadin.server.views` holds both server-side
 and client-side views, having the `server` in the
naming of that object can confuse users. This 
changes the object to `Vaadin.views`.

Fixes #2375

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
