### PR TITLE
fix: support route parameters in menu

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListener.java
@@ -191,13 +191,16 @@ public class RouteUnifyingIndexHtmlRequestListener
             final String targetUrl = serverView.getTemplate();
             if (targetUrl != null) {
                 final String url;
-                if (!serverView.getRouteParameters().isEmpty()) {
+                if (serverView.getRouteParameters() != null
+                        && !serverView.getRouteParameters().isEmpty()) {
                     String editUrl = "/" + targetUrl;
                     excludeFromMenu = serverView.getRouteParameters().values()
                             .stream().anyMatch(param -> !param.getTemplate()
                                     .contains("?"));
                     for (RouteParameterData param : serverView
-                            .getRouteParameters().values()) {
+                            .getRouteParameters().values().stream()
+                            .filter(param -> param.getTemplate().contains("?"))
+                            .toList()) {
                         editUrl = editUrl.replace("/" + param.getTemplate(),
                                 "");
                     }

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListenerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListenerTest.java
@@ -352,8 +352,7 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
         MatcherAssert.assertThat(
                 views.get("//:___userId/edit").routeParameters(),
                 Matchers.is(Map.of(":___userId", RouteParamType.REQUIRED)));
-        MatcherAssert.assertThat(
-                views.get("/comments/:___commentId?").routeParameters(),
+        MatcherAssert.assertThat(views.get("/comments").routeParameters(),
                 Matchers.is(Map.of(":___commentId?", RouteParamType.OPTIONAL)));
 
     }

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-admin.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-admin.json
@@ -75,11 +75,11 @@
       ":___userId": "req"
     }
   },
-  "/comments/:___commentId?": {
+  "/comments": {
     "title": "RouteTarget",
     "rolesAllowed": null,
     "requiresLogin": false,
-    "route": "/comments/:___commentId?",
+    "route": "/comments",
     "lazy": false,
     "register": false,
     "menu": null,

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-anonymous.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-anonymous.json
@@ -53,11 +53,11 @@
       ":___userId": "req"
     }
   },
-  "/comments/:___commentId?": {
+  "/comments": {
     "title": "RouteTarget",
     "rolesAllowed": null,
     "requiresLogin": false,
-    "route": "/comments/:___commentId?",
+    "route": "/comments",
     "lazy": false,
     "register": false,
     "menu": null,

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-user.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-user.json
@@ -63,11 +63,11 @@
       ":___userId": "req"
     }
   },
-  "/comments/:___commentId?": {
+  "/comments": {
     "title": "RouteTarget",
     "rolesAllowed": null,
     "requiresLogin": false,
-    "route": "/comments/:___commentId?",
+    "route": "/comments",
     "lazy": false,
     "register": false,
     "menu": null,


### PR DESCRIPTION
Fixes server menu item url for routes with route parameters. Routes with only required parameters are excluded automatically from the menu. Fixes vaadin/flow/issues/19392 for 24.4.

RelatedTo: vaadin/flow/issues/19392
