### PR TITLE
chore: fix `tsx` not stopping on breakpoints

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,13 +1,15 @@
-const { join } = require('node:path');
+const {pathToFileURL} = require("node:url");
 const isCI = !!process.env.CI;
 
 const karmaMochaConfig = {
   forbidOnly: isCI,
 };
 
+const root = pathToFileURL(`${__dirname}/`);
+
 module.exports = {
   extensions: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs', 'tsx'],
-  import: join(__dirname, 'scripts/hooks.js'),
+  import: new URL('scripts/hooks.js', root),
   exit: true,
   karmaMochaConfig,
   ...karmaMochaConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "prettier": "^3.2.5",
         "simple-git-hooks": "^2.9.0",
         "sync-request": "^6.1.0",
-        "tsx": "4.7.1",
+        "tsx": "^4.16.2",
         "typescript": "5.5.2",
         "vite": "5.3.1"
       },
@@ -15798,13 +15798,14 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.1.tgz",
-      "integrity": "sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.16.2.tgz",
+      "integrity": "sha512-C1uWweJDgdtX2x600HjaFaucXTilT7tgUZHbOE4+ypskZ1OP8CRCSDkCxG6Vya9EwaFIVagWwpaVAn5wzypaqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.19.10",
-        "get-tsconfig": "^4.7.2"
+        "esbuild": "~0.21.5",
+        "get-tsconfig": "^4.7.5"
       },
       "bin": {
         "tsx": "dist/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prettier": "^3.2.5",
     "simple-git-hooks": "^2.9.0",
     "sync-request": "^6.1.0",
-    "tsx": "4.7.1",
+    "tsx": "^4.16.2",
     "typescript": "5.5.2",
     "vite": "5.3.1"
   }

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -3,7 +3,9 @@ import { MessageChannel } from 'node:worker_threads';
 
 function createMessageChannel(
   callback = (msg) => {
-    console.log(msg);
+    if (typeof msg === 'string') {
+      console.log(msg);
+    }
   },
 ) {
   const { port1, port2 } = new MessageChannel();


### PR DESCRIPTION
Update `tsx` to the version with privatenumber/tsx#506 fixed