### PR TITLE
chore: increase build java and typescript validation step timeout

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -31,7 +31,7 @@ jobs:
   init:
     name: Build Java and TypeScript for other tasks
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 6
     env:
       NX_SKIP_NX_CACHE: true
 


### PR DESCRIPTION
## Description

It seems that the it takes more than 5 minutes for the validation build step "Build Java and TypeScript for other tasks" to be done. This increases the timeout.