### PR TITLE
fix(TypeScript): npm peer dependency install conflicts in user applications

### DIFF
--- a/packages/ts/generator-cli/package.json
+++ b/packages/ts/generator-cli/package.json
@@ -44,10 +44,8 @@
   "bin": {
     "tsgen": "bin/index.js"
   },
-  "peerDependencies": {
-    "@vaadin/hilla-generator-core": "24.5.0-alpha12"
-  },
   "dependencies": {
+    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "get-stdin": "^9.0.0",
     "meow": "^12.1.1"

--- a/packages/ts/generator-plugin-backbone/package.json
+++ b/packages/ts/generator-plugin-backbone/package.json
@@ -50,11 +50,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
-    "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12"
-  },
   "dependencies": {
+    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
+    "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",

--- a/packages/ts/generator-plugin-barrel/package.json
+++ b/packages/ts/generator-plugin-barrel/package.json
@@ -50,11 +50,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
-    "@vaadin/hilla-generator-plugin-backbone": "24.5.0-alpha12"
-  },
   "dependencies": {
+    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
+    "@vaadin/hilla-generator-plugin-backbone": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "typescript": "5.5.2"
   },

--- a/packages/ts/generator-plugin-client/package.json
+++ b/packages/ts/generator-plugin-client/package.json
@@ -50,10 +50,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "@vaadin/hilla-generator-core": "24.5.0-alpha12"
-  },
   "dependencies": {
+    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "typescript": "5.5.2"
   },

--- a/packages/ts/generator-plugin-model/package.json
+++ b/packages/ts/generator-plugin-model/package.json
@@ -50,13 +50,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@vaadin/hilla-generator-core": "24.5.0-alpha12",
     "@vaadin/hilla-generator-plugin-backbone": "24.5.0-alpha12",
-    "@vaadin/hilla-lit-form": "24.5.0-alpha12"
-  },
-  "dependencies": {
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
+    "@vaadin/hilla-lit-form": "24.5.0-alpha12",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",
     "typescript": "5.5.2"

--- a/packages/ts/generator-plugin-push/package.json
+++ b/packages/ts/generator-plugin-push/package.json
@@ -50,11 +50,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
-    "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12"
-  },
   "dependencies": {
+    "@vaadin/hilla-generator-core": "24.5.0-alpha12",
+    "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",

--- a/packages/ts/generator-plugin-signals/package.json
+++ b/packages/ts/generator-plugin-signals/package.json
@@ -50,12 +50,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12"
-  },
   "dependencies": {
     "@vaadin/hilla-generator-core": "24.5.0-alpha12",
     "@vaadin/hilla-generator-plugin-backbone": "24.5.0-alpha12",
+    "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "fast-deep-equal": "^3.1.3",
     "iterator-helpers-polyfill": "^3.0.1",

--- a/packages/ts/generator-plugin-subtypes/package.json
+++ b/packages/ts/generator-plugin-subtypes/package.json
@@ -49,12 +49,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@vaadin/hilla-generator-core": "24.5.0-alpha12",
     "@vaadin/hilla-generator-plugin-client": "24.5.0-alpha12",
-    "@vaadin/hilla-generator-plugin-model": "24.5.0-alpha12"
-  },
-  "dependencies": {
+    "@vaadin/hilla-generator-plugin-model": "24.5.0-alpha12",
     "@vaadin/hilla-generator-utils": "24.5.0-alpha12",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3",


### PR DESCRIPTION
As pointed out in https://github.com/npm/cli/issues/7719, npm struggles with resolving peer dependencies when running `npm install` and applying new peer dependency requirements that do not align with previously installed versions. In many cases it produces an unexpected error for the user instead of updating installed peer dependency packages.

As a (temporary?) workaround, let us avoid using strict peer dependency requirements for our packages.

This changes the `package.json` to use regular dependency version spec even though the expectation is that the install is “flat”, i. e., the packages are is installed on the top-level of `node_modules/` in the user application.
