### PR TITLE
chore: fix ts build script

### DIFF
--- a/scripts/prepare/index.ts
+++ b/scripts/prepare/index.ts
@@ -63,7 +63,7 @@ await Promise.all(
 );
 
 const reactComponentsPackageName = '@vaadin/react-components';
-const reactComponentsVersion = versions.react['react-components'].jsVersion ?? '';
+const reactComponentsVersion = versions.core.react['react-components'].jsVersion ?? '';
 const reactComponentsSpec = `${reactComponentsPackageName}@${reactComponentsVersion}`;
 console.log(`Installing "${reactComponentsSpec}".`);
 // The root hoisted version should be updated first, before the workspaces


### PR DESCRIPTION
Versions collected during the build are restructured in a way that there is no immediate `"react"` child for versions (root object) in the [scripts/prepare/index.ts](https://github.com/vaadin/hilla/blob/main/scripts/prepare/index.ts#L66), but under "core" and "vaadin" (core and commercial), which leads to a runtime error during the builds. 
This fixes the issue by reading the version of `react-components` from the `versions.core` instead.