### PR TITLE
chore: upgrade flow to fix atmosphere runtime convergence

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.vaadin.external.atmosphere</groupId>
             <artifactId>atmosphere-runtime</artifactId>
-            <version>3.0.5.slf4jvaadin1</version>
+            <version>${atmosphere.runtime.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.google</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <jackson.version>2.15.4</jackson.version>
     <junit.version>5.10.1</junit.version>
     <mockito.version>4.5.0</mockito.version>
-    <flow.version>24.3.8</flow.version>
+    <flow.version>24.3.14</flow.version>
     <slf4j.version>2.0.9</slf4j.version>
     <spring.boot.version>3.2.4</spring.boot.version>
     <testbench.version>9.2.2</testbench.version>
@@ -92,6 +92,7 @@
     <jaxb.version>4.0.4</jaxb.version>
     <github.javaparser.core.version>3.25.6</github.javaparser.core.version>
     <jetty.version>12.0.3</jetty.version>
+    <atmosphere.runtime.version>3.0.5.slf4jvaadin1</atmosphere.runtime.version>
   </properties>
 
   <organization>


### PR DESCRIPTION
This is to fix the dependency convergence error for atmosphere runtime version conflict between Flow and Hilla.