### PR TITLE
fix: if config doesn't exist, add minimal one with flowLayout

### DIFF
--- a/packages/ts/file-router/src/vite-plugin/createViewConfigJson.ts
+++ b/packages/ts/file-router/src/vite-plugin/createViewConfigJson.ts
@@ -74,6 +74,10 @@ export default async function createViewConfigJson(views: readonly RouteMeta[]):
             }
           }
 
+          if (config === undefined) {
+            config = { flowLayout: flowLayout ?? false };
+          }
+
           let title: string;
 
           if (config?.title) {

--- a/packages/ts/file-router/src/vite-plugin/createViewConfigJson.ts
+++ b/packages/ts/file-router/src/vite-plugin/createViewConfigJson.ts
@@ -80,7 +80,7 @@ export default async function createViewConfigJson(views: readonly RouteMeta[]):
 
           let title: string;
 
-          if (config?.title) {
+          if (config.title) {
             ({ title } = config);
           } else {
             if (!componentName) {
@@ -95,7 +95,7 @@ export default async function createViewConfigJson(views: readonly RouteMeta[]):
           return {
             route: convertFSRouteSegmentToURLPatternFormat(path),
             ...config,
-            params: extractParameterFromRouteSegment(config?.route ?? path),
+            params: extractParameterFromRouteSegment(config.route ?? path),
             title,
             children: newChildren ?? (layout ? [] : undefined),
           } satisfies ServerViewConfig;


### PR DESCRIPTION
When Hilla view has no config, make sure to create a minimal config for it, containing the `flowLayout` value.

Fixes https://github.com/vaadin/flow/issues/20110