### PR TITLE
fix: Check main layout presence separately (#2831)(CP: main)

### DIFF
--- a/packages/java/endpoint/src/test/resources/META-INF/VAADIN/server-and-client-views-layout-and-index-route.json
+++ b/packages/java/endpoint/src/test/resources/META-INF/VAADIN/server-and-client-views-layout-and-index-route.json
@@ -1,0 +1,87 @@
+{
+  "/foo": {
+    "params": {},
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "loginRequired": false,
+    "route": "/foo",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "flowLayout":false
+  },
+  "/bar": {
+    "params": {},
+    "title": "Component",
+    "rolesAllowed": null,
+    "loginRequired": false,
+    "route": "/bar",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "flowLayout":false
+  },
+  "": {
+    "title": "Home",
+    "rolesAllowed": null,
+    "loginRequired": false,
+    "route": "",
+    "lazy": false,
+    "register": false,
+    "menu": {
+      "title": "Home",
+      "order": null,
+      "exclude": false,
+      "icon": null,
+      "menuClass": null
+    },
+    "flowLayout":false,
+    "params": {}
+  },
+  "/comments": {
+    "params": {
+      ":___commentId?": "opt"
+    },
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "loginRequired": false,
+    "route": "/comments",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "flowLayout":false
+  },
+  "/wildcard": {
+    "params": {
+      ":___wildcard*": "*"
+    },
+    "title": "RouteTarget",
+    "rolesAllowed": null,
+    "loginRequired": false,
+    "route": "/wildcard",
+    "lazy": false,
+    "register": false,
+    "menu": null,
+    "flowLayout":false
+  },
+  "/profile": {
+    "params": {},
+    "title": "Profile",
+    "rolesAllowed": [
+      "ROLE_USER",
+      "ROLE_ADMIN"
+    ],
+    "loginRequired": true,
+    "route": "/profile",
+    "lazy": false,
+    "register": false,
+    "menu": {
+      "title": "Profile",
+      "order": null,
+      "exclude": false,
+      "icon": null,
+      "menuClass": null
+    },
+    "flowLayout":false
+  }
+}

--- a/packages/java/endpoint/src/test/resources/com/vaadin/hilla/route/clientRoutesWithLayoutAndIndexView.json
+++ b/packages/java/endpoint/src/test/resources/com/vaadin/hilla/route/clientRoutesWithLayoutAndIndexView.json
@@ -1,0 +1,35 @@
+[
+  {
+    "route": "",
+    "params": {},
+    "title": "Layout",
+    "children": [
+      {
+        "route": "",
+        "params": {},
+        "title": "Home"
+      },
+      {
+        "route": "/profile",
+        "params": {},
+        "title": "Profile",
+        "loginRequired": true,
+        "rolesAllowed": [
+          "ROLE_USER",
+          "ROLE_ADMIN"
+        ]
+      },
+      {
+        "route": "/user/:userId",
+        "loginRequired": true,
+        "rolesAllowed": [
+          "ROLE_ADMIN"
+        ],
+        "params": {
+          ":userId": "req"
+        },
+        "title": "User Profile"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

MenuRegistry::collectClientViews erases/overrides the layout entry by the view entry, if they have the same mapping, e.g. when you add @layout.tsx and @index.tsx in the same folder.

Thus, the ServerAndClientViewsProvider::hasMainMenu method may not get all the layouts in the input collection.

That leads to hasMainMenu=false and to skipping menu entries for Flow routes.

This patch uses https://github.com/vaadin/flow/pull/20245 new method to detect top-level main layout that fulfils the same criteria: empty route, non-null children, no other root elements.

Related-to https://github.com/vaadin/hilla/issues/2825

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
