### PR TITLE
fix: remove onDisconnect callback from flux subscription

### DIFF
--- a/packages/ts/frontend/src/Connect.ts
+++ b/packages/ts/frontend/src/Connect.ts
@@ -43,9 +43,6 @@ export interface Subscription<T> {
   /** Called when a new value is available. */
   onNext(callback: (value: T) => void): Subscription<T>;
 
-  /** Called when subscription disconnected */
-  onDisconnect(callback: () => void): Subscription<T>;
-
   /**
    * Called when the connection is restored, but there's no longer a valid subscription. If the callback returns
    * `ActionOnLostSubscription.RESUBSCRIBE`, the subscription will be re-established by connecting to the same

--- a/packages/ts/frontend/src/FluxConnection.ts
+++ b/packages/ts/frontend/src/FluxConnection.ts
@@ -58,7 +58,6 @@ export class FluxConnection extends EventTarget {
   readonly #onCompleteCallbacks = new Map<string, () => void>();
   readonly #onErrorCallbacks = new Map<string, () => void>();
   readonly #onNextCallbacks = new Map<string, (value: any) => void>();
-  readonly #onDisconnectCallbacks = new Map<string, () => void>();
   #pendingMessages: ServerMessage[] = [];
   #socket?: Atmosphere.Request;
 
@@ -112,10 +111,6 @@ export class FluxConnection extends EventTarget {
       },
       onNext: (callback: (value: any) => void): Subscription<any> => {
         this.#onNextCallbacks.set(id, callback);
-        return hillaSubscription;
-      },
-      onDisconnect: (callback: () => void): Subscription<any> => {
-        this.#onDisconnectCallbacks.set(id, callback);
         return hillaSubscription;
       },
       onSubscriptionLost: (callback: () => ActionOnLostSubscription | void): Subscription<any> => {
@@ -198,7 +193,6 @@ export class FluxConnection extends EventTarget {
       onReconnect: () => {
         if (this.state !== State.RECONNECTING) {
           this.state = State.RECONNECTING;
-          this.#onDisconnectCallbacks.forEach((callback) => callback());
         }
       },
       onFailureToReconnect: () => {
@@ -248,7 +242,6 @@ export class FluxConnection extends EventTarget {
     this.#onCompleteCallbacks.delete(id);
     this.#onErrorCallbacks.delete(id);
     this.#endpointInfos.delete(id);
-    this.#onDisconnectCallbacks.delete(id);
   }
 
   #send(message: ServerMessage) {

--- a/packages/ts/frontend/test/FluxConnection.test.ts
+++ b/packages/ts/frontend/test/FluxConnection.test.ts
@@ -357,16 +357,6 @@ describe('@vaadin/hilla-frontend', () => {
       expect(fluxConnection.state).to.equal(State.INACTIVE);
     });
 
-    it('should call disconnect callbacks on reconnect', () => {
-      const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
-      const onDisconnect = sinon.stub();
-
-      sub.onDisconnect(onDisconnect);
-
-      getSubscriptionEventSpies()?.onReconnect?.();
-      expect(onDisconnect).to.have.been.calledOnce;
-    });
-
     it('should update state while reconnecting', () => {
       const sub = fluxConnection.subscribe('MyEndpoint', 'myMethod');
       fluxConnection.state = State.INACTIVE;

--- a/packages/ts/react-signals/test/FullStackSignal.spec.tsx
+++ b/packages/ts/react-signals/test/FullStackSignal.spec.tsx
@@ -100,9 +100,6 @@ describe('@vaadin/hilla-react-signals', () => {
         onNext() {
           return this;
         },
-        onDisconnect() {
-          return this;
-        },
         onSubscriptionLost() {
           return this;
         },

--- a/packages/ts/react-signals/test/utils.ts
+++ b/packages/ts/react-signals/test/utils.ts
@@ -26,9 +26,6 @@ export function createSubscriptionStub<T>(): sinon.SinonSpiedInstance<Subscripti
     onNext() {
       return this;
     },
-    onDisconnect() {
-      return this;
-    },
     onSubscriptionLost() {
       return this;
     },


### PR DESCRIPTION
Remove onDisconnect callback as for https://github.com/vaadin/hilla/pull/2737 and later introduce the onConnectionStateChange callback.

Fixes: #398 and #2769
