### PR TITLE
chore: Make hilla endpoint optional for plugin

### DIFF
--- a/packages/java/hilla-dev/pom.xml
+++ b/packages/java/hilla-dev/pom.xml
@@ -26,6 +26,7 @@
             <groupId>com.vaadin</groupId>
             <artifactId>hilla-endpoint</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hotswapagent</groupId>


### PR DESCRIPTION
This is an alternative for https://github.com/vaadin/platform/pull/5264 that prevents `hilla-dev` to include Hilla artifacts (endpoint artifact) into projects that don't use Spring and Hilla.

Fixes https://github.com/vaadin/platform/issues/5260