### PR TITLE
fix(file-router): preserve empty children for layout routes

### DIFF
--- a/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
+++ b/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
@@ -52,7 +52,7 @@ function createImport(mod: string, file: string): ImportDeclaration {
  */
 function createRouteData(path: string, mod: string | undefined, children?: readonly CallExpression[]): CallExpression {
   return template(
-    `const route = createRoute("${path}"${mod ? `, ${mod}` : ''}${children && children.length > 0 ? `, CHILDREN` : ''})`,
+    `const route = createRoute("${path}"${mod ? `, ${mod}` : ''}${children ? `, CHILDREN` : ''})`,
     ([statement]) => (statement as VariableStatement).declarationList.declarations[0].initializer as CallExpression,
     [
       transformer((node) =>

--- a/packages/ts/file-router/test/utils.tsx
+++ b/packages/ts/file-router/test/utils.tsx
@@ -59,6 +59,7 @@ export async function createTestingRouteFiles(dir: URL): Promise<void> {
     mkdir(new URL('empty-dir/empty-file-subdir/', dir), { recursive: true }),
     mkdir(new URL('test', dir), { recursive: true }),
     mkdir(new URL('test/issue-002378/{requiredParam}', dir), { recursive: true }),
+    mkdir(new URL('test/issue-002571-empty-layout/', dir), { recursive: true }),
   ]);
   await Promise.all([
     appendFile(
@@ -109,6 +110,11 @@ export async function createTestingRouteFiles(dir: URL): Promise<void> {
       new URL('test/issue-002378/{requiredParam}/edit.tsx', dir),
       'export default function Issue002378RequiredParam() {};',
     ),
+    appendFile(
+      new URL('test/issue-002571-empty-layout/@layout.tsx', dir),
+      'export default function Issue002571EmptyLayout() {};',
+    ),
+    // this file has no title configured, so it must be derived from its file name
     appendFile(
       new URL('test/issue-002879-config-below.tsx', dir),
       'export default function Issue002879ConfigBelow() {};\nexport const config = { title: "Config Below" };',
@@ -191,6 +197,11 @@ export function createTestingRouteMeta(dir: URL): readonly RouteMeta[] {
               ],
             },
           ],
+        },
+        {
+          path: 'issue-002571-empty-layout',
+          layout: new URL('test/issue-002571-empty-layout/@layout.tsx', dir),
+          children: [],
         },
         {
           path: 'issue-002879-config-below',

--- a/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
@@ -38,7 +38,8 @@ import * as Layout8 from "../views/profile/friends/@layout.js";
 import * as Page10 from "../views/test/{{optional}}.js";
 import * as Page11 from "../views/test/{...wildcard}.js";
 import * as Page12 from "../views/test/issue-002378/{requiredParam}/edit.js";
-import * as Page15 from "../views/test/issue-002879-config-below.js";
+import * as Layout15 from "../views/test/issue-002571-empty-layout/@layout.js";
+import * as Page16 from "../views/test/issue-002879-config-below.js";
 const routes: readonly AgnosticRoute[] = [
     createRoute("nameToReplace", Page0),
     createRoute("profile", [
@@ -62,7 +63,8 @@ const routes: readonly AgnosticRoute[] = [
                 createRoute("edit", Page12)
             ])
         ]),
-        createRoute("issue-002879-config-below", Page15)
+        createRoute("issue-002571-empty-layout", Layout15, []),
+        createRoute("issue-002879-config-below", Page16)
     ])
 ];
 export default routes;

--- a/packages/ts/file-router/test/vite-plugin/createViewConfigJson.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/createViewConfigJson.spec.ts
@@ -100,6 +100,7 @@ describe('@vaadin/hilla-file-router', () => {
                     },
                   ],
                 },
+                { route: 'issue-002571-empty-layout', params: {}, title: 'Issue002571 Empty Layout', children: [] },
                 { route: 'issue-002879-config-below', title: 'Config Below', params: {} },
               ],
             },


### PR DESCRIPTION
Fixes #2571