### PR TITLE
Revert "chore: add parent project for hilla-bom"

### DIFF
--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -4,17 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.vaadin</groupId>
-        <artifactId>hilla-project</artifactId>
-        <version>24.5-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
-    </parent>
-
+    <groupId>com.vaadin</groupId>
     <artifactId>hilla-bom</artifactId>
     <packaging>pom</packaging>
     <name>Hilla Platform (Bill of Materials)</name>
     <description>Hilla Platform (Bill of Materials)</description>
+    <version>24.5-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
     <properties>

--- a/packages/java/hilla/pom.xml
+++ b/packages/java/hilla/pom.xml
@@ -15,6 +15,7 @@
     <packaging>jar</packaging>
     <name>Hilla Platform</name>
     <description>Hilla Platform</description>
+    <version>24.5-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
     <properties>


### PR DESCRIPTION
Reverts vaadin/hilla#2532

A bom cannot use a parent with dependencyManagement for only Hilla