### PR TITLE
fix: support classes that extend or implement an Iterable

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/ExplicitNullableTypeCheckerHelper.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/ExplicitNullableTypeCheckerHelper.java
@@ -161,7 +161,7 @@ class ExplicitNullableTypeCheckerHelper {
 
             if (Iterable.class.isAssignableFrom(expectedClass)) {
                 // Let's deal with classes extending or implementing an iterator
-                itemType = Generics.getExactIterableType(expectedClass);
+                itemType = Generics.getExactIterableType(expectedClass).orElse(Object.class);
                 iterableDescription = "collection";
             } else {
                 itemType = expectedClass.getComponentType();

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/ExplicitNullableTypeCheckerHelper.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/ExplicitNullableTypeCheckerHelper.java
@@ -161,7 +161,8 @@ class ExplicitNullableTypeCheckerHelper {
 
             if (Iterable.class.isAssignableFrom(expectedClass)) {
                 // Let's deal with classes extending or implementing an iterator
-                itemType = Generics.getExactIterableType(expectedClass).orElse(Object.class);
+                itemType = Generics.getExactIterableType(expectedClass)
+                        .orElse(Object.class);
                 iterableDescription = "collection";
             } else {
                 itemType = expectedClass.getComponentType();

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/ExplicitNullableTypeCheckerHelper.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/ExplicitNullableTypeCheckerHelper.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vaadin.hilla.parser.utils.Generics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,8 +157,16 @@ class ExplicitNullableTypeCheckerHelper {
                     .getActualTypeArguments()[0];
             iterableDescription = "collection";
         } else if (expectedType instanceof Class<?>) {
-            itemType = ((Class<?>) expectedType).getComponentType();
-            iterableDescription = "array";
+            var expectedClass = ((Class<?>) expectedType);
+
+            if (Iterable.class.isAssignableFrom(expectedClass)) {
+                // Let's deal with classes extending or implementing an iterator
+                itemType = Generics.getExactIterableType(expectedClass);
+                iterableDescription = "collection";
+            } else {
+                itemType = expectedClass.getComponentType();
+                iterableDescription = "array";
+            }
         }
 
         for (Object item : value) {

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/ExplicitNullableTypeCheckerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/ExplicitNullableTypeCheckerTest.java
@@ -237,6 +237,24 @@ public class ExplicitNullableTypeCheckerTest {
         verify(checker).checkValueForType("bar", String.class);
     }
 
+    private static class MyList extends ArrayList<String> {
+    }
+
+    @Test
+    public void should_Recognize_Extended_List() {
+        ExplicitNullableTypeCheckerHelper checker = spy(helper);
+
+        MyList list = new MyList();
+        list.add("foo");
+        list.add("bar");
+
+        checker.checkValueForType(list, MyList.class);
+        verify(checker).checkValueForType(list, MyList.class);
+
+        verify(checker).checkValueForType("foo", String.class);
+        verify(checker).checkValueForType("bar", String.class);
+    }
+
     @Test
     public void should_ReturnNull_When_GivenNonNullItems_InListType() {
         Assert.assertNull(explicitNullableTypeChecker.checkValueForType(

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
@@ -27,8 +27,9 @@ import com.vaadin.hilla.parser.plugins.backbone.nodes.MethodNode;
 import com.vaadin.hilla.parser.plugins.backbone.nodes.MethodParameterNode;
 import com.vaadin.hilla.parser.plugins.backbone.nodes.PropertyNode;
 import com.vaadin.hilla.parser.plugins.backbone.nodes.TypeSignatureNode;
-
 import com.vaadin.hilla.parser.plugins.backbone.nodes.TypedNode;
+import com.vaadin.hilla.parser.utils.Generics;
+
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
@@ -177,6 +178,10 @@ public final class TypeSignaturePlugin
 
             if (!typeArguments.isEmpty()) {
                 items = List.of(typeArguments.get(0));
+            } else {
+                // Let's deal with classes extending or implementing an iterator
+                var cls = (Class<?>) ((ClassRefSignatureModel) signature).getClassInfo().get();
+                items = List.of(SignatureModel.of(Generics.getExactIterableType(cls)));
             }
         } else if (signature.isOptional()) {
             var typeArguments = ((ClassRefSignatureModel) signature)

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
@@ -1,5 +1,6 @@
 package com.vaadin.hilla.parser.plugins.backbone;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -180,8 +181,10 @@ public final class TypeSignaturePlugin
                 items = List.of(typeArguments.get(0));
             } else {
                 // Let's deal with classes extending or implementing an iterator
-                var cls = (Class<?>) ((ClassRefSignatureModel) signature).getClassInfo().get();
-                items = List.of(SignatureModel.of(Generics.getExactIterableType(cls)));
+                var cls = (Class<?>) ((ClassRefSignatureModel) signature)
+                        .getClassInfo().get();
+                items = List.of(SignatureModel.of(
+                        (AnnotatedElement) Generics.getExactIterableType(cls)));
             }
         } else if (signature.isOptional()) {
             var typeArguments = ((ClassRefSignatureModel) signature)

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
@@ -183,8 +183,10 @@ public final class TypeSignaturePlugin
                 // Let's deal with classes extending or implementing an iterator
                 var cls = (Class<?>) ((ClassRefSignatureModel) signature)
                         .getClassInfo().get();
-                items = List.of(SignatureModel.of(
-                        (AnnotatedElement) Generics.getExactIterableType(cls)));
+                items = Generics.getExactIterableType(cls)
+                        .map(type -> List
+                                .of(SignatureModel.of((AnnotatedElement) type)))
+                        .orElse(items);
             }
         } else if (signature.isOptional()) {
             var typeArguments = ((ClassRefSignatureModel) signature)

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/iterable/IterableEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/iterable/IterableEndpoint.java
@@ -59,9 +59,11 @@ public class IterableEndpoint {
         }
     }
 
-    public static class SpecializedIterable extends ArrayList<String> {}
+    public static class SpecializedIterable extends ArrayList<String> {
+    }
 
-    public static class SpecializedIterableCustom extends ArrayList<Foo> {}
+    public static class SpecializedIterableCustom extends ArrayList<Foo> {
+    }
 
     public static class Foo {
         public String bar = "bar";

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/iterable/IterableEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/iterable/IterableEndpoint.java
@@ -25,6 +25,14 @@ public class IterableEndpoint {
         return Arrays.asList(new Foo(), new Foo());
     }
 
+    public SpecializedIterable getSpecializedIterable() {
+        return new SpecializedIterable();
+    }
+
+    public SpecializedIterableCustom getSpecializedIterableCustom() {
+        return new SpecializedIterableCustom();
+    }
+
     public List<Foo> getFooList() {
         return new ArrayList<>();
     }
@@ -50,6 +58,10 @@ public class IterableEndpoint {
             return list.iterator();
         }
     }
+
+    public static class SpecializedIterable extends ArrayList<String> {}
+
+    public static class SpecializedIterableCustom extends ArrayList<Foo> {}
 
     public static class Foo {
         public String bar = "bar";

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/com/vaadin/hilla/parser/plugins/backbone/iterable/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/com/vaadin/hilla/parser/plugins/backbone/iterable/openapi.json
@@ -180,6 +180,58 @@
           }
         }
       }
+    },
+    "/IterableEndpoint/getSpecializedIterable": {
+      "post": {
+        "tags": ["IterableEndpoint"],
+        "operationId": "IterableEndpoint_getSpecializedIterable_POST",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "nullable": true,
+                  "items" : {
+                    "type" : "string",
+                    "nullable" : true
+                  },
+                  "x-class-name": "com.vaadin.hilla.parser.plugins.backbone.iterable.IterableEndpoint$SpecializedIterable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/IterableEndpoint/getSpecializedIterableCustom": {
+      "post": {
+        "tags": ["IterableEndpoint"],
+        "operationId": "IterableEndpoint_getSpecializedIterableCustom_POST",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "nullable": true,
+                  "items": {
+                    "nullable": true,
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/com.vaadin.hilla.parser.plugins.backbone.iterable.IterableEndpoint$Foo"
+                      }
+                    ]
+                  },
+                  "x-class-name": "com.vaadin.hilla.parser.plugins.backbone.iterable.IterableEndpoint$SpecializedIterableCustom"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/java/parser-jvm-utils/pom.xml
+++ b/packages/java/parser-jvm-utils/pom.xml
@@ -68,5 +68,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
+        <!-- Small reflection library -->
+        <dependency>
+            <groupId>com.vaadin.external</groupId>
+            <artifactId>gentyref</artifactId>
+            <version>1.2.0.vaadin1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
+++ b/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
@@ -13,29 +13,33 @@ public class Generics {
     /**
      * Returns the exact type of the elements in an iterable class.
      *
-     * @param cls the class to get the exact type of
+     * @param cls
+     *            the class to get the exact type of
      * @return the exact type of the elements in the iterable class
      */
-    public static AnnotatedElement getExactIterableType(Class<?> cls) {
+    public static Type getExactIterableType(Class<?> cls) {
         try {
-            // We can find the exact type by looking at the iterator method return type
+            // We can find the exact type by looking at the iterator method
+            // return type
             var method = cls.getMethod("iterator");
-            var exactReturnType = GenericTypeReflector.getExactReturnType(method, cls);
+            var exactReturnType = GenericTypeReflector
+                    .getExactReturnType(method, cls);
 
             // We know the format of the method, so we can safely cast the type
             if (exactReturnType instanceof ParameterizedType) {
-                Type actualTypeArgument = ((ParameterizedType) exactReturnType).getActualTypeArguments()[0];
-
-                if (actualTypeArgument instanceof AnnotatedElement) {
-                    return (AnnotatedElement) actualTypeArgument;
-                }
+                return ((ParameterizedType) exactReturnType)
+                        .getActualTypeArguments()[0];
             }
 
             // If we get here, there's probably a case we haven't handled
-            throw new RuntimeException("Unable to determine the exact iterable type of " + cls.getName());
+            throw new RuntimeException(
+                    "Unable to determine the exact iterable type of "
+                            + cls.getName());
         } catch (NoSuchMethodException e) {
-            // This should really never happen if the passed class is an Iterable
-            throw new IllegalArgumentException("Class " + cls.getName() + " is not an Iterable");
+            // This should really never happen if the passed class is an
+            // Iterable
+            throw new IllegalArgumentException(
+                    "Class " + cls.getName() + " is not an Iterable");
         }
     }
 }

--- a/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
+++ b/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
@@ -5,6 +5,7 @@ import com.googlecode.gentyref.GenericTypeReflector;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Optional;
 
 /**
  * Utility class for working with generics.
@@ -17,7 +18,7 @@ public class Generics {
      *            the class to get the exact type of
      * @return the exact type of the elements in the iterable class
      */
-    public static Type getExactIterableType(Class<?> cls) {
+    public static Optional<Type> getExactIterableType(Class<?> cls) {
         try {
             // We can find the exact type by looking at the iterator method
             // return type
@@ -27,14 +28,11 @@ public class Generics {
 
             // We know the format of the method, so we can safely cast the type
             if (exactReturnType instanceof ParameterizedType) {
-                return ((ParameterizedType) exactReturnType)
-                        .getActualTypeArguments()[0];
+                return Optional.of( ((ParameterizedType) exactReturnType)
+                        .getActualTypeArguments()[0]);
             }
 
-            // If we get here, there's probably a case we haven't handled
-            throw new RuntimeException(
-                    "Unable to determine the exact iterable type of "
-                            + cls.getName());
+            return Optional.empty();
         } catch (NoSuchMethodException e) {
             // This should really never happen if the passed class is an
             // Iterable

--- a/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
+++ b/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
@@ -1,0 +1,41 @@
+package com.vaadin.hilla.parser.utils;
+
+import com.googlecode.gentyref.GenericTypeReflector;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Utility class for working with generics.
+ */
+public class Generics {
+    /**
+     * Returns the exact type of the elements in an iterable class.
+     *
+     * @param cls the class to get the exact type of
+     * @return the exact type of the elements in the iterable class
+     */
+    public static AnnotatedElement getExactIterableType(Class<?> cls) {
+        try {
+            // We can find the exact type by looking at the iterator method return type
+            var method = cls.getMethod("iterator");
+            var exactReturnType = GenericTypeReflector.getExactReturnType(method, cls);
+
+            // We know the format of the method, so we can safely cast the type
+            if (exactReturnType instanceof ParameterizedType) {
+                Type actualTypeArgument = ((ParameterizedType) exactReturnType).getActualTypeArguments()[0];
+
+                if (actualTypeArgument instanceof AnnotatedElement) {
+                    return (AnnotatedElement) actualTypeArgument;
+                }
+            }
+
+            // If we get here, there's probably a case we haven't handled
+            throw new RuntimeException("Unable to determine the exact iterable type of " + cls.getName());
+        } catch (NoSuchMethodException e) {
+            // This should really never happen if the passed class is an Iterable
+            throw new IllegalArgumentException("Class " + cls.getName() + " is not an Iterable");
+        }
+    }
+}

--- a/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
+++ b/packages/java/parser-jvm-utils/src/main/java/com/vaadin/hilla/parser/utils/Generics.java
@@ -28,7 +28,7 @@ public class Generics {
 
             // We know the format of the method, so we can safely cast the type
             if (exactReturnType instanceof ParameterizedType) {
-                return Optional.of( ((ParameterizedType) exactReturnType)
+                return Optional.of(((ParameterizedType) exactReturnType)
                         .getActualTypeArguments()[0]);
             }
 

--- a/packages/java/parser-jvm-utils/src/main/java/module-info.java
+++ b/packages/java/parser-jvm-utils/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module com.vaadin.hilla.parser.utils {
     requires com.fasterxml.jackson.datatype.jsr310;
     requires com.fasterxml.jackson.datatype.jdk8;
     requires com.fasterxml.jackson.module.paramnames;
+    requires gentyref;
 
     exports com.vaadin.hilla.parser.utils;
     exports com.vaadin.hilla.parser.jackson;


### PR DESCRIPTION
This PR introduces a dependency from `gentyref`. This library is already used in Flow Server and thus nothing new is added to user applications.

Fixes #2391