### PR TITLE
feat(generator): support `@JsonCreator` and `@JsonValue` annotations

### DIFF
--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/BackbonePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/BackbonePlugin.java
@@ -6,8 +6,8 @@ public final class BackbonePlugin
         extends AbstractCompositePlugin<BackbonePluginConfiguration> {
     public BackbonePlugin() {
         super(new EndpointPlugin(), new EndpointExposedPlugin(),
-                new MethodPlugin(), new MethodParameterPlugin(),
-                new EntityPlugin(), new PropertyPlugin(),
-                new TypeSignaturePlugin());
+                new JsonValuePlugin(), new MethodPlugin(),
+                new MethodParameterPlugin(), new EntityPlugin(),
+                new PropertyPlugin(), new TypeSignaturePlugin());
     }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
@@ -23,10 +23,7 @@ import java.util.stream.Stream;
  */
 public class JsonValuePlugin
         extends AbstractPlugin<BackbonePluginConfiguration> {
-    private static class NotAJsonValue {
-    }
-
-    private final Map<Class<?>, Class<?>> jsonValues = new HashMap<>();
+    private final Map<Class<?>, Optional<Class<?>>> jsonValues = new HashMap<>();
 
     @Override
     public void enter(NodePath<?> nodePath) {
@@ -62,12 +59,10 @@ public class JsonValuePlugin
 
     private Optional<Class<?>> getValueType(Class<?> cls) {
         // Use cached results to avoid recomputing the value type.
-        var valueType = jsonValues.computeIfAbsent(cls, this::findValueType);
-        return valueType == NotAJsonValue.class ? Optional.empty()
-                : Optional.of(valueType);
+        return jsonValues.computeIfAbsent(cls, this::findValueType);
     }
 
-    private Class<?> findValueType(Class<?> cls) {
+    private Optional<Class<?>> findValueType(Class<?> cls) {
         // First of all, we check that the `@JsonValue` annotation is
         // used on a method of the class.
         var jsonValue = Arrays.stream(cls.getMethods())
@@ -95,7 +90,7 @@ public class JsonValuePlugin
                     + " Hilla only supports classes with both annotations.");
         }
 
-        return jsonValue.orElse(NotAJsonValue.class);
+        return jsonValue;
     }
 
     // this shouldn't be a runtime exception, but `resolve` doesn't allow

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
@@ -88,8 +88,7 @@ public class JsonValuePlugin
         // they break the generator or, at least, make data transfer impossible,
         // so we throw an exception for those.
         if (jsonValue.isPresent() ^ jsonCreator.isPresent()) {
-            throw new MissingJsonCreatorAnnotationException("Class "
-                    + cls.getName()
+            throw new MalformedValueTypeException("Class " + cls.getName()
                     + " has only one of @JsonValue and @JsonCreator."
                     + " Hilla only supports classes with both annotations.");
         }
@@ -99,9 +98,8 @@ public class JsonValuePlugin
 
     // this shouldn't be a runtime exception, but `resolve` doesn't allow
     // checked exceptions
-    public static class MissingJsonCreatorAnnotationException
-            extends RuntimeException {
-        public MissingJsonCreatorAnnotationException(String message) {
+    public static class MalformedValueTypeException extends RuntimeException {
+        public MalformedValueTypeException(String message) {
             super(message);
         }
     }

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
@@ -48,6 +48,9 @@ public class JsonValuePlugin
                     .getSource() instanceof ClassRefSignatureModel classRefSignatureModel) {
                 var cls = (Class<?>) classRefSignatureModel.getClassInfo()
                         .get();
+                // Check if the class has the annotations which qualify for a
+                // value type. If so, replace the type with the corresponding
+                // value type.
                 Optional<TypeSignatureNode> valueNode = getValueType(cls)
                         .map(SignatureModel::of).map(TypeSignatureNode::of);
                 return valueNode.orElse(typeSignatureNode);
@@ -86,7 +89,8 @@ public class JsonValuePlugin
         // so we throw an exception for those.
         if (jsonValue.isPresent() ^ jsonCreator.isPresent()) {
             throw new MissingJsonCreatorAnnotationException("Class "
-                    + cls.getName() + " has @JsonValue, but no @JsonCreator."
+                    + cls.getName()
+                    + " has only one of @JsonValue and @JsonCreator."
                     + " Hilla only supports classes with both annotations.");
         }
 

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
@@ -1,0 +1,91 @@
+package com.vaadin.hilla.parser.plugins.backbone;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.vaadin.hilla.parser.core.AbstractPlugin;
+import com.vaadin.hilla.parser.core.Node;
+import com.vaadin.hilla.parser.core.NodeDependencies;
+import com.vaadin.hilla.parser.core.NodePath;
+import com.vaadin.hilla.parser.models.*;
+import com.vaadin.hilla.parser.plugins.backbone.nodes.TypeSignatureNode;
+import jakarta.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * Adds support for Jackson's {@code JsonValue} and {@code JsonCreator}
+ * annotations.
+ */
+public class JsonValuePlugin
+        extends AbstractPlugin<BackbonePluginConfiguration> {
+    @Override
+    public void enter(NodePath<?> nodePath) {
+    }
+
+    @Override
+    public void exit(NodePath<?> nodePath) {
+    }
+
+    @Nonnull
+    @Override
+    public NodeDependencies scan(@Nonnull NodeDependencies nodeDependencies) {
+        return nodeDependencies;
+    }
+
+    @Nonnull
+    @Override
+    public Node<?, ?> resolve(@Nonnull Node<?, ?> node,
+            @Nonnull NodePath<?> parentPath) {
+        if (node instanceof TypeSignatureNode typeSignatureNode) {
+            if (typeSignatureNode
+                    .getSource() instanceof ClassRefSignatureModel classRefSignatureModel) {
+                // First of all, we check that the `@JsonValue` annotation is
+                // used on a method of the class.
+                var jsonValue = classRefSignatureModel.getClassInfo()
+                        .getMethods().stream()
+                        .filter(method -> method.getAnnotations().stream()
+                                .map(NamedModel::getName)
+                                .anyMatch(name -> name
+                                        .equals(JsonValue.class.getName())))
+                        .map(MethodInfoModel::getResultType).findFirst();
+
+                if (jsonValue.isPresent()) {
+                    // Then we check that the class has a `@JsonCreator`
+                    // annotation on a method or on a constructor.
+                    // This is a basic check, we could also check that they use
+                    // the same type, or if a class uses `@JsonCreator` without
+                    // `@JsonValue`.
+                    var cls = (Class<?>) classRefSignatureModel.getClassInfo()
+                            .get();
+                    Stream.concat(Arrays.stream(cls.getMethods()),
+                            Arrays.stream(cls.getConstructors()))
+                            .filter(executable -> executable
+                                    .isAnnotationPresent(JsonCreator.class))
+                            .findAny().orElseThrow(
+                                    () -> new MissingJsonCreatorAnnotationException(
+                                            "Class " + cls.getName()
+                                                    + " has @JsonValue, but no @JsonCreator."
+                                                    + " Hilla only supports classes with both annotations."));
+                }
+
+                // If the class has both annotations, we return the return type
+                // of the `@JsonValue`-annotated method, otherwise we return the
+                // type itself as usual.
+                return jsonValue.map(TypeSignatureNode::of)
+                        .orElse(typeSignatureNode);
+            }
+        }
+
+        return node;
+    }
+
+    // this shouldn't be a runtime exception, but `resolve` doesn't allow
+    // checked exceptions
+    public static class MissingJsonCreatorAnnotationException
+            extends RuntimeException {
+        public MissingJsonCreatorAnnotationException(String message) {
+            super(message);
+        }
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/JsonValuePlugin.java
@@ -69,9 +69,7 @@ public class JsonValuePlugin
         // First of all, we check that the `@JsonValue` annotation is
         // used on a method of the class.
         var jsonValue = Arrays.stream(cls.getMethods())
-                .filter(method -> Arrays.stream(method.getAnnotations())
-                        .map(ann -> ann.annotationType().getName()).anyMatch(
-                                name -> name.equals(JsonValue.class.getName())))
+                .filter(method -> method.isAnnotationPresent(JsonValue.class))
                 .map(Method::getReturnType).findAny();
 
         // Then we check that the class has a `@JsonCreator` annotation

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/Endpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/Endpoint.java
@@ -1,0 +1,11 @@
+package com.vaadin.hilla.parser.plugins.backbone.jsonvalue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Endpoint {
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/JsonValueEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/JsonValueEndpoint.java
@@ -1,0 +1,61 @@
+package com.vaadin.hilla.parser.plugins.backbone.jsonvalue;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@Endpoint
+public class JsonValueEndpoint {
+    public record Name(String firstName, String lastName) {
+        @JsonCreator
+        public Name(String fullName) {
+            this(fullName.split(" ")[0], fullName.split(" ")[1]);
+        }
+
+        @JsonValue
+        public String fullName() {
+            return firstName + " " + lastName;
+        }
+    }
+
+    public static class Email {
+        private String value;
+
+        @JsonCreator
+        public Email(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public record PhoneNumber(@JsonValue int value) {
+        @JsonCreator
+        public PhoneNumber {
+        }
+    }
+
+    public record Person(Name name, Email email, PhoneNumber phoneNumber) {
+    }
+
+    public Person getPerson() {
+        return new Person(new Name("John", "Doe"),
+                new Email("john.doe@example.com"), new PhoneNumber(1234567890));
+    }
+
+    public void setPerson(Person person) {
+    }
+
+    public Email getEmail() {
+        return new Email("john.doe@example.com");
+    }
+
+    public void setEmail(Email email) {
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/JsonValueTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/JsonValueTest.java
@@ -1,0 +1,25 @@
+package com.vaadin.hilla.parser.plugins.backbone.jsonvalue;
+
+import com.vaadin.hilla.parser.core.Parser;
+import com.vaadin.hilla.parser.plugins.backbone.BackbonePlugin;
+import com.vaadin.hilla.parser.plugins.backbone.test.helpers.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+public class JsonValueTest {
+    private final TestHelper helper = new TestHelper(getClass());
+
+    @Test
+    public void should_CorrectlyMapJsonValue()
+            throws IOException, URISyntaxException {
+        var openAPI = new Parser().classLoader(getClass().getClassLoader())
+                .classPath(Set.of(helper.getTargetDir().toString()))
+                .endpointAnnotation(Endpoint.class.getName())
+                .addPlugin(new BackbonePlugin()).execute();
+
+        helper.executeParserWithConfig(openAPI);
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/Endpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/Endpoint.java
@@ -1,0 +1,11 @@
+package com.vaadin.hilla.parser.plugins.backbone.jsonvaluenojsoncreator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Endpoint {
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorEndpoint.java
@@ -1,0 +1,30 @@
+package com.vaadin.hilla.parser.plugins.backbone.jsonvaluenojsoncreator;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@Endpoint
+public class JsonValueNoJsonCreatorEndpoint {
+    public static class Email {
+        private String value;
+
+        public Email(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    public Email getEmail() {
+        return new Email("john.doe@example.com");
+    }
+
+    public void setEmail(Email email) {
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
@@ -2,7 +2,7 @@ package com.vaadin.hilla.parser.plugins.backbone.jsonvaluenojsoncreator;
 
 import com.vaadin.hilla.parser.core.Parser;
 import com.vaadin.hilla.parser.plugins.backbone.BackbonePlugin;
-import com.vaadin.hilla.parser.plugins.backbone.JsonValuePlugin;
+import com.vaadin.hilla.parser.plugins.backbone.JsonValuePlugin.MalformedValueTypeException;
 import com.vaadin.hilla.parser.plugins.backbone.test.helpers.TestHelper;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +15,7 @@ public class JsonValueNoJsonCreatorTest {
 
     @Test
     public void should_CorrectlyMapJsonValue() {
-        assertThrows(JsonValuePlugin.MalformedValueTypeException.class, () -> {
+        assertThrows(MalformedValueTypeException.class, () -> {
             new Parser().classLoader(getClass().getClassLoader())
                     .classPath(Set.of(helper.getTargetDir().toString()))
                     .endpointAnnotation(Endpoint.class.getName())

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
@@ -15,13 +15,11 @@ public class JsonValueNoJsonCreatorTest {
 
     @Test
     public void should_CorrectlyMapJsonValue() {
-        assertThrows(
-                JsonValuePlugin.MissingJsonCreatorAnnotationException.class,
-                () -> {
-                    new Parser().classLoader(getClass().getClassLoader())
-                            .classPath(Set.of(helper.getTargetDir().toString()))
-                            .endpointAnnotation(Endpoint.class.getName())
-                            .addPlugin(new BackbonePlugin()).execute();
-                });
+        assertThrows(JsonValuePlugin.MalformedValueTypeException.class, () -> {
+            new Parser().classLoader(getClass().getClassLoader())
+                    .classPath(Set.of(helper.getTargetDir().toString()))
+                    .endpointAnnotation(Endpoint.class.getName())
+                    .addPlugin(new BackbonePlugin()).execute();
+        });
     }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
@@ -14,7 +14,7 @@ public class JsonValueNoJsonCreatorTest {
     private final TestHelper helper = new TestHelper(getClass());
 
     @Test
-    public void should_CorrectlyMapJsonValue() {
+    public void should_ThrowExceptionWhenOnlyJsonValueIsUsed() {
         assertThrows(MalformedValueTypeException.class, () -> {
             new Parser().classLoader(getClass().getClassLoader())
                     .classPath(Set.of(helper.getTargetDir().toString()))

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/jsonvaluenojsoncreator/JsonValueNoJsonCreatorTest.java
@@ -1,0 +1,27 @@
+package com.vaadin.hilla.parser.plugins.backbone.jsonvaluenojsoncreator;
+
+import com.vaadin.hilla.parser.core.Parser;
+import com.vaadin.hilla.parser.plugins.backbone.BackbonePlugin;
+import com.vaadin.hilla.parser.plugins.backbone.JsonValuePlugin;
+import com.vaadin.hilla.parser.plugins.backbone.test.helpers.TestHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JsonValueNoJsonCreatorTest {
+    private final TestHelper helper = new TestHelper(getClass());
+
+    @Test
+    public void should_CorrectlyMapJsonValue() {
+        assertThrows(
+                JsonValuePlugin.MissingJsonCreatorAnnotationException.class,
+                () -> {
+                    new Parser().classLoader(getClass().getClassLoader())
+                            .classPath(Set.of(helper.getTargetDir().toString()))
+                            .endpointAnnotation(Endpoint.class.getName())
+                            .addPlugin(new BackbonePlugin()).execute();
+                });
+    }
+}

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/com/vaadin/hilla/parser/plugins/backbone/jsonvalue/openapi.json
@@ -1,0 +1,148 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Hilla Application",
+    "version" : "1.0.0"
+  },
+  "servers" : [
+    {
+      "url" : "http://localhost:8080/connect",
+      "description" : "Hilla Backend"
+    }
+  ],
+  "tags" : [
+    {
+      "name" : "JsonValueEndpoint",
+      "x-class-name" : "com.vaadin.hilla.parser.plugins.backbone.jsonvalue.JsonValueEndpoint"
+    }
+  ],
+  "paths" : {
+    "/JsonValueEndpoint/getEmail" : {
+      "post" : {
+        "tags" : [
+          "JsonValueEndpoint"
+        ],
+        "operationId" : "JsonValueEndpoint_getEmail_POST",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "nullable" : true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/JsonValueEndpoint/getPerson" : {
+      "post" : {
+        "tags" : [
+          "JsonValueEndpoint"
+        ],
+        "operationId" : "JsonValueEndpoint_getPerson_POST",
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "nullable" : true,
+                  "anyOf" : [
+                    {
+                      "$ref" : "#/components/schemas/com.vaadin.hilla.parser.plugins.backbone.jsonvalue.JsonValueEndpoint$Person"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/JsonValueEndpoint/setEmail" : {
+      "post" : {
+        "tags" : [
+          "JsonValueEndpoint"
+        ],
+        "operationId" : "JsonValueEndpoint_setEmail_POST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "email" : {
+                    "type" : "string",
+                    "nullable" : true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : ""
+          }
+        }
+      }
+    },
+    "/JsonValueEndpoint/setPerson" : {
+      "post" : {
+        "tags" : [
+          "JsonValueEndpoint"
+        ],
+        "operationId" : "JsonValueEndpoint_setPerson_POST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "person" : {
+                    "nullable" : true,
+                    "anyOf" : [
+                      {
+                        "$ref" : "#/components/schemas/com.vaadin.hilla.parser.plugins.backbone.jsonvalue.JsonValueEndpoint$Person"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : ""
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "com.vaadin.hilla.parser.plugins.backbone.jsonvalue.JsonValueEndpoint$Person" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "email" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "phoneNumber" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds support for `@JsonCreator` and `@JsonValue` annotations to allow to customize how a type is transferred.

The main purpose is to provide support for domain primitives, like:

```java
    public record Email(@JsonValue String value) {
        @JsonCreator public Email {}
    }
```

Fixes #2055

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
