### PR TITLE
feat: add automatic unsubscription from the signal instance

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/registry/SecureSignalsRegistry.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/registry/SecureSignalsRegistry.java
@@ -51,6 +51,18 @@ public class SecureSignalsRegistry {
         delegate.register(clientSignalId, signal);
     }
 
+    public synchronized void unsubscribe(String clientSignalId)
+            throws EndpointInvocationException.EndpointAccessDeniedException,
+            EndpointInvocationException.EndpointNotFoundException {
+        var endpointMethodInfo = endpointMethods.get(clientSignalId);
+        if (endpointMethodInfo == null) {
+            return;
+        }
+        checkAccess(endpointMethodInfo.endpoint, endpointMethodInfo.method);
+        delegate.removeClientSignalToSignalMapping(clientSignalId);
+        endpointMethods.remove(clientSignalId);
+    }
+
     public synchronized NumberSignal get(String clientSignalId)
             throws EndpointInvocationException.EndpointAccessDeniedException,
             EndpointInvocationException.EndpointNotFoundException {

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/handler/SignalsHandler.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/handler/SignalsHandler.java
@@ -51,6 +51,18 @@ public class SignalsHandler {
     }
 
     /**
+     * Unsubscribes a client from a signal.
+     *
+     * @param clientSignalId
+     *            the client signal id
+     */
+    public void unsubscribe(String clientSignalId)
+            throws EndpointInvocationException.EndpointAccessDeniedException,
+            EndpointInvocationException.EndpointNotFoundException {
+        registry.unsubscribe(clientSignalId);
+    }
+
+    /**
      * Updates a signal with an event.
      *
      * @param clientSignalId

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/StateEventTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/StateEventTest.java
@@ -106,8 +106,8 @@ public class StateEventTest {
         json.put(StateEvent.Field.ID, clientId);
         json.put(StateEvent.Field.TYPE,
                 StateEvent.EventType.SET.name().toLowerCase());
-        json.set(StateEvent.Field.VALUE, mapper.createArrayNode()); // Unsupported
-                                                                    // type
+        // Unsupported type:
+        json.set(StateEvent.Field.VALUE, mapper.createArrayNode());
 
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> new StateEvent<>(json));

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/handler/SignalsHandlerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/handler/SignalsHandlerTest.java
@@ -2,6 +2,8 @@ package com.vaadin.hilla.signals.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.vaadin.hilla.EndpointInvoker;
+import com.vaadin.hilla.EndpointRegistry;
 import com.vaadin.hilla.signals.NumberSignal;
 import com.vaadin.hilla.signals.core.registry.SecureSignalsRegistry;
 import org.junit.Before;
@@ -10,6 +12,10 @@ import org.mockito.Mockito;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -97,5 +103,86 @@ public class SignalsHandlerTest {
         StepVerifier.create(firstFlux)
                 .expectNext(expectedUpdatedSignalEventJson).thenCancel()
                 .verify();
+    }
+
+    @Test
+    public void when_unsubscribedFromSignal_noMoreUpdatesAreReceived()
+            throws Exception {
+        NumberSignal numberSignal = new NumberSignal(10.0);
+        var signalId = numberSignal.getId();
+        var endpointInvokerMocked = mockEndpointInvokerThatGrantsAccess(
+                numberSignal);
+        signalsRegistry = new SecureSignalsRegistry(endpointInvokerMocked);
+        signalsHandler = new SignalsHandler(signalsRegistry);
+
+        // verify that updates are received when subscribed:
+        Flux<ObjectNode> firstFlux = signalsHandler.subscribe("endpoint.method",
+                CLIENT_SIGNAL_ID_1);
+        Flux<ObjectNode> secondFlux = signalsHandler
+                .subscribe("endpoint.method", CLIENT_SIGNAL_ID_2);
+
+        var firstFluxEmittedEvents = new ArrayList<>();
+        firstFlux.subscribe(firstFluxEmittedEvents::add);
+        var secondFluxEmittedEvents = new ArrayList<>();
+        secondFlux.subscribe(secondFluxEmittedEvents::add);
+
+        var setEvent = new ObjectNode(mapper.getNodeFactory()).put("value", 42)
+                .put("id", UUID.randomUUID().toString()).put("type", "set");
+
+        var expectedUpdateEventJson1 = new ObjectNode(mapper.getNodeFactory())
+                .put("value", 10.0).put("id", signalId.toString())
+                .put("type", "snapshot");
+        var expectedUpdateEventJson2 = new ObjectNode(mapper.getNodeFactory())
+                .put("value", 42.0).put("id", signalId.toString())
+                .put("type", "snapshot");
+
+        // first client update the signal:
+        signalsHandler.update(CLIENT_SIGNAL_ID_1, setEvent);
+
+        // second client unsubscribes:
+        signalsHandler.unsubscribe(CLIENT_SIGNAL_ID_2);
+
+        // first client update the signal again:
+        signalsHandler.update(CLIENT_SIGNAL_ID_1, setEvent);
+
+        StepVerifier.create(Flux.fromIterable(firstFluxEmittedEvents))
+                .expectNext(expectedUpdateEventJson1)
+                .expectNext(expectedUpdateEventJson2).thenCancel().verify();
+        StepVerifier.create(Flux.fromIterable(secondFluxEmittedEvents))
+                .expectNext(expectedUpdateEventJson1)
+                .expectNoEvent(Duration.ofSeconds(5)).thenCancel().verify();
+
+        assertThrows(IllegalStateException.class,
+                () -> signalsHandler.update(CLIENT_SIGNAL_ID_2, null));
+
+        // first client also unsubscribes:
+        signalsHandler.unsubscribe(CLIENT_SIGNAL_ID_1);
+
+        assertThrows(IllegalStateException.class,
+                () -> signalsHandler.update(CLIENT_SIGNAL_ID_1, null));
+    }
+
+    private EndpointInvoker mockEndpointInvokerThatGrantsAccess(
+            NumberSignal signal) throws Exception {
+        EndpointInvoker invoker = Mockito.mock(EndpointInvoker.class);
+        when(invoker.invoke(Mockito.anyString(), Mockito.anyString(),
+                Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(signal);
+        fakeMethodExistenceOn(invoker);
+        return invoker;
+    }
+
+    private void fakeMethodExistenceOn(EndpointInvoker invoker)
+            throws Exception {
+        EndpointRegistry.VaadinEndpointData mockVaadinEndpointData = Mockito
+                .mock(EndpointRegistry.VaadinEndpointData.class);
+        Method mockMethod = this.getClass().getMethod("aFakeMethod");
+        when(mockVaadinEndpointData.getMethod(Mockito.anyString()))
+                .thenReturn(Optional.of(mockMethod));
+        when(invoker.getVaadinEndpointData(Mockito.anyString()))
+                .thenReturn(mockVaadinEndpointData);
+    }
+
+    public void aFakeMethod() {
     }
 }

--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/SignalBasicSecurityIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/SignalBasicSecurityIT.java
@@ -52,16 +52,11 @@ public class SignalBasicSecurityIT extends ChromeBrowserTest {
     public void userCounterSignalIsAccessibleForLoggedInUser() {
 
         loginAs("user");
-
-        Assert.assertEquals(20, fetchCounterValue("User")); // shows server and
-                                                            // related endpoint
-                                                            // are working
-        Assert.assertEquals(20, getCounterSignalValue("userCounter")); // user
-                                                                       // counter
-                                                                       // should
-                                                                       // be
-                                                                       // accessible
-        // Still admin counter should not be accessible:
+        // shows server and related endpoint are working:
+        Assert.assertEquals(20, fetchCounterValue("User"));
+        // user counter should be accessible:
+        Assert.assertEquals(20, getCounterSignalValue("userCounter"));
+        // Still admin counter should not be accessed:
         Assert.assertEquals(-1, getCounterSignalValue("adminCounter"));
 
         // Logged-in user can manipulate the user counter:
@@ -72,9 +67,8 @@ public class SignalBasicSecurityIT extends ChromeBrowserTest {
         // But cannot manipulate the admin counter:
         clickButton("incrementAdminCounter");
         Assert.assertEquals(-1, getCounterSignalValue("adminCounter"));
-        Assert.assertEquals(30, fetchCounterValue("Admin")); // shows server and
-                                                             // related endpoint
-                                                             // are working
+        // shows server and related endpoint are working:
+        Assert.assertEquals(30, fetchCounterValue("Admin"));
 
         clickButton("reset");
         logout();
@@ -85,16 +79,10 @@ public class SignalBasicSecurityIT extends ChromeBrowserTest {
 
         loginAs("admin");
 
-        Assert.assertEquals(20, getCounterSignalValue("userCounter")); // user
-                                                                       // counter
-                                                                       // should
-                                                                       // be
-                                                                       // accessible
-        Assert.assertEquals(30, getCounterSignalValue("adminCounter")); // admin
-                                                                        // counter
-                                                                        // should
-                                                                        // be
-                                                                        // accessible
+        // user counter should be accessible:
+        Assert.assertEquals(20, getCounterSignalValue("userCounter"));
+        // admin counter should be accessible:
+        Assert.assertEquals(30, getCounterSignalValue("adminCounter"));
 
         clickButton("increaseUserCounter");
         Assert.assertEquals(21, getCounterSignalValue("userCounter"));

--- a/packages/ts/react-signals/src/EventChannel.ts
+++ b/packages/ts/react-signals/src/EventChannel.ts
@@ -95,9 +95,11 @@ abstract class SignalChannel<T, S extends ValueSignal<T>> {
       return;
     }
 
-    this.#signalsHandler.unsubscribe(this.#id);
     this.#subscription.cancel();
     this.#subscription = undefined;
+    this.#signalsHandler.unsubscribe(this.#id).catch((error) => {
+      console.error(error);
+    });
   }
 
   #updateSignals(stateEvent: StateEvent): void {

--- a/packages/ts/react-signals/src/EventChannel.ts
+++ b/packages/ts/react-signals/src/EventChannel.ts
@@ -94,9 +94,8 @@ abstract class SignalChannel<T, S extends ValueSignal<T>> {
     if (!this.#subscription) {
       return;
     }
-    // eslint-disable-next-line no-console
-    console.log('Cancelling subscription...');
 
+    this.#signalsHandler.unsubscribe(this.#id);
     this.#subscription.cancel();
     this.#subscription = undefined;
   }

--- a/packages/ts/react-signals/src/SignalsHandler.ts
+++ b/packages/ts/react-signals/src/SignalsHandler.ts
@@ -18,10 +18,8 @@ export default class SignalsHandler {
     return this.#client.subscribe('SignalsHandler', 'subscribe', { signalProviderEndpointMethod, clientSignalId });
   }
 
-  unsubscribe(clientSignalId: string, init?: EndpointRequestInit): void {
-    this.#client.call('SignalsHandler', 'unsubscribe', { clientSignalId }, init).catch((error) => {
-      throw error;
-    });
+  async unsubscribe(clientSignalId: string, init?: EndpointRequestInit): Promise<void> {
+    return this.#client.call('SignalsHandler', 'unsubscribe', { clientSignalId }, init);
   }
 
   async update(clientSignalId: string, event: StateEvent, init?: EndpointRequestInit): Promise<void> {

--- a/packages/ts/react-signals/src/SignalsHandler.ts
+++ b/packages/ts/react-signals/src/SignalsHandler.ts
@@ -18,6 +18,12 @@ export default class SignalsHandler {
     return this.#client.subscribe('SignalsHandler', 'subscribe', { signalProviderEndpointMethod, clientSignalId });
   }
 
+  unsubscribe(clientSignalId: string, init?: EndpointRequestInit): void {
+    this.#client.call('SignalsHandler', 'unsubscribe', { clientSignalId }, init).catch((error) => {
+      throw error;
+    });
+  }
+
   async update(clientSignalId: string, event: StateEvent, init?: EndpointRequestInit): Promise<void> {
     return this.#client.call('SignalsHandler', 'update', { clientSignalId, event }, init);
   }

--- a/packages/ts/react-signals/test/EventChannel.spec.tsx
+++ b/packages/ts/react-signals/test/EventChannel.spec.tsx
@@ -92,7 +92,7 @@ describe('@vaadin/hilla-react-signals', () => {
       expect(numberSignal.value).to.equal(42);
     });
 
-    it("should render signal's the updated value", async () => {
+    it("should render signal's updated value", async () => {
       const numberSignalChannel = new NumberSignalChannel('testEndpoint', connectClientMock);
       const numberSignal = numberSignalChannel.signal;
 

--- a/packages/ts/react-signals/test/Signals.spec.tsx
+++ b/packages/ts/react-signals/test/Signals.spec.tsx
@@ -15,9 +15,13 @@ use(chaiLike);
 describe('@vaadin/hilla-react-signals', () => {
   describe('NumberSignal', () => {
     let publishSpy: sinon.SinonSpy;
+    let subscribeSpy: sinon.SinonSpy;
+    let unsubscribeSpy: sinon.SinonSpy;
 
     beforeEach(() => {
       publishSpy = sinon.spy(async (_: StateEvent): Promise<boolean> => Promise.resolve(true));
+      subscribeSpy = sinon.spy();
+      unsubscribeSpy = sinon.spy();
     });
 
     afterEach(() => {
@@ -25,31 +29,31 @@ describe('@vaadin/hilla-react-signals', () => {
     });
 
     it('should retain default value as initialized', () => {
-      const numberSignal1 = new NumberSignal(publishSpy);
+      const numberSignal1 = new NumberSignal(publishSpy, undefined, subscribeSpy, unsubscribeSpy);
       expect(numberSignal1.value).to.be.undefined;
 
-      const numberSignal2 = new NumberSignal(publishSpy, undefined);
+      const numberSignal2 = new NumberSignal(publishSpy, undefined, subscribeSpy, unsubscribeSpy);
       expect(numberSignal2.value).to.be.undefined;
 
-      const numberSignal3 = new NumberSignal(publishSpy, 0);
+      const numberSignal3 = new NumberSignal(publishSpy, 0, subscribeSpy, unsubscribeSpy);
       expect(numberSignal3.value).to.equal(0);
 
-      const numberSignal4 = new NumberSignal(publishSpy, 42.424242);
+      const numberSignal4 = new NumberSignal(publishSpy, 42.424242, subscribeSpy, unsubscribeSpy);
       expect(numberSignal4.value).to.equal(42.424242);
 
-      const numberSignal5 = new NumberSignal(publishSpy, -42.424242);
+      const numberSignal5 = new NumberSignal(publishSpy, -42.424242, subscribeSpy, unsubscribeSpy);
       expect(numberSignal5.value).to.equal(-42.424242);
     });
 
     it('should publish the new value to the server when set', () => {
-      const numberSignal = new NumberSignal(publishSpy);
+      const numberSignal = new NumberSignal(publishSpy, undefined, subscribeSpy, unsubscribeSpy);
       numberSignal.value = 42;
       expect(publishSpy).to.have.been.calledOnce;
       expect(publishSpy).to.have.been.calledWithMatch({ type: 'set', value: 42 });
 
       publishSpy.resetHistory();
 
-      const numberSignal2 = new NumberSignal(publishSpy, 0);
+      const numberSignal2 = new NumberSignal(publishSpy, 0, subscribeSpy, unsubscribeSpy);
       // eslint-disable-next-line no-plusplus
       numberSignal2.value++;
       expect(publishSpy).to.have.been.calledOnce;
@@ -57,19 +61,19 @@ describe('@vaadin/hilla-react-signals', () => {
     });
 
     it('should render value when signal is rendered', async () => {
-      const numberSignal = new NumberSignal(publishSpy, 42);
+      const numberSignal = new NumberSignal(publishSpy, 42, subscribeSpy, unsubscribeSpy);
       const result = render(<span>Value is {numberSignal}</span>);
       await nextFrame();
       expect(result.container.textContent).to.equal('Value is 42');
     });
 
     it('should set the underlying value locally without waiting for server confirmation', () => {
-      const numberSignal = new NumberSignal(publishSpy);
+      const numberSignal = new NumberSignal(publishSpy, undefined, subscribeSpy, unsubscribeSpy);
       expect(numberSignal.value).to.equal(undefined);
       numberSignal.value = 42;
       expect(numberSignal.value).to.equal(42);
 
-      const anotherNumberSignal = new NumberSignal(publishSpy);
+      const anotherNumberSignal = new NumberSignal(publishSpy, undefined, subscribeSpy, unsubscribeSpy);
       const results: Array<number | undefined> = [];
 
       effect(() => {

--- a/packages/ts/react-signals/test/SignalsHandler.spec.ts
+++ b/packages/ts/react-signals/test/SignalsHandler.spec.ts
@@ -34,7 +34,7 @@ describe('@vaadin/hilla-react-signals', () => {
       });
     });
 
-    it('update should call client.call', async () => {
+    it("update should call client.call to invoke endpoint's update", async () => {
       const clientSignalId = 'testSignalId';
       const event: StateEvent = { id: 'testEvent', type: StateEventType.SET, value: 10 };
       const init = {};
@@ -48,6 +48,17 @@ describe('@vaadin/hilla-react-signals', () => {
         { clientSignalId, event },
         init,
       );
+    });
+
+    it("unsubscribe should call client.call to invoke endpoint's unsubscribe", async () => {
+      const clientSignalId = 'testSignalId';
+      const event: StateEvent = { id: 'testEvent', type: StateEventType.SET, value: 10 };
+      const init = {};
+
+      await signalsHandler.unsubscribe(clientSignalId, init);
+
+      expect(connectClientMock.call).to.be.have.been.calledOnce;
+      expect(connectClientMock.call).to.have.been.calledWith('SignalsHandler', 'unsubscribe', { clientSignalId }, init);
     });
   });
 });


### PR DESCRIPTION
## Description

This also postpones subscribing to a signal
instance until the client-side signal is
actually being subscribed to (rendered).

Fixes #2621

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
