### PR TITLE
refactor: notify clients with acceptance/rejection of events instead of snapshots

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/ValueSignal.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/ValueSignal.java
@@ -74,9 +74,8 @@ public class ValueSignal<T> {
             LOGGER.debug("New Flux subscription...");
             lock.lock();
             try {
-                var currentValue = createStatusUpdateEvent(this.id.toString(),
-                        StateEvent.EventType.SNAPSHOT);
-                sink.tryEmitNext(currentValue);
+                var snapshot = createSnapshotEvent();
+                sink.tryEmitNext(snapshot);
                 subscribers.add(sink);
             } finally {
                 lock.unlock();
@@ -102,14 +101,11 @@ public class ValueSignal<T> {
     public void submit(ObjectNode event) {
         lock.lock();
         try {
-            boolean success = processEvent(event);
+            boolean accepted = processEvent(event);
             // Notify subscribers
             subscribers.removeIf(sink -> {
-                var updatedValue = createStatusUpdateEvent(
-                        event.get("id").asText(),
-                        success ? StateEvent.EventType.SNAPSHOT
-                                : StateEvent.EventType.REJECT);
-                boolean failure = sink.tryEmitNext(updatedValue).isFailure();
+                var eventWithStatus = StateEvent.setAccepted(event, accepted);
+                boolean failure = sink.tryEmitNext(eventWithStatus).isFailure();
                 if (failure) {
                     LOGGER.debug("Failed push");
                 }
@@ -139,10 +135,10 @@ public class ValueSignal<T> {
         return this.value;
     }
 
-    private ObjectNode createStatusUpdateEvent(String eventId,
-            StateEvent.EventType eventType) {
-        var snapshot = new StateEvent<>(eventId, eventType, this.value);
-        return snapshot.toJson();
+    private ObjectNode  createSnapshotEvent() {
+        var snapshot = new StateEvent<>(getId().toString(),
+            StateEvent.EventType.SNAPSHOT, this.value).toJson();
+        return StateEvent.setAccepted(snapshot, true);
     }
 
     /**

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/event/StateEvent.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/core/event/StateEvent.java
@@ -25,13 +25,14 @@ public class StateEvent<T> {
         public static final String TYPE = "type";
         public static final String VALUE = "value";
         public static final String EXPECTED = "expected";
+        public static final String ACCEPTED = "accepted";
     }
 
     /**
      * Possible types of state events.
      */
     public enum EventType {
-        SNAPSHOT, SET, REPLACE, REJECT, INCREMENT
+        SNAPSHOT, SET, REPLACE, INCREMENT
     }
 
     /**
@@ -163,6 +164,15 @@ public class StateEvent<T> {
             json.set(Field.EXPECTED, valueAsJsonNode(getExpected()));
         }
         return json;
+    }
+
+    public static ObjectNode setAccepted(ObjectNode event, boolean accepted) {
+        return event.put(Field.ACCEPTED, accepted);
+    }
+
+    public static boolean isAccepted(ObjectNode event) {
+        return event.has(Field.ACCEPTED)
+            && event.get(Field.ACCEPTED).asBoolean();
     }
 
     private JsonNode valueAsJsonNode(T value) {

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/ValueSignalTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/ValueSignalTest.java
@@ -12,9 +12,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ValueSignalTest {
 
@@ -96,9 +98,13 @@ public class ValueSignalTest {
                 // notification for the initial value
                 assertNull(stateEvent.getValue());
             } else if (counter.get() == 1) {
+                assertTrue(StateEvent.isAccepted(eventJson));
                 assertEquals(name, stateEvent.getValue().getName());
+                assertEquals(name, signal.getValue().getName());
                 assertEquals(age, stateEvent.getValue().getAge());
+                assertEquals(age, signal.getValue().getAge());
                 assertEquals(adult, stateEvent.getValue().isAdult());
+                assertEquals(adult, signal.getValue().isAdult());
             }
             counter.incrementAndGet();
         });
@@ -123,12 +129,14 @@ public class ValueSignalTest {
             if (counter.get() == 0) {
                 // notification for the initial value
                 assertEquals(2.0, stateEvent.getValue(), 0.0);
+                assertTrue(StateEvent.isAccepted(eventJson));
             } else if (counter.get() == 1) {
                 assertEquals(conditionalReplaceEvent.get(StateEvent.Field.ID)
-                        .asText(), stateEvent.getId());
-                assertEquals(StateEvent.EventType.SNAPSHOT,
-                        stateEvent.getEventType());
-                assertEquals(3.0, stateEvent.getValue(), 0.0);
+                    .asText(), stateEvent.getId());
+                assertEquals(StateEvent.EventType.REPLACE,
+                    stateEvent.getEventType());
+                assertTrue(StateEvent.isAccepted(eventJson));
+                assertEquals(3.0, signal.getValue(), 0.0);
             }
             counter.incrementAndGet();
         });
@@ -151,13 +159,14 @@ public class ValueSignalTest {
             var stateEvent = new StateEvent<>(eventJson, Double.class);
             if (counter.get() == 0) {
                 // notification for the initial value
-                assertEquals(1.0, stateEvent.getValue(), 0.0);
+                assertTrue(StateEvent.isAccepted(eventJson));
             } else if (counter.get() == 1) {
                 assertEquals(conditionalReplaceEvent.get(StateEvent.Field.ID)
-                        .asText(), stateEvent.getId());
-                assertEquals(StateEvent.EventType.REJECT,
-                        stateEvent.getEventType());
-                assertEquals(1.0, stateEvent.getValue(), 0.0);
+                    .asText(), stateEvent.getId());
+                assertEquals(StateEvent.EventType.REPLACE,
+                    stateEvent.getEventType());
+                assertFalse(StateEvent.isAccepted(eventJson));
+                assertEquals(1.0, signal.getValue(), 0.0);
             }
             counter.incrementAndGet();
         });

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/event/StateEventTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/core/event/StateEventTest.java
@@ -133,7 +133,7 @@ public class StateEventTest {
                 StateEvent.InvalidEventTypeException.class,
                 () -> new StateEvent<>(json, String.class));
 
-        String expectedMessage = "Invalid event type invalidType. Type should be one of: [SNAPSHOT, SET, REPLACE, REJECT, INCREMENT]";
+        String expectedMessage = "Invalid event type invalidType. Type should be one of: [SNAPSHOT, SET, REPLACE, INCREMENT]";
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));
@@ -152,7 +152,7 @@ public class StateEventTest {
                 StateEvent.InvalidEventTypeException.class,
                 () -> new StateEvent<>(json, String.class));
 
-        String expectedMessage = "Missing event type. Type is required, and should be one of: [SNAPSHOT, SET, REPLACE, REJECT, INCREMENT]";
+        String expectedMessage = "Missing event type. Type is required, and should be one of: [SNAPSHOT, SET, REPLACE, INCREMENT]";
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/handler/SignalsHandlerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/handler/SignalsHandlerTest.java
@@ -96,7 +96,7 @@ public class SignalsHandlerTest {
 
         var expectedUpdatedSignalEventJson = new ObjectNode(
                 mapper.getNodeFactory()).put("value", 42.0)
-                .put("id", signalId.toString()).put("type", "snapshot");
+                .put("id", signalId.toString()).put("type", "snapshot").put("accepted", true);
         StepVerifier.create(firstFlux)
                 .expectNext(expectedUpdatedSignalEventJson).thenCancel()
                 .verify();

--- a/packages/ts/react-signals/src/NumberSignal.ts
+++ b/packages/ts/react-signals/src/NumberSignal.ts
@@ -1,5 +1,5 @@
-import { createIncrementStateEvent } from './events.js';
-import { $update } from './FullStackSignal.js';
+import { createIncrementStateEvent, type StateEvent } from './events.js';
+import { $processServerResponse, $update } from './FullStackSignal.js';
 import { ValueSignal } from './ValueSignal.js';
 
 /**
@@ -26,6 +26,7 @@ import { ValueSignal } from './ValueSignal.js';
  * ```
  */
 export class NumberSignal extends ValueSignal<number> {
+  readonly #sentIncrementEvents = new Map<string, StateEvent<number>>();
   /**
    * Increments the value by the specified delta. The delta can be negative to
    * decrease the value.
@@ -44,6 +45,19 @@ export class NumberSignal extends ValueSignal<number> {
     }
     this.setValueLocal(this.value + delta);
     const event = createIncrementStateEvent(delta);
+    this.#sentIncrementEvents.set(event.id, event);
     this[$update](event);
+  }
+
+  protected override [$processServerResponse](event: StateEvent<number>): void {
+    if (event.accepted && event.type === 'increment') {
+      if (this.#sentIncrementEvents.has(event.id)) {
+        this.#sentIncrementEvents.delete(event.id);
+        return;
+      }
+      this.setValueLocal(this.value + event.value);
+    } else {
+      super[$processServerResponse](event);
+    }
   }
 }

--- a/packages/ts/react-signals/src/events.ts
+++ b/packages/ts/react-signals/src/events.ts
@@ -9,6 +9,7 @@ type CreateStateEventType<V, T extends string, C extends Record<string, unknown>
     id: string;
     type: T;
     value: V;
+    accepted: boolean;
   }> &
     Readonly<C>
 >;
@@ -19,11 +20,8 @@ type CreateStateEventType<V, T extends string, C extends Record<string, unknown>
  */
 export type SnapshotStateEvent<T> = CreateStateEventType<T, 'snapshot'>;
 
-export type RejectStateEvent = CreateStateEventType<never, 'reject'>;
-
 /**
  * A state event defines a new value of the signal shared with the server. The
- *
  */
 export type SetStateEvent<T> = CreateStateEventType<T, 'set'>;
 
@@ -32,6 +30,7 @@ export function createSetStateEvent<T>(value: T): SetStateEvent<T> {
     id: nanoid(),
     type: 'set',
     value,
+    accepted: false,
   };
 }
 
@@ -43,6 +42,7 @@ export function createReplaceStateEvent<T>(expected: T, value: T): ReplaceStateE
     type: 'replace',
     value,
     expected,
+    accepted: false,
   };
 }
 
@@ -53,15 +53,11 @@ export function createIncrementStateEvent(delta: number): IncrementStateEvent {
     id: nanoid(),
     type: 'increment',
     value: delta,
+    accepted: false,
   };
 }
 
 /**
  * An object that describes the change of the signal state.
  */
-export type StateEvent<T> =
-  | IncrementStateEvent
-  | RejectStateEvent
-  | ReplaceStateEvent<T>
-  | SetStateEvent<T>
-  | SnapshotStateEvent<T>;
+export type StateEvent<T> = IncrementStateEvent | ReplaceStateEvent<T> | SetStateEvent<T> | SnapshotStateEvent<T>;

--- a/packages/ts/react-signals/test/FullStackSignal.spec.tsx
+++ b/packages/ts/react-signals/test/FullStackSignal.spec.tsx
@@ -51,8 +51,11 @@ describe('@vaadin/hilla-react-signals', () => {
   });
 
   describe('FullStackSignal', () => {
-    function createSnapshotEvent(value: number): SnapshotStateEvent<number> {
-      return { id: nanoid(), type: 'snapshot', value };
+    function createAcceptedEvent(
+      value: number,
+      type: 'increment' | 'replace' | 'set' | 'snapshot',
+    ): StateEvent<number> {
+      return { id: nanoid(), type, value, expected: 0, accepted: true };
     }
 
     function simulateReceivedChange(
@@ -184,7 +187,7 @@ describe('@vaadin/hilla-react-signals', () => {
       await nextFrame();
 
       // Simulate the event received from the server:
-      const snapshotEvent = createSnapshotEvent(42);
+      const snapshotEvent = createAcceptedEvent(42, 'snapshot');
       simulateReceivedChange(subscription, snapshotEvent);
 
       // Check if the signal value is updated:
@@ -196,13 +199,13 @@ describe('@vaadin/hilla-react-signals', () => {
 
       let result = render(<span>Value is {numberSignal}</span>);
       await nextFrame();
-      simulateReceivedChange(subscription, createSnapshotEvent(42));
+      simulateReceivedChange(subscription, createAcceptedEvent(42, 'snapshot'));
 
       result = render(<span>Value is {numberSignal}</span>);
       await nextFrame();
       expect(result.container.textContent).to.equal('Value is 42');
 
-      simulateReceivedChange(subscription, createSnapshotEvent(99));
+      simulateReceivedChange(subscription, createAcceptedEvent(99, 'set'));
       await nextFrame();
       expect(result.container.textContent).to.equal('Value is 99');
     });

--- a/packages/ts/react-signals/test/NumberSignal.spec.tsx
+++ b/packages/ts/react-signals/test/NumberSignal.spec.tsx
@@ -18,9 +18,9 @@ describe('@vaadin/hilla-react-signals', () => {
   let subscription: sinon.SinonStubbedInstance<Subscription<StateEvent<number>>>;
   let client: sinon.SinonStubbedInstance<ConnectClient>;
 
-  function simulateReceivingSnapshot(eventId: string, value: number): void {
+  function simulateReceivingAcceptedEvent(event: StateEvent<number>): void {
     const [onNextCallback] = subscription.onNext.firstCall.args;
-    onNextCallback({ id: eventId, type: 'snapshot', value });
+    onNextCallback({ ...event, accepted: true });
   }
 
   beforeEach(() => {
@@ -78,35 +78,38 @@ describe('@vaadin/hilla-react-signals', () => {
 
       numberSignal.incrementBy(1);
       const [, , params1] = client.call.firstCall.args;
+      // @ts-expect-error params.event type has id property
+      const expectedEvent1 = { id: params1?.event.id, type: 'increment', value: 1 };
       expect(client.call).to.have.been.calledWithMatch('SignalsHandler', 'update', {
         clientSignalId: numberSignal.id,
-        // @ts-expect-error params.event type has id property
-        event: { id: params1?.event.id, type: 'increment', value: 1 },
+        event: expectedEvent1,
       });
       // @ts-expect-error params.event type has id property
-      simulateReceivingSnapshot(params1?.event.id, 43);
+      simulateReceivingAcceptedEvent(expectedEvent1);
       expect(numberSignal.value).to.equal(43);
 
       numberSignal.incrementBy(2);
       const [, , params2] = client.call.secondCall.args;
+      // @ts-expect-error params.event type has id property
+      const expectedEvent2 = { id: params2?.event.id, type: 'increment', value: 2 };
       expect(client.call).to.have.been.calledWithMatch('SignalsHandler', 'update', {
         clientSignalId: numberSignal.id,
-        // @ts-expect-error params.event type has id property
-        event: { id: params2?.event.id, type: 'increment', value: 2 },
+        event: expectedEvent2,
       });
       // @ts-expect-error params.event type has id property
-      simulateReceivingSnapshot(params2?.event.id, 45);
+      simulateReceivingAcceptedEvent(expectedEvent2);
       expect(numberSignal.value).to.equal(45);
 
       numberSignal.incrementBy(-5);
       const [, , params3] = client.call.thirdCall.args;
+      // @ts-expect-error params.event type has id property
+      const expectedEvent3 = { id: params3?.event.id, type: 'increment', value: -5 };
       expect(client.call).to.have.been.calledWithMatch('SignalsHandler', 'update', {
         clientSignalId: numberSignal.id,
-        // @ts-expect-error params.event type has id property
-        event: { id: params3?.event.id, type: 'increment', value: -5 },
+        event: expectedEvent3,
       });
       // @ts-expect-error params.event type has id property
-      simulateReceivingSnapshot(params3?.event.id, 40);
+      simulateReceivingAcceptedEvent(expectedEvent3);
       expect(numberSignal.value).to.equal(40);
     });
 

--- a/packages/ts/react-signals/test/ValueSignal.spec.tsx
+++ b/packages/ts/react-signals/test/ValueSignal.spec.tsx
@@ -133,7 +133,7 @@ describe('@vaadin/hilla-react-signals', () => {
       expect(valueSignal.value).to.equal('baz');
     });
 
-    it('should send the correct event and update the value when receiving snapshot event after calling update', async () => {
+    it('should send the correct event and update the value when receiving accepted event after calling update', async () => {
       const valueSignal = new ValueSignal<string>('ba', config);
       render(<div>{valueSignal}</div>);
       await nextFrame();
@@ -142,15 +142,16 @@ describe('@vaadin/hilla-react-signals', () => {
       const [, , params] = client.call.firstCall.args;
 
       expect(client.call).to.have.been.calledOnce;
+      // @ts-expect-error params.event type has id property
+      const expectedEvent = { id: params?.event.id, type: 'replace', value: 'bar', expected: 'ba' };
       expect(client.call).to.have.been.calledWithMatch('SignalsHandler', 'update', {
         clientSignalId: valueSignal.id,
-        // @ts-expect-error params.event type has id property
-        event: { id: params?.event.id, type: 'replace', value: 'bar', expected: 'ba' },
+        event: expectedEvent,
       });
 
       const [onNextCallback] = subscription.onNext.firstCall.args;
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params?.event.id, type: 'snapshot', value: 'bar' });
+      onNextCallback({ ...expectedEvent, accepted: true });
       expect(valueSignal.value).to.equal('bar');
     });
 
@@ -171,12 +172,12 @@ describe('@vaadin/hilla-react-signals', () => {
 
       const [onNextCallback] = subscription.onNext.firstCall.args;
 
-      // Simulate a snapshot event representing a concurrent value change before the reject is received:
-      onNextCallback({ id: 'another-event-id', type: 'snapshot', value: 'b' });
+      // Simulate an accepted event representing a concurrent value change before the reject is received:
+      onNextCallback({ id: 'another-event-id', type: 'replace', value: 'b', expected: 'a', accepted: true });
       expect(valueSignal.value).to.equal('b');
 
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params1?.event.id, type: 'reject', value: 'dont care' });
+      onNextCallback({ id: params1?.event.id, type: 'replace', value: 'aa', expected: 'a', accepted: false });
       // verify that the value is not updated after receiving a reject event:
       expect(valueSignal.value).to.equal('b');
       // verify that receiving reject event triggers another update call:
@@ -185,54 +186,52 @@ describe('@vaadin/hilla-react-signals', () => {
       expect(client.call).to.have.been.calledWithMatch('SignalsHandler', 'update', {
         clientSignalId: valueSignal.id,
         // @ts-expect-error params.event type has id property
-        event: { id: params2?.event.id, type: 'replace', value: 'ba', expected: 'b' },
+        event: { id: params2?.event.id, type: 'replace', value: 'ba', expected: 'b', accepted: false },
       });
 
       // Simulate another concurrent value change before the reject is received:
-      onNextCallback({ id: 'another-event-id', type: 'snapshot', value: 'c' });
+      onNextCallback({ id: 'another-event-id', type: 'replace', value: 'c', expected: 'b', accepted: true });
       expect(valueSignal.value).to.equal('c');
 
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params2?.event.id, type: 'reject' });
+      onNextCallback({ id: params2?.event.id, type: 'replace', value: 'ba', expected: 'b', accepted: false });
       expect(client.call).to.have.been.calledThrice;
       const [, , params3] = client.call.thirdCall.args;
       expect(client.call).to.have.been.calledWithMatch('SignalsHandler', 'update', {
         clientSignalId: valueSignal.id,
         // @ts-expect-error params.event type has id property
-        event: { id: params3?.event.id, type: 'replace', value: 'ca', expected: 'c' },
+        event: { id: params3?.event.id, type: 'replace', value: 'ca', expected: 'c', accepted: false },
       });
 
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params3?.event.id, type: 'reject', value: 'dont care' });
+      onNextCallback({ id: params3?.event.id, type: 'replace', value: 'ca', expected: 'c', accepted: false });
       expect(client.call).to.have.been.callCount(4);
 
       setTimeout(() => updateOperation.cancel(), 500);
       expect(valueSignal.value).to.equal('c');
     });
 
-    it('should update the value when receive snapshot event following reject events after calling update', async () => {
+    it('should update the value when receive accepted event following rejected events after calling update', async () => {
       const valueSignal = new ValueSignal<string>('foo', config);
       expect(valueSignal.value).to.equal('foo');
       render(<div>{valueSignal}</div>);
       await nextFrame();
-
       const [onNextCallback] = subscription.onNext.firstCall.args;
-
       valueSignal.update((currValue) => `${currValue}bar`);
       const [, , params1] = client.call.firstCall.args;
 
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params1?.event.id, type: 'reject', value: 'dont care' });
+      onNextCallback({ id: params1?.event.id, type: 'replace', value: 'dont care', accepted: false });
       expect(valueSignal.value).to.equal('foo');
 
       const [, , params2] = client.call.secondCall.args;
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params2?.event.id, type: 'reject', value: 'dont care' });
+      onNextCallback({ id: params2?.event.id, type: 'replace', value: 'dont care', accepted: false });
       expect(valueSignal.value).to.equal('foo');
 
       const [, , params3] = client.call.thirdCall.args;
       // @ts-expect-error params.event type has id property
-      onNextCallback({ id: params3?.event.id, type: 'snapshot', value: 'foobar' });
+      onNextCallback({ id: params3?.event.id, type: 'replace', value: 'foobar', expected: 'foo', accepted: true });
       expect(valueSignal.value).to.equal('foobar');
     });
   });


### PR DESCRIPTION
## Description

This changes the way updates are sent to the clients after the acceptance/rejection of an event on the server. With this applied, the REJECT event is removed and SNAPSHOT event containing the current state of the server-side signal only when (re)subscribing to a signal and not after each update. The events received by the server regarding each update to a signal is propagated to the clients with a boolean value that indicates the acceptance/rejection of the operation so clients decide to discard/apply/confirm the operation on their local value.

This unifies the way with how List signals are going to work: to get snapshot events with the current state on the server only when subscribing signals (which can be a long list of values), and then getting updates of individual operations for subsequent updates, one at a time.

Part of #2654