### PR TITLE
fix(crud): use 3-params overload for dates instead of separate assignments

### DIFF
--- a/packages/ts/react-crud/src/locale.ts
+++ b/packages/ts/react-crud/src/locale.ts
@@ -66,7 +66,8 @@ export class LocaleFormatter {
   formatDate(value?: DatePickerDate | string): string {
     if (typeof value === 'object') {
       const { year, month, day } = value;
-      const date = new Date(year, month, day);
+      const date = new Date();
+      date.setFullYear(year, month, day);
       return this.#date.format(date);
     }
 
@@ -96,7 +97,8 @@ export class LocaleFormatter {
     const day = Number(match?.groups?.day);
 
     // Verify that the parsed date is valid
-    const dateInstance = new Date(year, month, day);
+    const dateInstance = new Date();
+    dateInstance.setFullYear(year, month, day);
 
     if (dateInstance.getFullYear() !== year || dateInstance.getMonth() !== month || dateInstance.getDate() !== day) {
       return undefined;

--- a/packages/ts/react-crud/src/locale.ts
+++ b/packages/ts/react-crud/src/locale.ts
@@ -66,10 +66,7 @@ export class LocaleFormatter {
   formatDate(value?: DatePickerDate | string): string {
     if (typeof value === 'object') {
       const { year, month, day } = value;
-      const date = new Date();
-      date.setFullYear(year);
-      date.setMonth(month);
-      date.setDate(day);
+      const date = new Date(year, month, day);
       return this.#date.format(date);
     }
 
@@ -99,10 +96,7 @@ export class LocaleFormatter {
     const day = Number(match?.groups?.day);
 
     // Verify that the parsed date is valid
-    const dateInstance = new Date();
-    dateInstance.setFullYear(year);
-    dateInstance.setMonth(month);
-    dateInstance.setDate(day);
+    const dateInstance = new Date(year, month, day);
 
     if (dateInstance.getFullYear() !== year || dateInstance.getMonth() !== month || dateInstance.getDate() !== day) {
       return undefined;


### PR DESCRIPTION
Assigning year, month, and day, in this order, is problematic when the chosen month has less days than the current day of month.

So, for example, on Oct. 31st 2024, choosing Sept. 15th 2024 leads to 2024 -> Sept. 31 -> Oct. 1 -> Oct. 15.

Passing the 3 parameters at once avoids this problem.

Fixes #2887