### PR TITLE
fix: support wildcard route parameter in menu

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListener.java
@@ -195,11 +195,14 @@ public class RouteUnifyingIndexHtmlRequestListener
                         && !serverView.getRouteParameters().isEmpty()) {
                     String editUrl = "/" + targetUrl;
                     excludeFromMenu = serverView.getRouteParameters().values()
-                            .stream().anyMatch(param -> !param.getTemplate()
-                                    .contains("?"));
+                            .stream()
+                            .anyMatch(param -> !param.getTemplate()
+                                    .contains("?")
+                                    && !param.getTemplate().contains("*"));
                     for (RouteParameterData param : serverView
                             .getRouteParameters().values().stream()
-                            .filter(param -> param.getTemplate().contains("?"))
+                            .filter(param -> param.getTemplate().contains("?")
+                                    || param.getTemplate().contains("*"))
                             .toList()) {
                         editUrl = editUrl.replace("/" + param.getTemplate(),
                                 "");

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListenerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/route/RouteUnifyingIndexHtmlRequestListenerTest.java
@@ -346,8 +346,7 @@ public class RouteUnifyingIndexHtmlRequestListenerTest {
                 Matchers.is("RouteTarget"));
         MatcherAssert.assertThat(views.get("/bar").route(),
                 Matchers.is("/bar"));
-        MatcherAssert.assertThat(
-                views.get("/wildcard/:___wildcard*").routeParameters(),
+        MatcherAssert.assertThat(views.get("/wildcard").routeParameters(),
                 Matchers.is(Map.of(":___wildcard*", RouteParamType.WILDCARD)));
         MatcherAssert.assertThat(
                 views.get("//:___userId/edit").routeParameters(),

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-admin.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-admin.json
@@ -51,11 +51,11 @@
     "menu": null,
     "params": {}
   },
-  "/wildcard/:___wildcard*": {
+  "/wildcard": {
     "title": "RouteTarget",
     "rolesAllowed": null,
     "requiresLogin": false,
-    "route": "/wildcard/:___wildcard*",
+    "route": "/wildcard",
     "lazy": false,
     "register": false,
     "menu": null,

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-anonymous.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-anonymous.json
@@ -29,11 +29,11 @@
     "menu": null,
     "params": {}
   },
-  "/wildcard/:___wildcard*": {
+  "/wildcard": {
     "title": "RouteTarget",
     "rolesAllowed": null,
     "requiresLogin": false,
-    "route": "/wildcard/:___wildcard*",
+    "route": "/wildcard",
     "lazy": false,
     "register": false,
     "menu": null,

--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-user.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/available-views-user.json
@@ -39,11 +39,11 @@
     "menu": null,
     "params": {}
   },
-  "/wildcard/:___wildcard*": {
+  "/wildcard": {
     "title": "RouteTarget",
     "rolesAllowed": null,
     "requiresLogin": false,
-    "route": "/wildcard/:___wildcard*",
+    "route": "/wildcard",
     "lazy": false,
     "register": false,
     "menu": null,


### PR DESCRIPTION
Fixes server menu item url for routes with route parameter with a wildcard like (route/:param*).

RelatedTo: vaadin/flow/issues/19392
