### PR TITLE
fix: checkbox group undefined field strategy

### DIFF
--- a/packages/ts/lit-form/src/Field.ts
+++ b/packages/ts/lit-form/src/Field.ts
@@ -235,6 +235,19 @@ export class CheckedFieldStrategy<
   }
 }
 
+export class CheckedGroupFieldStrategy<
+  T = any,
+  E extends FieldElement<T> = FieldElement<T>,
+> extends GenericFieldStrategy<T, E> {
+  override get value(): T | undefined {
+    return super.value;
+  }
+
+  override set value(val: T | undefined) {
+    super.value = val ?? ([] as T);
+  }
+}
+
 type ComboBoxFieldElement<T> = FieldElement<T> & {
   value: string;
   selectedItem: T | null;
@@ -319,6 +332,8 @@ export function getDefaultFieldStrategy<T>(elm: FieldElement<T>, model?: Abstrac
     case 'vaadin-checkbox':
     case 'vaadin-radio-button':
       return new CheckedFieldStrategy(elm as CheckedFieldElement<T>, model);
+    case 'vaadin-checkbox-group':
+      return new CheckedGroupFieldStrategy(elm, model);
     case 'vaadin-combo-box':
       return new ComboBoxFieldStrategy(elm as ComboBoxFieldElement<T>, model);
     case 'vaadin-list-box':

--- a/packages/ts/lit-form/src/Field.ts
+++ b/packages/ts/lit-form/src/Field.ts
@@ -2,7 +2,15 @@
 import { type ElementPart, noChange, nothing, type PropertyPart } from 'lit';
 import { directive, Directive, type DirectiveParameters, type PartInfo, PartType } from 'lit/directive.js';
 import { getBinderNode } from './BinderNode.js';
-import { _fromString, type AbstractModel, ArrayModel, BooleanModel, hasFromString, ObjectModel } from './Models.js';
+import {
+  _fromString,
+  type AbstractModel,
+  ArrayModel,
+  BooleanModel,
+  hasFromString,
+  NumberModel,
+  ObjectModel,
+} from './Models.js';
 import { StringModel } from './Models.js';
 import type { ValueError } from './Validation.js';
 import { _validity, defaultValidity } from './Validity.js';
@@ -94,6 +102,10 @@ export abstract class AbstractFieldStrategy<T = any, E extends FieldElement<T> =
   }
 
   set value(value: T | undefined) {
+    if (this.model instanceof StringModel || this.model instanceof NumberModel) {
+      this.#element.value = value ?? ('' as T);
+      return;
+    }
     this.#element.value = value;
   }
 
@@ -201,16 +213,6 @@ export class GenericFieldStrategy<T = any, E extends FieldElement<T> = FieldElem
 
   set invalid(value: boolean) {
     this.setAttribute('invalid', value);
-  }
-}
-
-export class GenericStringFieldStrategy extends GenericFieldStrategy<string> {
-  override get value(): string | undefined {
-    return super.value;
-  }
-
-  override set value(val: string | undefined) {
-    super.value = val ?? '';
   }
 }
 
@@ -354,12 +356,7 @@ export function getDefaultFieldStrategy<T>(elm: FieldElement<T>, model?: Abstrac
       if ((elm.constructor as unknown as MaybeVaadinElementConstructor).version) {
         return new VaadinFieldStrategy(elm, model);
       }
-      return model instanceof StringModel
-        ? (new GenericStringFieldStrategy(
-            elm as FieldElement<string>,
-            model as AbstractModel<string>,
-          ) as AbstractFieldStrategy<T>)
-        : new GenericFieldStrategy(elm, model);
+      return new GenericFieldStrategy(elm, model);
   }
 }
 

--- a/packages/ts/lit-form/test/Field.test.ts
+++ b/packages/ts/lit-form/test/Field.test.ts
@@ -23,6 +23,7 @@ import {
   Required,
   SelectedFieldStrategy,
   VaadinFieldStrategy,
+  CheckedGroupFieldStrategy,
 } from '../src/index.js';
 import { OrderModel, TestModel } from './TestModels.js';
 
