### PR TITLE
fix: Do not skip endpoint registration if there are no custom types

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/OpenAPIUtil.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/OpenAPIUtil.java
@@ -104,30 +104,30 @@ public class OpenAPIUtil {
     public static Set<String> findOpenApiClasses(String openApiAsText)
             throws IOException {
         JsonNode openApi = new ObjectMapper().readTree(openApiAsText);
-        if (!openApi.has("components")) {
-            return Collections.emptySet();
-        }
 
         Set<String> types = new HashSet<>();
 
         // Endpoints
-        ArrayNode tags = (ArrayNode) openApi.get("tags");
+        if (openApi.has("tags")) {
+            ArrayNode tags = (ArrayNode) openApi.get("tags");
 
-        if (tags != null) {
-            tags.forEach(nameAndClass -> {
-                types.add(nameAndClass.get("x-class-name").asText());
-            });
+            if (tags != null) {
+                tags.forEach(nameAndClass -> {
+                    types.add(nameAndClass.get("x-class-name").asText());
+                });
+            }
         }
 
         // Parameters and return types
-        ObjectNode schemas = (ObjectNode) openApi.get("components")
-                .get("schemas");
-        if (schemas != null) {
-            schemas.fieldNames().forEachRemaining(type -> {
-                types.add(type);
-            });
+        if (openApi.has("components")) {
+            ObjectNode schemas = (ObjectNode) openApi.get("components")
+                    .get("schemas");
+            if (schemas != null) {
+                schemas.fieldNames().forEachRemaining(type -> {
+                    types.add(type);
+                });
+            }
         }
-
         return types;
 
     }

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/OpenAPIUtilTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/OpenAPIUtilTest.java
@@ -14,6 +14,13 @@ public class OpenAPIUtilTest {
     @Test
     public void emptySchemaReturnsNoComponents() throws IOException {
         Assert.assertEquals(Collections.emptySet(),
+                parse("openapi-noendpoints.json"));
+    }
+
+    @Test
+    public void noComponentsReturnEndpointTypes() throws IOException {
+        Assert.assertEquals(Set.of(
+                "com.example.application.endpoints.helloreact.HelloReactEndpoint"),
                 parse("openapi-nocustomtypes.json"));
     }
 

--- a/packages/java/endpoint/src/test/resources/com/vaadin/hilla/openapi-noendpoints.json
+++ b/packages/java/endpoint/src/test/resources/com/vaadin/hilla/openapi-noendpoints.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Hilla Application",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080/connect",
+      "description": "Hilla Backend"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #2461
