### PR TITLE
fix: remove warning on entities with no properties

### DIFF
--- a/packages/ts/generator-plugin-model/src/EntityModelProcessor.ts
+++ b/packages/ts/generator-plugin-model/src/EntityModelProcessor.ts
@@ -5,7 +5,6 @@ import {
   convertReferenceSchemaToSpecifier,
   decomposeSchema,
   isComposedSchema,
-  isEmptyObject,
   isEnumSchema,
   isObjectSchema,
   isReferenceSchema,
@@ -189,10 +188,6 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
     if (!isObjectSchema(schema)) {
       logger.debug(schema, `Component is not an object: ${this.#fullyQualifiedName}`);
       return undefined;
-    }
-
-    if (isEmptyObject(schema)) {
-      logger.debug(`Component has no properties: ${this.#fullyQualifiedName}`);
     }
 
     const typeT = ts.factory.createIdentifier('T');

--- a/packages/ts/generator-plugin-model/src/EntityModelProcessor.ts
+++ b/packages/ts/generator-plugin-model/src/EntityModelProcessor.ts
@@ -192,7 +192,7 @@ export class EntityClassModelProcessor extends EntityModelProcessor {
     }
 
     if (isEmptyObject(schema)) {
-      logger.warn(`Component has no properties: ${this.#fullyQualifiedName}`);
+      logger.debug(`Component has no properties: ${this.#fullyQualifiedName}`);
     }
 
     const typeT = ts.factory.createIdentifier('T');


### PR DESCRIPTION
The entity generator emits a `debug` log to warn about entities without properties. The model generator emits a real `warn`-level message.

This PR removes this second message.

Fixes #2506.