### PR TITLE
chore: add parent project for hilla-bom (24.4)

### DIFF
--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -4,6 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>hilla-project</artifactId>
+        <version>24.4-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+    
     <groupId>com.vaadin</groupId>
     <artifactId>hilla-bom</artifactId>
     <packaging>pom</packaging>

--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -10,13 +10,11 @@
         <version>24.4-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
-    
-    <groupId>com.vaadin</groupId>
+
     <artifactId>hilla-bom</artifactId>
     <packaging>pom</packaging>
     <name>Hilla Platform (Bill of Materials)</name>
     <description>Hilla Platform (Bill of Materials)</description>
-    <version>24.4-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
     <properties>

--- a/packages/java/hilla/pom.xml
+++ b/packages/java/hilla/pom.xml
@@ -15,7 +15,6 @@
     <packaging>jar</packaging>
     <name>Hilla Platform</name>
     <description>Hilla Platform</description>
-    <version>24.4-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
     <properties>


### PR DESCRIPTION
this seems has been missing from the beginning of our project. without it, there is missing deploy settings to maven central

