### PR TITLE
fix(build): add `process` to script context

### DIFF
--- a/scripts/prepare/generate.ts
+++ b/scripts/prepare/generate.ts
@@ -37,6 +37,7 @@ async function loadScripts(): Promise<readonly [Writer, Transformer]> {
       exports,
       module: { exports },
       require: req,
+      process: { env: {} },
     };
     script.runInNewContext(ctx);
 


### PR DESCRIPTION
Adds a fake `process` to script context to allow building Hilla with recent Platform script requirements.