### PR TITLE
fix: localdatetime fills in AutoCrud and allow other java time classes to be used automatically

### DIFF
--- a/packages/ts/lit-form/src/Field.ts
+++ b/packages/ts/lit-form/src/Field.ts
@@ -288,6 +288,22 @@ export class VaadinStringFieldStrategy extends VaadinFieldStrategy<string> {
     super.value = val ?? '';
   }
 }
+function isEmptyObject(val: any): boolean {
+  return val && typeof val === 'object' && !Array.isArray(val) && Object.keys(val).length === 0;
+}
+
+export class VaadinDateTimeFieldStrategy<
+  T = string,
+  E extends FieldElement<T> = FieldElement<T>,
+> extends VaadinFieldStrategy<T, E> {
+  override set value(val: T | undefined) {
+    if (!val || isEmptyObject(val)) {
+      super.value = '' as T;
+    }
+    const date = Date.parse(val as string);
+    super.value = (Number.isNaN(date) ? '' : new Date(date).toISOString().slice(0, 19)) as T;
+  }
+}
 
 type MultiSelectComboBoxFieldElement<T> = FieldElement<T> & {
   value: never;
@@ -349,6 +365,8 @@ export function getDefaultFieldStrategy<T>(elm: FieldElement<T>, model?: Abstrac
         elm as FieldElement<string>,
         model as AbstractModel<string>,
       ) as AbstractFieldStrategy<T>;
+    case 'vaadin-date-time-picker':
+      return new VaadinDateTimeFieldStrategy(elm, model) as AbstractFieldStrategy<T>;
     default:
       if (elm.localName === 'input' && /^(checkbox|radio)$/u.test((elm as unknown as HTMLInputElement).type)) {
         return new CheckedFieldStrategy(elm as CheckedFieldElement<T>, model);

--- a/packages/ts/lit-form/src/Field.ts
+++ b/packages/ts/lit-form/src/Field.ts
@@ -296,6 +296,10 @@ export class VaadinDateTimeFieldStrategy<
   T = string,
   E extends FieldElement<T> = FieldElement<T>,
 > extends VaadinFieldStrategy<T, E> {
+  override get value(): T | undefined {
+    return super.value;
+  }
+
   override set value(val: T | undefined) {
     if (!val || isEmptyObject(val)) {
       super.value = '' as T;

--- a/packages/ts/lit-form/test/Field.test.ts
+++ b/packages/ts/lit-form/test/Field.test.ts
@@ -21,6 +21,7 @@ import {
   MultiSelectComboBoxFieldStrategy,
   Required,
   SelectedFieldStrategy,
+  VaadinDateTimeFieldStrategy,
   VaadinFieldStrategy,
   CheckedGroupFieldStrategy,
 } from '../src/index.js';
@@ -593,6 +594,39 @@ describe('@vaadin/hilla-lit-form', () => {
             expect(currentStrategy.value).to.be.equal('');
             expect(element.value).to.be.equal('');
           });
+        });
+      });
+
+      describe(`VaadinStringFieldStrategy vaadin-date-time-picker`, () => {
+        const tagName = unsafeStatic('vaadin-date-time-picker');
+        let currentStrategy: FieldStrategy;
+        let element: Element & { value?: any };
+
+        function renderTag(model: AbstractModel) {
+          render(
+            html`
+                <${tagName} ${field(model)}></${tagName}>`,
+            div,
+          );
+          currentStrategy = getFieldStrategySpy.lastCall.returnValue;
+          element = div.firstElementChild as Element & { value?: string };
+        }
+
+        it('should clear optional field to an empty string', () => {
+          const model = binder.model.fieldOptionalString;
+
+          binder.read({ ...TestModel.createEmptyValue(), fieldOptionalString: '2024-12-14T11:15:30.1234567' });
+          renderTag(model);
+
+          currentStrategy = getFieldStrategySpy.lastCall.returnValue;
+          expect(currentStrategy instanceof VaadinDateTimeFieldStrategy).to.be.true;
+          expect(currentStrategy.value).to.be.equal('2024-12-14T11:15:30');
+          expect(element.value).to.be.equal('2024-12-14T11:15:30');
+
+          binder.clear();
+          renderTag(model);
+          expect(currentStrategy.value).to.be.equal('');
+          expect(element.value).to.be.equal('');
         });
       });
 

--- a/packages/ts/react-crud/src/model-info.ts
+++ b/packages/ts/react-crud/src/model-info.ts
@@ -38,7 +38,12 @@ const javaTypeMap: Record<string, PropertyType> = {
   'java.lang.Double': 'decimal',
   'java.time.LocalDate': 'date',
   'java.time.LocalTime': 'time',
+  'java.time.OffsetTime': 'time',
   'java.time.LocalDateTime': 'datetime',
+  'java.time.OffsetDateTime': 'datetime',
+  'java.time.ZonedDateTime': 'datetime',
+  'java.util.Date': 'datetime',
+  'java.sql.Date': 'datetime',
 };
 
 function determinePropertyType(model: AbstractModel): PropertyType {

--- a/packages/ts/react-crud/test/model-info.spec.ts
+++ b/packages/ts/react-crud/test/model-info.spec.ts
@@ -43,7 +43,12 @@ describe('@vaadin/hilla-react-crud', () => {
 
       expect(getPropertyType(StringModel, 'java.time.LocalDate')).to.equal('date');
       expect(getPropertyType(StringModel, 'java.time.LocalTime')).to.equal('time');
+      expect(getPropertyType(StringModel, 'java.time.OffsetTime')).to.equal('time');
       expect(getPropertyType(StringModel, 'java.time.LocalDateTime')).to.equal('datetime');
+      expect(getPropertyType(StringModel, 'java.time.ZonedDateTime')).to.equal('datetime');
+      expect(getPropertyType(StringModel, 'java.time.OffsetDateTime')).to.equal('datetime');
+      expect(getPropertyType(StringModel, 'java.util.Date')).to.equal('datetime');
+      expect(getPropertyType(StringModel, 'java.sql.Date')).to.equal('datetime');
     });
 
     describe('getProperty', () => {


### PR DESCRIPTION
- Always convert it to YYYY-MM-ddTHH:mm:ss.SSS as other formats are not allowed for time being (https://github.com/vaadin/web-components/pull/3953#discussion_r902399701)
- Add support for other datetime types, but formatting must be done by server

Fixes: https://github.com/vaadin/hilla/issues/2770
and adds support for https://github.com/vaadin/hilla/issues/2390-

For time zone types, @JsonConverter or @JsonDeserializer needs to be used, as DateTimePicker does not support time zones, so that time zone is adjusted on the server side.