### PR TITLE
chore: add package.properties

### DIFF
--- a/packages/java/endpoint/src/main/resources/META-INF/VAADIN/package.properties
+++ b/packages/java/endpoint/src/main/resources/META-INF/VAADIN/package.properties
@@ -1,0 +1,1 @@
+vaadin.allowed-packages=com/vaadin/hilla/startup


### PR DESCRIPTION
Flow uses package.properties file to optimize class scanning to only include relevant package from the hilla-endpoint jar.

Related-to: vaadin/flow/issues/19117
