### PR TITLE
feat: Do not force full reload when changing routes

### DIFF
--- a/packages/ts/file-router/src/runtime/createMenuItems.ts
+++ b/packages/ts/file-router/src/runtime/createMenuItems.ts
@@ -39,3 +39,19 @@ export function createMenuItems(): readonly MenuItem[] {
       })
   );
 }
+
+// @ts-expect-error Vite hotswapping
+if (import.meta.hot) {
+  // @ts-expect-error Vite hotswapping
+  // eslint-disable-next-line
+  import.meta.hot.on('fs-route-update', () => {
+    fetch('?v-r=routeinfo')
+      .then(async (resp) => resp.json())
+      .then((json) => {
+        viewsSignal.value = json;
+      })
+      .catch((e) => {
+        console.error('Failed to fetch route info', e);
+      });
+  });
+}

--- a/packages/ts/file-router/src/vite-plugin.ts
+++ b/packages/ts/file-router/src/vite-plugin.ts
@@ -97,7 +97,7 @@ export default function vitePluginFileSystemRouter({
       const changeListener = (file: string): void => {
         if (!file.startsWith(dir)) {
           if (file === fileURLToPath(runtimeUrls.json)) {
-            server.hot.send({ type: 'full-reload' });
+            server.hot.send({ type: 'custom', event: 'fs-route-update' });
           }
           return;
         }

--- a/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
+++ b/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
@@ -32,20 +32,28 @@ export type RuntimeFileUrls = Readonly<{
  *
  * @param url - The URL of the file to generate.
  * @param data - The data to write to the file.
+ * @param forceWrite - true to force writing the file even if there are no changes
+ * @returns true if the file was written, false otherwise.
  */
-async function generateRuntimeFile(url: URL, data: string): Promise<void> {
+async function generateRuntimeFile(url: URL, data: string, forceWrite?: boolean): Promise<boolean> {
   await mkdir(new URL('./', url), { recursive: true });
-  let contents: string | undefined;
-  try {
-    contents = await readFile(url, 'utf-8');
-  } catch (e: unknown) {
-    if (!(e != null && typeof e === 'object' && 'code' in e && e.code === 'ENOENT')) {
-      throw e;
+  let shouldWrite = forceWrite ?? false;
+  if (!forceWrite) {
+    let contents: string | undefined;
+    try {
+      contents = await readFile(url, 'utf-8');
+    } catch (e: unknown) {
+      if (!(e != null && typeof e === 'object' && 'code' in e && e.code === 'ENOENT')) {
+        throw e;
+      }
     }
+    shouldWrite = contents !== data;
   }
-  if (contents !== data) {
+  if (shouldWrite) {
     await writeFile(url, data, 'utf-8');
   }
+
+  return shouldWrite;
 }
 
 /**
@@ -72,16 +80,15 @@ export async function generateRuntimeFiles(
   const runtimeRoutesCode = createRoutesFromMeta(routeMeta, urls);
   const viewConfigJson = await createViewConfigJson(routeMeta);
 
-  await Promise.all([
-    generateRuntimeFile(urls.json, viewConfigJson).then(() => {
-      if (debug) {
-        logger.info(`Frontend route list is generated: ${String(urls.json)}`);
-      }
-    }),
-    generateRuntimeFile(urls.code, runtimeRoutesCode).then(() => {
-      if (debug) {
-        logger.info(`File Route module is generated: ${String(urls.code)}`);
-      }
-    }),
-  ]);
+  const jsonWritten = await generateRuntimeFile(urls.json, viewConfigJson);
+  if (debug) {
+    logger.info(`Frontend route list is generated: ${String(urls.json)}`);
+  }
+  // If the metadata has changed, we need to write the TS file also to make Vite HMR updates work properly.
+  // Even though the contents of the TS file does not change, the contents of the files imported in the TS
+  // files changes and the routes must be re-applied to the React router
+  await generateRuntimeFile(urls.code, runtimeRoutesCode, jsonWritten);
+  if (debug) {
+    logger.info(`File Route module is generated: ${String(urls.code)}`);
+  }
 }

--- a/packages/ts/file-router/test/vite-plugin/vite-plugin.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/vite-plugin.spec.ts
@@ -38,16 +38,16 @@ describe('@vaadin/hilla-file-router', () => {
       sinon.resetHistory();
     });
 
-    it('should send full-reload only when file-routes.json is added', () => {
+    it('should send fs-route-update when file-routes.json is added', () => {
       expect(mockServer.hot.send).to.not.be.called;
       mockServer.watcher.emit('add', fileURLToPath(new URL('file-routes.json', generatedDir)));
-      expect(mockServer.hot.send).to.be.calledWith({ type: 'full-reload' });
+      expect(mockServer.hot.send).to.be.calledWith({ type: 'custom', event: 'fs-route-update' });
     });
 
-    it('should send full-reload only when file-routes.json changes', () => {
+    it('should send fs-route-update when file-routes.json changes', () => {
       expect(mockServer.hot.send).to.not.be.called;
       mockServer.watcher.emit('change', fileURLToPath(new URL('file-routes.json', generatedDir)));
-      expect(mockServer.hot.send).to.be.calledWith({ type: 'full-reload' });
+      expect(mockServer.hot.send).to.be.calledWith({ type: 'custom', event: 'fs-route-update' });
     });
 
     it('should not send full-reload when other files change', () => {


### PR DESCRIPTION
HMR now works as following:

When a file inside the `views` folder changes, the vite plugin for the file router picks that up.
After writing file-routes.ts and file-routes.json with the new data, it fires a `fs-route-update` event through the Vite event bus. It is important to write `file-routes.ts` also when its contents does not change but some meta info in a view has changed (i.e. when the json file changes). This will propagate the new meta data also to the router configuration.

The custom HMR code in `createMenuItems.ts` reacts to this events and initiates a re-fetch of `window.Vaadin.views` from the server. Once the new data is available, the signal the menu is based upon is updated and the menu re-rendered.

Vite reacts on `file-routes.ts` being changed and propagates HMR events to its importers, which typically is `index.tsx` that configures the react router using the routes and `vaadin-react.tsx` which stores the routes so that the Flow router integration can access them. `index.tsx` reacts to the HMR event by re-rendering the full application with the new routes, updating the React router configuration.

Fixes #2749