### PR TITLE
fix(signals): require a default value for non-nullable signals

### DIFF
--- a/packages/ts/generator-plugin-signals/test/fixtures/ValueSignalServiceMix.snap.ts
+++ b/packages/ts/generator-plugin-signals/test/fixtures/ValueSignalServiceMix.snap.ts
@@ -6,7 +6,9 @@ async function getPerson_1(init?: EndpointRequestInit_1): Promise<Person_1 | und
 function personSignal_1(): ValueSignal_1<Person_1 | undefined> {
     return new ValueSignal_1(undefined, { client: client_1, endpoint: "PersonService", method: "personSignal" });
 }
-function personSignalNonNull_1(): ValueSignal_1<Person_1> {
-    return new ValueSignal_1(undefined, { client: client_1, endpoint: "PersonService", method: "personSignalNonNull" });
+function personSignalNonNull_1({ defaultValue: defaultValue_1 }: {
+    defaultValue: Person_1;
+}): ValueSignal_1<Person_1> {
+    return new ValueSignal_1(defaultValue_1, { client: client_1, endpoint: "PersonService", method: "personSignalNonNull" });
 }
 export { getPerson_1 as getPerson, personSignal_1 as personSignal, personSignalNonNull_1 as personSignalNonNull };


### PR DESCRIPTION
This PR amends the code generation to require a default value when the Java signal is not nullable.

Fixes # 2719