### PR TITLE
chore: upgrade commons-io to 2.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.13.0</version>
+        <version>2.16.1</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
```
[ERROR] +-com.vaadin:vaadin:jar:24.4-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-internal:jar:24.4-SNAPSHOT:compile
[ERROR]     +-com.vaadin:vaadin-core-internal:jar:24.4-SNAPSHOT:compile
[ERROR]       +-com.vaadin:flow-server:jar:24.4-SNAPSHOT:compile
[ERROR]         +-commons-io:commons-io:jar:2.16.1:compile

[ERROR] and
[ERROR] +-com.vaadin:vaadin:jar:24.4-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spring-boot-starter:jar:24.4-SNAPSHOT:compile
[ERROR]     +-com.vaadin:hilla:jar:24.4.1:compile
[ERROR]       +-com.vaadin:hilla-endpoint:jar:24.4.1:compile
[ERROR]         +-commons-io:commons-io:jar:2.13.0:compile
```