### PR TITLE
refactor: use nanoid instead of crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18913,7 +18913,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",
-        "@vaadin/hilla-frontend": "24.5.0-alpha7"
+        "@vaadin/hilla-frontend": "24.5.0-alpha7",
+        "nanoid": "^5.0.7"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
@@ -18967,6 +18968,23 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "packages/ts/react-signals/node_modules/nanoid": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     }
   }

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/NumberSignal.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/NumberSignal.java
@@ -123,8 +123,8 @@ public class NumberSignal {
     }
 
     private ObjectNode createSnapshot() {
-        var snapshot = new StateEvent<>(this.id, StateEvent.EventType.SNAPSHOT,
-                this.value);
+        var snapshot = new StateEvent<>(this.id.toString(),
+                StateEvent.EventType.SNAPSHOT, this.value);
         return snapshot.toJson();
     }
 

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/SignalsRegistry.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/SignalsRegistry.java
@@ -20,7 +20,7 @@ public class SignalsRegistry {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(SignalsRegistry.class);
     private final Map<UUID, NumberSignal> signals = new WeakHashMap<>();
-    private final Map<UUID, UUID> clientSignalToSignalMapping = new HashMap<>();
+    private final Map<String, UUID> clientSignalToSignalMapping = new HashMap<>();
 
     /**
      * Registers a signal instance and creates an association between the
@@ -37,7 +37,7 @@ public class SignalsRegistry {
      * @throws NullPointerException
      *             if {@code clientSignalId} or {@code signal} is null
      */
-    public synchronized void register(UUID clientSignalId,
+    public synchronized void register(String clientSignalId,
             NumberSignal signal) {
         Objects.requireNonNull(clientSignalId,
                 "Client signal id must not be null");
@@ -64,7 +64,7 @@ public class SignalsRegistry {
      * @throws NullPointerException
      *             if {@code clientSignalId} is null
      */
-    public synchronized NumberSignal get(UUID clientSignalId) {
+    public synchronized NumberSignal get(String clientSignalId) {
         Objects.requireNonNull(clientSignalId,
                 "Client signal id must not be null");
         UUID signalId = clientSignalToSignalMapping.get(clientSignalId);
@@ -103,7 +103,7 @@ public class SignalsRegistry {
      * @throws NullPointerException
      *             if {@code signalId} is null
      */
-    public synchronized boolean contains(UUID clientSignalId) {
+    public synchronized boolean contains(String clientSignalId) {
         Objects.requireNonNull(clientSignalId,
                 "Client signal id must not be null");
         if (!clientSignalToSignalMapping.containsKey(clientSignalId)) {
@@ -148,7 +148,7 @@ public class SignalsRegistry {
      *             if {@code clientSignalId} is null
      */
     public synchronized void removeClientSignalToSignalMapping(
-            UUID clientSignalId) {
+            String clientSignalId) {
         Objects.requireNonNull(clientSignalId,
                 "Client signal id to remove must not be null");
         clientSignalToSignalMapping.remove(clientSignalId);
@@ -194,7 +194,7 @@ public class SignalsRegistry {
      * @throws NullPointerException
      *             if {@code signalId} is null
      */
-    public synchronized Set<UUID> getAllClientSignalIdsFor(UUID signalId) {
+    public synchronized Set<String> getAllClientSignalIdsFor(UUID signalId) {
         Objects.requireNonNull(signalId, "Signal id must not be null");
         if (!signals.containsKey(signalId)) {
             return Set.of();

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/StateEvent.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/StateEvent.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * A utility class for representing state events out of an ObjectNode. This
@@ -52,7 +51,7 @@ public class StateEvent<T> {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final UUID id;
+    private final String id;
     private final EventType eventType;
     private final T value;
 
@@ -66,7 +65,7 @@ public class StateEvent<T> {
      * @param value
      *            The value of the event.
      */
-    public StateEvent(UUID id, EventType eventType, T value) {
+    public StateEvent(String id, EventType eventType, T value) {
         this.id = id;
         this.eventType = eventType;
         this.value = value;
@@ -79,7 +78,7 @@ public class StateEvent<T> {
      *            The JSON representation of the event.
      */
     public StateEvent(ObjectNode json) {
-        this.id = UUID.fromString(json.get(Field.ID).asText());
+        this.id = json.get(Field.ID).asText();
         this.eventType = extractEventType(json);
         JsonNode value = json.get(Field.VALUE);
         if (value.isTextual()) {
@@ -132,7 +131,7 @@ public class StateEvent<T> {
      */
     public ObjectNode toJson() {
         ObjectNode json = mapper.createObjectNode();
-        json.put(Field.ID, id.toString());
+        json.put(Field.ID, id);
         json.put(Field.TYPE, eventType.name().toLowerCase());
         json.set(Field.VALUE, getValueAsJson());
         return json;
@@ -143,7 +142,7 @@ public class StateEvent<T> {
      *
      * @return The unique identifier of the event.
      */
-    public UUID getId() {
+    public String getId() {
         return id;
     }
 
@@ -167,15 +166,17 @@ public class StateEvent<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (!(o instanceof StateEvent<?> that))
+        }
+        if (!(o instanceof StateEvent<?> that)) {
             return false;
+        }
         return Objects.equals(getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getId());
+        return Objects.hash(getId());
     }
 }

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/handler/SignalsHandler.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/handler/SignalsHandler.java
@@ -8,8 +8,6 @@ import com.vaadin.hilla.signals.NumberSignal;
 import com.vaadin.hilla.signals.core.SignalsRegistry;
 import reactor.core.publisher.Flux;
 
-import java.util.UUID;
-
 /**
  * Handler Endpoint for Fullstack Signals' subscription and update events.
  */
@@ -36,7 +34,7 @@ public class SignalsHandler {
      * @return a Flux of JSON events
      */
     public Flux<ObjectNode> subscribe(String signalProviderEndpointMethod,
-            UUID clientSignalId) {
+            String clientSignalId) {
         try {
             if (registry.contains(clientSignalId)) {
                 return signalAsFlux(clientSignalId);
@@ -54,7 +52,7 @@ public class SignalsHandler {
         }
     }
 
-    private Flux<ObjectNode> signalAsFlux(UUID clientSignalId) {
+    private Flux<ObjectNode> signalAsFlux(String clientSignalId) {
         return registry.get(clientSignalId).subscribe();
     }
 
@@ -66,7 +64,7 @@ public class SignalsHandler {
      * @param event
      *            the event to update with
      */
-    public void update(UUID clientSignalId, ObjectNode event) {
+    public void update(String clientSignalId, ObjectNode event) {
         if (!registry.contains(clientSignalId)) {
             throw new IllegalStateException(String.format(
                     "Signal not found for client signal: %s", clientSignalId));

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/NumberSignalTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/NumberSignalTest.java
@@ -103,7 +103,7 @@ public class NumberSignalTest {
     }
 
     private ObjectNode createSetEvent(String value) {
-        var setEvent = new StateEvent<>(UUID.randomUUID(),
+        var setEvent = new StateEvent<>(UUID.randomUUID().toString(),
                 StateEvent.EventType.SET, Double.parseDouble(value));
         return setEvent.toJson();
     }

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/SignalsRegistryTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/SignalsRegistryTest.java
@@ -20,8 +20,8 @@ public class SignalsRegistryTest {
 
         assertThrows(NullPointerException.class,
                 () -> signalsRegistry.register(null, new NumberSignal()));
-        assertThrows(NullPointerException.class,
-                () -> signalsRegistry.register(UUID.randomUUID(), null));
+        assertThrows(NullPointerException.class, () -> signalsRegistry
+                .register(UUID.randomUUID().toString(), null));
         assertThrows(NullPointerException.class,
                 () -> signalsRegistry.register(null, null));
     }
@@ -31,7 +31,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -50,7 +50,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -59,7 +59,7 @@ public class SignalsRegistryTest {
         assertEquals(1, signalsRegistry.getAllClientSubscriptionsSize());
         assertEquals(signal, signalsRegistry.get(clientSignalId));
 
-        UUID anotherClientSignalId = UUID.randomUUID();
+        String anotherClientSignalId = UUID.randomUUID().toString();
         signalsRegistry.register(anotherClientSignalId, signal);
 
         assertEquals(1, signalsRegistry.size());
@@ -81,7 +81,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -90,7 +90,7 @@ public class SignalsRegistryTest {
         assertEquals(1, signalsRegistry.getAllClientSubscriptionsSize());
         assertEquals(signal, signalsRegistry.get(clientSignalId));
 
-        UUID anotherClientSignalId = UUID.randomUUID();
+        String anotherClientSignalId = UUID.randomUUID().toString();
         assertNull(signalsRegistry.get(anotherClientSignalId));
     }
 
@@ -106,7 +106,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -130,7 +130,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -146,9 +146,9 @@ public class SignalsRegistryTest {
     public void when_signalIsNotRegistered_contains_returnsFalse() {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
-        assertFalse(signalsRegistry.contains(UUID.randomUUID()));
+        assertFalse(signalsRegistry.contains(UUID.randomUUID().toString()));
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -157,7 +157,7 @@ public class SignalsRegistryTest {
         assertEquals(1, signalsRegistry.getAllClientSubscriptionsSize());
         assertEquals(signal, signalsRegistry.get(clientSignalId));
 
-        assertFalse(signalsRegistry.contains(UUID.randomUUID()));
+        assertFalse(signalsRegistry.contains(UUID.randomUUID().toString()));
     }
 
     @Test
@@ -165,7 +165,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -187,7 +187,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);
@@ -211,7 +211,7 @@ public class SignalsRegistryTest {
         SignalsRegistry signalsRegistry = new SignalsRegistry();
         assertTrue(signalsRegistry.isEmpty());
 
-        UUID clientSignalId = UUID.randomUUID();
+        String clientSignalId = UUID.randomUUID().toString();
         NumberSignal signal = new NumberSignal();
 
         signalsRegistry.register(clientSignalId, signal);

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/StateEventTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/StateEventTest.java
@@ -16,7 +16,7 @@ public class StateEventTest {
 
     @Test
     public void constructor_withParameters_shouldCreateStateEvent() {
-        UUID id = UUID.randomUUID();
+        String id = UUID.randomUUID().toString();
         StateEvent.EventType eventType = StateEvent.EventType.SET;
         String value = "testValue";
 
@@ -29,32 +29,32 @@ public class StateEventTest {
 
     @Test
     public void constructor_withJson_shouldCreateStateEvent() {
-        UUID id = UUID.randomUUID();
+        String clientId = UUID.randomUUID().toString();
         StateEvent.EventType eventType = StateEvent.EventType.SET;
         String value = "testValue";
 
         ObjectNode json = mapper.createObjectNode();
-        json.put(StateEvent.Field.ID, id.toString());
+        json.put(StateEvent.Field.ID, clientId);
         json.put(StateEvent.Field.TYPE, eventType.name().toLowerCase());
         json.put(StateEvent.Field.VALUE, value);
 
         StateEvent<String> event = new StateEvent<>(json);
 
-        assertEquals(id, event.getId());
+        assertEquals(clientId, event.getId());
         assertEquals(eventType, event.getEventType());
         assertEquals(value, event.getValue());
     }
 
     @Test
     public void toJson_whenCalled_shouldReturnCorrectJson() {
-        UUID id = UUID.randomUUID();
+        String id = UUID.randomUUID().toString();
         StateEvent.EventType eventType = StateEvent.EventType.SNAPSHOT;
         String value = "testValue";
 
         StateEvent<String> event = new StateEvent<>(id, eventType, value);
         ObjectNode json = event.toJson();
 
-        assertEquals(id.toString(), json.get(StateEvent.Field.ID).asText());
+        assertEquals(id, json.get(StateEvent.Field.ID).asText());
         assertEquals(eventType.name().toLowerCase(),
                 json.get(StateEvent.Field.TYPE).asText());
         assertEquals(value, json.get(StateEvent.Field.VALUE).asText());
@@ -62,11 +62,11 @@ public class StateEventTest {
 
     @Test
     public void constructor_withJsonInvalidEventType_shouldThrowInvalidEventTypeException() {
-        UUID id = UUID.randomUUID();
+        String clientId = UUID.randomUUID().toString();
         String value = "testValue";
 
         ObjectNode json = mapper.createObjectNode();
-        json.put(StateEvent.Field.ID, id.toString());
+        json.put(StateEvent.Field.ID, clientId);
         json.put(StateEvent.Field.TYPE, "invalidType");
         json.put(StateEvent.Field.VALUE, value);
 
@@ -82,11 +82,11 @@ public class StateEventTest {
 
     @Test
     public void constructor_withJsonMissingEventType_shouldThrowInvalidEventTypeException() {
-        UUID id = UUID.randomUUID();
+        String clientId = UUID.randomUUID().toString();
         String value = "testValue";
 
         ObjectNode json = mapper.createObjectNode();
-        json.put(StateEvent.Field.ID, id.toString());
+        json.put(StateEvent.Field.ID, clientId);
         json.put(StateEvent.Field.VALUE, value);
 
         Exception exception = assertThrows(
@@ -101,9 +101,9 @@ public class StateEventTest {
 
     @Test
     public void constructor_withJsonUnsupportedValueType_shouldThrowIllegalArgumentException() {
-        UUID id = UUID.randomUUID();
+        String clientId = UUID.randomUUID().toString();
         ObjectNode json = mapper.createObjectNode();
-        json.put(StateEvent.Field.ID, id.toString());
+        json.put(StateEvent.Field.ID, clientId);
         json.put(StateEvent.Field.TYPE,
                 StateEvent.EventType.SET.name().toLowerCase());
         json.set(StateEvent.Field.VALUE, mapper.createArrayNode()); // Unsupported

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/handler/SignalsHandlerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/handler/SignalsHandlerTest.java
@@ -20,10 +20,8 @@ import static org.mockito.Mockito.when;
 
 public class SignalsHandlerTest {
 
-    private static final UUID CLIENT_SIGNAL_ID_1 = UUID
-            .fromString("90000000-9000-9000-9000-900000000000");
-    private static final UUID CLIENT_SIGNAL_ID_2 = UUID
-            .fromString("80000000-8000-8000-8000-800000000000");
+    private static final String CLIENT_SIGNAL_ID_1 = "90000000-9000-9000-9000-900000000000";
+    private static final String CLIENT_SIGNAL_ID_2 = "80000000-8000-8000-8000-800000000000";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private SignalsHandler signalsHandler;

--- a/packages/java/tests/spring/react-signals/package-lock.json
+++ b/packages/java/tests/spring/react-signals/package-lock.json
@@ -653,7 +653,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",
-        "@vaadin/hilla-frontend": "24.5.0-alpha7"
+        "@vaadin/hilla-frontend": "24.5.0-alpha7",
+        "nanoid": "^5.0.7"
       },
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",

--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/NumberSignalIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/NumberSignalIT.java
@@ -3,6 +3,7 @@ package com.vaadin.hilla.test;
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+import com.vaadin.testbench.parallel.Browser;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,15 +12,13 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WindowType;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 @RunWith(BlockJUnit4ClassRunner.class)
-@NotThreadSafe
 public class NumberSignalIT extends ChromeBrowserTest {
 
     @Override
     @Before
     public void setup() throws Exception {
+        setDesiredCapabilities(Browser.CHROME.getDesiredCapabilities());
         super.setup();
         getDriver().get(getRootURL() + "/SharedNumberSignal");
         waitForPageToLoad();
@@ -83,8 +82,6 @@ public class NumberSignalIT extends ChromeBrowserTest {
             secondWindowCounterValue = Long.parseLong(
                     secondWindowDriver.findElement(By.id("counter")).getText());
             Assert.assertEquals(0, secondWindowCounterValue);
-
-            secondWindowDriver.close();
 
             // check that the first window is also updated:
             getDriver().switchTo().window(firstWindowHandle);

--- a/packages/ts/react-signals/package.json
+++ b/packages/ts/react-signals/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@preact/signals-react": "^2.0.0",
-    "@vaadin/hilla-frontend": "24.5.0-alpha7"
+    "@vaadin/hilla-frontend": "24.5.0-alpha7",
+    "nanoid": "^5.0.7"
   },
   "peerDependencies": {
     "react": "^18",

--- a/packages/ts/react-signals/src/EventChannel.ts
+++ b/packages/ts/react-signals/src/EventChannel.ts
@@ -1,4 +1,5 @@
 import type { ConnectClient, Subscription } from '@vaadin/hilla-frontend';
+import { nanoid } from 'nanoid';
 import { NumberSignal, setInternalValue, type ValueSignal } from './Signals.js';
 import SignalsHandler from './SignalsHandler';
 import { type StateEvent, StateEventType } from './types.js';
@@ -33,7 +34,7 @@ abstract class SignalChannel<T, S extends ValueSignal<T>> {
   readonly #internalSignal: S;
 
   constructor(signalProviderServiceMethod: string, connectClient: ConnectClient) {
-    this.#id = crypto.randomUUID();
+    this.#id = nanoid();
     this.#signalsHandler = new SignalsHandler(connectClient);
     this.#channelDescriptor = {
       signalProviderEndpointMethod: signalProviderServiceMethod,

--- a/packages/ts/react-signals/src/Signals.ts
+++ b/packages/ts/react-signals/src/Signals.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid';
 import { Signal } from './core.js';
 import { type StateEvent, StateEventType } from './types';
 
@@ -46,7 +47,7 @@ export abstract class ValueSignal<T> extends Signal<T> {
    * to be published to the server.
    */
   override set value(value: T) {
-    const id = crypto.randomUUID();
+    const id = nanoid();
     // set the local value to be used for latency compensation and offline support:
     this.#setInternalValue(value);
     // publish the update to the server:


### PR DESCRIPTION
We do not need security-grade random ids neither
for the events being exchanged between client and
server, nor for the client-side signal instances.
Since `crypto.randomUUID()` was creating problems
for executing tests on hub (with no https connection), 
it is replaced with the nanoid npm package.

This also refactor the server-side APIs to replace UUID
type for client-side signal ids to be string, and keeps 
using UUID only for the server-side signal ids.

