### PR TITLE
fix: Report usage stats when isReactEnabled=false

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/startup/RouteUnifyingServiceInitListener.java
@@ -84,6 +84,7 @@ public class RouteUnifyingServiceInitListener
                 .getDeploymentConfiguration();
         LOGGER.debug("deploymentConfiguration.isReactEnabled() = {}",
                 deploymentConfiguration.isReactEnabled());
+        boolean hasHillaFsRoute = false;
         if (deploymentConfiguration.isReactEnabled()) {
             var routeUnifyingIndexHtmlRequestListener = new RouteUnifyingIndexHtmlRequestListener(
                     clientRouteRegistry, deploymentConfiguration, routeUtil,
@@ -102,10 +103,8 @@ public class RouteUnifyingServiceInitListener
             clientRouteRegistry.registerClientRoutes(deploymentConfiguration,
                     LocalDateTime.now());
 
-            boolean hasHillaFsRoute = !clientRouteRegistry.getAllRoutes()
-                    .isEmpty();
-            HillaStats.reportGenericHasFeatures(event.getSource(),
-                    hasHillaFsRoute);
+            hasHillaFsRoute = !clientRouteRegistry.getAllRoutes().isEmpty();
         }
+        HillaStats.reportGenericHasFeatures(event.getSource(), hasHillaFsRoute);
     }
 }


### PR DESCRIPTION
When `isReactEnabled=false` the stats reporting method `HillaStats.reportGenericHasFeatures` wasn't invoked making Lit stats not reported at all.

Related-to https://github.com/vaadin/platform/issues/6488