### PR TITLE
chore: change ClientViewMenuConfig order type

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/records/ClientViewMenuConfig.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/records/ClientViewMenuConfig.java
@@ -8,5 +8,5 @@ package com.vaadin.hilla.route.records;
  * Used for configuring MainLayout navigation items
  *
  */
-public record ClientViewMenuConfig(String title, Long order, String icon, Boolean exclude) {
+public record ClientViewMenuConfig(String title, Double order, String icon, Boolean exclude) {
 }


### PR DESCRIPTION
Changing ClientViewMenuConfig order field type from Long to Double to match with Flow's RouteData and Menu annotation.

Related-to: vaadin/flow/issues/19332