### PR TITLE
fix(file-router): improve the speed of the HMR injection

### DIFF
--- a/packages/ts/file-router/src/vite-plugin.ts
+++ b/packages/ts/file-router/src/vite-plugin.ts
@@ -118,11 +118,11 @@ export default function vitePluginFileSystemRouter({
           // with it. This ensures that the HMR mechanism perceives the
           // configuration as unchanged.
           const injectionPattern = /import\.meta\.hot\.accept[\s\S]+if\s\(!nextExports\)\s+return;/gu;
-          injectionPattern.test(modifiedCode);
-
-          modifiedCode = `${modifiedCode.substring(0, injectionPattern.lastIndex)}${INJECTION}${modifiedCode.substring(
-            injectionPattern.lastIndex,
-          )}`;
+          if (injectionPattern.test(modifiedCode)) {
+            modifiedCode = `${modifiedCode.substring(0, injectionPattern.lastIndex)}${INJECTION}${modifiedCode.substring(
+              injectionPattern.lastIndex,
+            )}`;
+          }
         } else {
           // In production mode, the function name is assigned as name to the function itself to avoid minification
           const functionNames = /export\s+default\s+(?:function\s+)?(\w+)/u.exec(modifiedCode);

--- a/packages/ts/file-router/src/vite-plugin.ts
+++ b/packages/ts/file-router/src/vite-plugin.ts
@@ -51,8 +51,6 @@ export default function vitePluginFileSystemRouter({
   extensions = ['.tsx', '.jsx'],
   isDevMode = false,
 }: PluginOptions = {}): Plugin {
-  const hmrInjectionPattern = /(?<=import\.meta\.hot\.accept[\s\S]+)if\s\(!nextExports\)\s+return;/u;
-
   let _viewsDir: URL;
   let _outDir: URL;
   let _logger: Logger;
@@ -119,11 +117,12 @@ export default function vitePluginFileSystemRouter({
           // replacing any newly created configuration objects (`nextExports.config`)
           // with it. This ensures that the HMR mechanism perceives the
           // configuration as unchanged.
-          const injectionIndex = modifiedCode.lastIndexOf(
-            'if (!nextExports) return;',
-            modifiedCode.indexOf('import.meta.hot.accept'),
-          );
-          modifiedCode = `${modifiedCode.substring(0, injectionIndex)}${INJECTION}${modifiedCode.substring(injectionIndex)}`;
+          const injectionPattern = /import\.meta\.hot\.accept[\s\S]if\s\(!nextExports\)\s+return;/gu;
+          injectionPattern.test(modifiedCode);
+
+          modifiedCode = `${modifiedCode.substring(0, injectionPattern.lastIndex)}${INJECTION}${modifiedCode.substring(
+            injectionPattern.lastIndex,
+          )}`;
         } else {
           // In production mode, the function name is assigned as name to the function itself to avoid minification
           const functionNames = /export\s+default\s+(?:function\s+)?(\w+)/u.exec(modifiedCode);

--- a/packages/ts/file-router/src/vite-plugin.ts
+++ b/packages/ts/file-router/src/vite-plugin.ts
@@ -117,7 +117,7 @@ export default function vitePluginFileSystemRouter({
           // replacing any newly created configuration objects (`nextExports.config`)
           // with it. This ensures that the HMR mechanism perceives the
           // configuration as unchanged.
-          const injectionPattern = /import\.meta\.hot\.accept[\s\S]if\s\(!nextExports\)\s+return;/gu;
+          const injectionPattern = /import\.meta\.hot\.accept[\s\S]+if\s\(!nextExports\)\s+return;/gu;
           injectionPattern.test(modifiedCode);
 
           modifiedCode = `${modifiedCode.substring(0, injectionPattern.lastIndex)}${INJECTION}${modifiedCode.substring(


### PR DESCRIPTION
Fixes #2410.

It looks like the lookbehind feature in `RegExp` is extremely slow. I replaced it with the regular `RegExp`, and according to my measurements, it is almost instant.