### PR TITLE
fix(parser): add position information to type signature node

### DIFF
--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/TypeSignaturePlugin.java
@@ -338,17 +338,15 @@ public final class TypeSignaturePlugin
     private NodeDependencies scanTypeSignature(TypeSignatureNode node,
             NodeDependencies nodeDependencies) {
         var signature = node.getSource();
+        var referredTypes = getReferredTypes(signature);
 
-        if (signature instanceof ClassRefSignatureModel) {
-            var classModel = (ClassRefSignatureModel) signature;
-            // Create dependencies for type arguments
-            nodeDependencies = nodeDependencies.appendChildNodes(classModel
-                    .getTypeArguments().stream().map(TypeSignatureNode::of));
+        for (var i = 0; i < referredTypes.size(); i++) {
+            var referredType = referredTypes.get(i);
+            nodeDependencies = nodeDependencies.appendChildNodes(
+                    Stream.of(TypeSignatureNode.of(referredType, i)));
         }
 
-        var referredTypes = getReferredTypes(signature);
-        return nodeDependencies.appendChildNodes(
-                referredTypes.stream().map(TypeSignatureNode::of));
+        return nodeDependencies;
     }
 
     private String signatureToTypeString(SignatureModel type) {

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/nodes/TypeSignatureNode.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/nodes/TypeSignatureNode.java
@@ -1,6 +1,7 @@
 package com.vaadin.hilla.parser.plugins.backbone.nodes;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 import com.vaadin.hilla.parser.core.AbstractNode;
@@ -13,15 +14,18 @@ import jakarta.annotation.Nonnull;
 public final class TypeSignatureNode
         extends AbstractNode<SignatureModel, Schema<?>> implements TypedNode {
     private final List<AnnotationInfoModel> annotations;
+    private final Integer position;
 
     private TypeSignatureNode(SignatureModel source, Schema<?> target,
-            List<AnnotationInfoModel> annotations) {
+            List<AnnotationInfoModel> annotations, Integer position) {
         super(source, target);
         this.annotations = annotations;
+        this.position = position;
     }
 
-    private TypeSignatureNode(SignatureModel source, Schema<?> target) {
-        this(source, target, source.getAnnotations());
+    private TypeSignatureNode(SignatureModel source, Schema<?> target,
+            Integer position) {
+        this(source, target, source.getAnnotations(), position);
     }
 
     public List<AnnotationInfoModel> getAnnotations() {
@@ -40,11 +44,45 @@ public final class TypeSignatureNode
         }
 
         return new TypeSignatureNode(typeProcessor.apply(getSource()),
-                getTarget(), annotations);
+                getTarget(), annotations, position);
     }
 
     @Nonnull
     static public TypeSignatureNode of(@Nonnull SignatureModel source) {
-        return new TypeSignatureNode(source, new Schema<>());
+        return new TypeSignatureNode(source, new Schema<>(), null);
+    }
+
+    @Nonnull
+    static public TypeSignatureNode of(@Nonnull SignatureModel source,
+            int position) {
+        return new TypeSignatureNode(source, new Schema<>(), position);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        boolean eq = super.equals(o);
+
+        if (eq) {
+            var other = (TypeSignatureNode) o;
+            eq = Objects.equals(position, other.position);
+        }
+
+        return eq;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ Objects.hashCode(position);
+    }
+
+    @Override
+    public String toString() {
+        var str = super.toString();
+
+        if (position != null) {
+            str += "[" + position + "]";
+        }
+
+        return str;
     }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/generics/GenericsBareEntityEndpoint.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/java/com/vaadin/hilla/parser/plugins/backbone/generics/GenericsBareEntityEndpoint.java
@@ -21,4 +21,14 @@ public class GenericsBareEntityEndpoint {
             GenericsBareRefEntity<List<Float>> ref) {
         return ref;
     }
+
+    public record GenericsRecord<T1,T2>(
+    T1 first, T2 second)
+    {
+    }
+
+    public GenericsRecord<String, String> getRecord(
+            GenericsRecord<String, String> record) {
+        return record;
+    }
 }

--- a/packages/java/parser-jvm-plugin-backbone/src/test/resources/com/vaadin/hilla/parser/plugins/backbone/generics/openapi.json
+++ b/packages/java/parser-jvm-plugin-backbone/src/test/resources/com/vaadin/hilla/parser/plugins/backbone/generics/openapi.json
@@ -261,6 +261,72 @@
         }
       }
     },
+    "/GenericsBareEntityEndpoint/getRecord": {
+      "post": {
+        "tags": ["GenericsBareEntityEndpoint"],
+        "operationId": "GenericsBareEntityEndpoint_getRecord_POST",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "record": {
+                    "nullable": true,
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/com.vaadin.hilla.parser.plugins.backbone.generics.GenericsBareEntityEndpoint$GenericsRecord"
+                      }
+                    ],
+                    "x-type-arguments": {
+                      "allOf": [
+                        {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/com.vaadin.hilla.parser.plugins.backbone.generics.GenericsBareEntityEndpoint$GenericsRecord"
+                    }
+                  ],
+                  "x-type-arguments": {
+                    "allOf": [
+                      {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      {
+                        "type": "string",
+                        "nullable": true
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/GenericsExtendedEndpoint/getMap": {
       "post": {
         "tags": ["GenericsExtendedEndpoint"],
@@ -718,11 +784,11 @@
               }
             ],
             "x-type-arguments": { 
-              "allOf" : [
+              "allOf": [
                 {
-                  "type" : "object",
-                  "nullable" : true,
-                  "x-type-variable" : "T"
+                  "type": "object",
+                  "nullable": true,
+                  "x-type-variable": "T"
                 }
               ]
             }
@@ -740,6 +806,25 @@
             "nullable": true
           }
         }
+      },
+      "com.vaadin.hilla.parser.plugins.backbone.generics.GenericsBareEntityEndpoint$GenericsRecord": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "object",
+            "nullable": true,
+            "x-type-variable": "T1"
+          },
+          "second": {
+            "type": "object",
+            "nullable": true,
+            "x-type-variable": "T2"
+          }
+        },
+        "x-type-parameters": [
+          "T1",
+          "T2"
+        ]
       },
       "com.vaadin.hilla.parser.plugins.backbone.generics.GenericsExtendedRefEntity": {
         "type": "object",
@@ -762,7 +847,7 @@
           }
         }
       },
-      "com.vaadin.hilla.parser.plugins.backbone.generics.ConcreteType" : {
+      "com.vaadin.hilla.parser.plugins.backbone.generics.ConcreteType": {
         "type": "object"
       }
     }


### PR DESCRIPTION
Adds position information to `TypeSignatureNode` so that identical type arguments are retained thanks to their different position.

Fixes #2847