### PR TITLE
fix!: change search endpoint log level to debug

### DIFF
--- a/packages/java/parser-jvm-core/src/main/java/com/vaadin/hilla/parser/core/Parser.java
+++ b/packages/java/parser-jvm-core/src/main/java/com/vaadin/hilla/parser/core/Parser.java
@@ -313,7 +313,7 @@ public final class Parser {
 
         // Packages explicitly defined in pom.xml have priority
         if (packages != null && !packages.isEmpty()) {
-            logger.info("Search for endpoints in packages {}", packages);
+            logger.debug("Search for endpoints in packages {}", packages);
             classGraph.acceptPackages(packages.toArray(String[]::new));
             classGraph.overrideClasspath(config.getClassPathElements());
         }
@@ -323,7 +323,7 @@ public final class Parser {
             var buildDirectories = config.getClassPathElements().stream()
                     .filter(e -> !e.endsWith(".jar"))
                     .collect(Collectors.toList());
-            logger.info("Search for endpoints in directories {}",
+            logger.debug("Search for endpoints in directories {}",
                     buildDirectories);
             classGraph.overrideClasspath(buildDirectories);
         }


### PR DESCRIPTION
## Description

In 24.4 the mechanism for hot-reloading the endpoint related changes is either based on HotSwapAgent or through Polling the changes, and when using polling by enabling the `hilla.endpoint.hot-reload` this INFO level log is annoying for the developers, since in most of the projects the endpoints are right there in the project and that log is not helping very much, and in other cases when there's a problem, the log level can easily be changed to debug to see this.
Based on internal discussion there is no need to make the Parser's code unnecessarily complicated just to have different log levels conditionally.

Fixes #2476 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
