### PR TITLE
feat(maven-plugin) add m2e metadata

### DIFF
--- a/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>validate</goal>
+          <goal>build-frontend</goal>
+          <goal>configure</goal>
+          <goal>generate</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>prepare-frontend</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>false</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -7,6 +7,7 @@
           <goal>validate</goal>
           <goal>build-frontend</goal>
           <goal>configure</goal>
+          <goal>generate</goal>
         </goals>
       </pluginExecutionFilter>
       <action>
@@ -23,19 +24,6 @@
         <execute>
           <runOnIncremental>false</runOnIncremental>
           <runOnConfiguration>true</runOnConfiguration>
-        </execute>
-      </action>
-    </pluginExecution>
-    <pluginExecution>
-      <pluginExecutionFilter>
-        <goals>
-          <goal>generate</goal>
-        </goals>
-      </pluginExecutionFilter>
-      <action>
-        <execute>
-          <runOnIncremental>true</runOnIncremental>
-          <runOnConfiguration>false</runOnConfiguration>
         </execute>
       </action>
     </pluginExecution>

--- a/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,9 +5,9 @@
       <pluginExecutionFilter>
         <goals>
           <goal>validate</goal>
+          <goal>prepare-frontend</goal>
           <goal>build-frontend</goal>
           <goal>configure</goal>
-          <goal>generate</goal>
         </goals>
       </pluginExecutionFilter>
       <action>
@@ -17,7 +17,7 @@
     <pluginExecution>
       <pluginExecutionFilter>
         <goals>
-          <goal>prepare-frontend</goal>
+          <goal>generate</goal>
         </goals>
       </pluginExecutionFilter>
       <action>

--- a/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/packages/java/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,7 +5,6 @@
       <pluginExecutionFilter>
         <goals>
           <goal>validate</goal>
-          <goal>prepare-frontend</goal>
           <goal>build-frontend</goal>
           <goal>configure</goal>
         </goals>
@@ -17,13 +16,26 @@
     <pluginExecution>
       <pluginExecutionFilter>
         <goals>
-          <goal>generate</goal>
+          <goal>prepare-frontend</goal>
         </goals>
       </pluginExecutionFilter>
       <action>
         <execute>
           <runOnIncremental>false</runOnIncremental>
           <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generate</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+          <runOnConfiguration>false</runOnConfiguration>
         </execute>
       </action>
     </pluginExecution>


### PR DESCRIPTION
Adds `lifecycle-mapping-metadata.xml` like in Flow plugin, but using `generate` as incremental goal.

Should fix both https://github.com/vaadin/platform/issues/6562 and https://github.com/vaadin/platform/issues/6590.