@@ -674,6 +675,43 @@ describe('@vaadin/hilla-lit-form', () => {
           expect(currentStrategy.model).to.be.equal(model);
 
           expect(element.checked).to.be.true;
+
+          await binderNode.validate();
+          element = renderElement();
+          expect(element.hasAttribute('invalid')).to.be.true;
+          expect(element.hasAttribute('errorMessage')).to.be.false;
+        });
+      });
+
+      [{ tag: 'vaadin-checkbox-group' }].forEach(({ tag }) => {
+        it(`CheckedGroupFieldStrategy ${tag} `, async () => {
+          const tagName = unsafeStatic(tag);
+
+          const model = binder.model.fieldArrayString;
+          const binderNode = binder.for(model);
+
+          let element;
+          const renderElement = () => {
+            render(
+              html`
+                  <${tagName} ${field(model)}></${tagName}>`,
+              div,
+            );
+            return div.firstElementChild as Element & { checked?: boolean };
+          };
+
+          binderNode.value = ['0', '1'];
+          await resetBinderNodeValidation(binderNode);
+
+          binderNode.validators = [{ message: 'any-err-msg', validate: () => false }];
+
+          element = renderElement();
+
+          const currentStrategy: FieldStrategy = getFieldStrategySpy.lastCall.returnValue;
+
+          expect(currentStrategy instanceof CheckedGroupFieldStrategy).to.be.true;
+          expect(currentStrategy.value).to.be.deep.equal(['0', '1']);
+          expect(currentStrategy.model).to.be.equal(model);
 
           await binderNode.validate();
           element = renderElement();

--- a/packages/ts/lit-form/test/Field.test.ts
+++ b/packages/ts/lit-form/test/Field.test.ts
@@ -18,7 +18,6 @@ import {
   type FieldElement,
   type FieldStrategy,
   GenericFieldStrategy,
-  GenericStringFieldStrategy,
   MultiSelectComboBoxFieldStrategy,
   Required,
   SelectedFieldStrategy,
@@ -538,41 +537,7 @@ describe('@vaadin/hilla-lit-form', () => {
       });
 
       ['div', 'input'].forEach((tag) => {
-        it(`GenericStringFieldStrategy ${tag}`, async () => {
-          const tagName = unsafeStatic(tag);
-
-          const model = binder.model.fieldString;
-          const binderNode = binder.for(model);
-          binderNode.value = 'foo';
-          await resetBinderNodeValidation(binderNode);
-
-          const renderElement = () => {
-            render(
-              html`
-                <${tagName} ${field(model)}></${tagName}>`,
-              div,
-            );
-            return div.firstElementChild as Element & { value?: any };
-          };
-
-          binderNode.validators = [{ message: 'any-err-msg', validate: () => false }];
-
-          renderElement();
-
-          const currentStrategy: FieldStrategy = getFieldStrategySpy.lastCall.returnValue;
-
-          expect(currentStrategy instanceof GenericStringFieldStrategy).to.be.true;
-          expect(currentStrategy.value).to.be.equal('foo');
-          expect(currentStrategy.model).to.be.equal(model);
-
-          await binderNode.validate();
-          const element = renderElement();
-
-          expect(element.hasAttribute('invalid')).to.be.true;
-          expect(element.hasAttribute('errorMessage')).to.be.false;
-        });
-
-        it(`GenericStringFieldStrategy undefined ${tag}`, async () => {
+        it(`GenericFieldStrategy undefined ${tag}`, async () => {
           const tagName = unsafeStatic(tag);
 
           const model = binder.model.fieldString;
@@ -593,7 +558,7 @@ describe('@vaadin/hilla-lit-form', () => {
 
           const currentStrategy: FieldStrategy = getFieldStrategySpy.lastCall.returnValue;
 
-          expect(currentStrategy instanceof GenericStringFieldStrategy).to.be.true;
+          expect(currentStrategy instanceof GenericFieldStrategy).to.be.true;
           expect(currentStrategy.value).to.be.equal('');
           expect(currentStrategy.model).to.be.equal(model);
         });

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -346,7 +346,7 @@ describe('@vaadin/hilla-react-crud', () => {
 
         const form = await FormController.init(user);
         expect(form.instance).to.exist;
-        expect((await form.getField('Name')).value).to.equal(undefined);
+        expect(await form.getField('Name')).to.have.value('');
       });
 
       it('closes the dialog when clicking close button', async () => {


### PR DESCRIPTION
Introduce a checkbox group field strategy to set an empty array instead of undefined as the field doesn't support undefined value change.

Fixes #2547
