### PR TITLE
chore: use vaadin-parent 2.2.1 as parent for hilla-bom

### DIFF
--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>hilla-bom</artifactId>
     <packaging>pom</packaging>
     <name>Hilla Platform (Bill of Materials)</name>
+    <version>24.5-SNAPSHOT</version>
     <description>Hilla Platform (Bill of Materials)</description>
     <url>https://hilla.dev</url>
 

--- a/packages/java/hilla-bom/pom.xml
+++ b/packages/java/hilla-bom/pom.xml
@@ -6,9 +6,8 @@
 
     <parent>
         <groupId>com.vaadin</groupId>
-        <artifactId>hilla-project</artifactId>
-        <version>24.5-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
+        <artifactId>vaadin-parent</artifactId>
+        <version>2.2.1</version>
     </parent>
 
     <artifactId>hilla-bom</artifactId>


### PR DESCRIPTION
using hilla-project brings the `<dependencyManangement>` from parent, which is not the one want