### PR TITLE
chore: add web-test-runner for react-auth

### DIFF
--- a/karma.config.cjs
+++ b/karma.config.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable import/unambiguous */
 const { parseArgs } = require('node:util');
 const { basename } = require('node:path');
 const { readFileSync } = require('node:fs');
@@ -13,11 +14,11 @@ const postcss = require('postcss');
 const cssnanoPlugin = require('cssnano');
 const { karmaMochaConfig } = require('./.mocharc.cjs');
 const reactPlugin = require('@vitejs/plugin-react');
-const { pathToFileURL, fileURLToPath} = require("node:url");
+const { pathToFileURL, fileURLToPath } = require('node:url');
 
 // The current package, one of the packages in the `packages` dir
 const cwd = pathToFileURL(`${process.cwd()}/`);
-const root = pathToFileURL(`${__dirname}/`)
+const root = pathToFileURL(`${__dirname}/`);
 
 function loadMockConfig() {
   try {
@@ -167,6 +168,10 @@ module.exports = (config) => {
               ...tsconfig.compilerOptions,
               useDefineForClassFields: false,
             },
+          },
+          supported: {
+            decorators: false,
+            'top-level-await': true,
           },
         },
         plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@types/karma": "^6.3.8",
         "@types/node": "^20.11.19",
         "@vaadin/react-components": "24.6.0-beta1",
-        "@vaadin/react-components": "24.6.0-beta1",
         "@vitejs/plugin-react": "^4.3.1",
         "@web/test-runner": "^0.19.0",
         "chai-dom": "^1.12.0",
@@ -3477,7 +3476,6 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
       "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
       }
@@ -4851,7 +4849,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4868,12 +4865,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/details": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4883,12 +4874,6 @@
       "integrity": "sha512-qf+IWtWgs7q+AV4DfMGYLNQTL6WDJJZkSmRF9gRXaoGrHHtPAY2KCOKjREQUX4YJvh/YBx4PQnNPBmLWX7z20A==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -4911,12 +4896,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/tooltip": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4926,17 +4905,7 @@
       "integrity": "sha512-CTVNYCYVvMKFSsCfQ6g0Jv8VdvzMepBM3fkVSe9XnlHzSNt+D+j6FqAgITPD1tmlRTKoRjZJ/sJZXQNFvvsuqQ==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/avatar": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/list-box": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/avatar": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -4989,12 +4958,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5012,13 +4975,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/checkbox": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5029,16 +4985,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/field-base": "24.6.0-beta1",
@@ -5089,13 +5035,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/dialog": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5106,15 +5045,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/list-box": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/item": "24.6.0-beta1",
@@ -5140,12 +5070,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5165,15 +5089,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5183,18 +5098,7 @@
       "integrity": "sha512-+EPoBT9VPYFMNsOxKeknsRp0nfdnbmxwMvnezQx7GIgy8cHdT2gXE7nceVUJ/HNTeMApD+ekhq3j8EoW0g6c4g==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/custom-field": "24.6.0-beta1",
-        "@vaadin/date-picker": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/time-picker": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "lit": "^3.0.0"
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/custom-field": "24.6.0-beta1",
@@ -5220,12 +5124,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5236,12 +5134,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/lit-renderer": "24.6.0-beta1",
         "@vaadin/overlay": "24.6.0-beta1",
@@ -5262,11 +5154,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/text-field": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5279,8 +5166,6 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5290,12 +5175,6 @@
       "integrity": "sha512-bldewzN84K4PqJDotcQLTCv+swQLskAKR5z1YqlKy1mneLoUL9GjrROQpCRs7msoHEukTpM6ET8kNrv6JCg0PQ==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/overlay": "24.6.0-beta1",
@@ -5316,11 +5195,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
       }
     },
     "node_modules/@vaadin/grid": {
@@ -5330,14 +5204,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/checkbox": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/text-field": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/checkbox": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5435,10 +5301,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5452,9 +5314,6 @@
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5464,7 +5323,6 @@
       "integrity": "sha512-Za/wfpcE3VUGoBlFVN2JyNdnjCq8QIzCNqLi2tc6LclnawaO+q1LwJiJkMXJ28DwIncLZnw6i1fFB8yxUlYSjg==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/icon": "24.6.0-beta1"
         "@vaadin/icon": "24.6.0-beta1"
       }
     },
@@ -5478,10 +5336,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5491,10 +5345,6 @@
       "integrity": "sha512-7fQ48KXj1qEkAJWJJ+ddjtp4cP6zH5PxkYwOnidWUxYTN7NgiTBcD5RgNonhU0C3D4GN8+tFGsif93XEsVOlqw==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/number-field": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1"
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/number-field": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
@@ -5513,11 +5363,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5528,12 +5373,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/item": "24.6.0-beta1",
@@ -5566,14 +5405,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/password-field": "24.6.0-beta1",
-        "@vaadin/text-field": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5584,16 +5415,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/context-menu": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/list-box": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5619,12 +5440,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/text-area": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
       }
     },
     "node_modules/@vaadin/message-list": {
@@ -5633,12 +5448,6 @@
       "integrity": "sha512-vLCDahiuysHA1vlme+u8I8Te671uWyHcNwRolvIHlsaJLvAd64E8bqTDzHzBrM/3l8MWVH5CM6OT671DIlhZnQ==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/avatar": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/avatar": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5654,20 +5463,7 @@
       "integrity": "sha512-q7DH6rhVXkWDSzriIhAZBNwM1zM16fj5yKjzy6D82SundNuKiAVXdMW1txejbWbXMKd1hHmJGhpvDbll2faXhA==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/combo-box": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "lit": "^3.0.0"
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/combo-box": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5694,11 +5490,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5709,13 +5500,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/field-base": "24.6.0-beta1",
@@ -5738,11 +5522,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5753,14 +5532,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/text-field": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5785,13 +5556,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5802,10 +5566,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
@@ -5826,12 +5586,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5841,65 +5595,6 @@
       "integrity": "sha512-1Td/cN8OsnK1esiGIfdpZR8w49+UYNxlRXP6KgbtCmMOrfyxSjD0xajmLU3076UJ8MBe4h87WI9tp5jv6h4RRw==",
       "dependencies": {
         "@lit/react": "^1.0.5",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/accordion": "24.6.0-beta1",
-        "@vaadin/app-layout": "24.6.0-beta1",
-        "@vaadin/avatar": "24.6.0-beta1",
-        "@vaadin/avatar-group": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/card": "24.6.0-beta1",
-        "@vaadin/checkbox": "24.6.0-beta1",
-        "@vaadin/checkbox-group": "24.6.0-beta1",
-        "@vaadin/combo-box": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/confirm-dialog": "24.6.0-beta1",
-        "@vaadin/context-menu": "24.6.0-beta1",
-        "@vaadin/custom-field": "24.6.0-beta1",
-        "@vaadin/date-picker": "24.6.0-beta1",
-        "@vaadin/date-time-picker": "24.6.0-beta1",
-        "@vaadin/details": "24.6.0-beta1",
-        "@vaadin/dialog": "24.6.0-beta1",
-        "@vaadin/email-field": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/field-highlighter": "24.6.0-beta1",
-        "@vaadin/form-layout": "24.6.0-beta1",
-        "@vaadin/grid": "24.6.0-beta1",
-        "@vaadin/horizontal-layout": "24.6.0-beta1",
-        "@vaadin/icon": "24.6.0-beta1",
-        "@vaadin/icons": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/integer-field": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/list-box": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/login": "24.6.0-beta1",
-        "@vaadin/menu-bar": "24.6.0-beta1",
-        "@vaadin/message-input": "24.6.0-beta1",
-        "@vaadin/message-list": "24.6.0-beta1",
-        "@vaadin/multi-select-combo-box": "24.6.0-beta1",
-        "@vaadin/notification": "24.6.0-beta1",
-        "@vaadin/number-field": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/password-field": "24.6.0-beta1",
-        "@vaadin/popover": "24.6.0-beta1",
-        "@vaadin/progress-bar": "24.6.0-beta1",
-        "@vaadin/radio-group": "24.6.0-beta1",
-        "@vaadin/scroller": "24.6.0-beta1",
-        "@vaadin/select": "24.6.0-beta1",
-        "@vaadin/side-nav": "24.6.0-beta1",
-        "@vaadin/split-layout": "24.6.0-beta1",
-        "@vaadin/tabs": "24.6.0-beta1",
-        "@vaadin/tabsheet": "24.6.0-beta1",
-        "@vaadin/text-area": "24.6.0-beta1",
-        "@vaadin/text-field": "24.6.0-beta1",
-        "@vaadin/time-picker": "24.6.0-beta1",
-        "@vaadin/tooltip": "24.6.0-beta1",
-        "@vaadin/upload": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/vertical-layout": "24.6.0-beta1",
-        "@vaadin/virtual-list": "24.6.0-beta1"
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/accordion": "24.6.0-beta1",
         "@vaadin/app-layout": "24.6.0-beta1",
@@ -5987,11 +5682,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -6002,18 +5692,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.2.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/list-box": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -6040,11 +5718,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -6055,10 +5728,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
@@ -6079,12 +5748,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -6095,12 +5758,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/scroller": "24.6.0-beta1",
-        "@vaadin/tabs": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/scroller": "24.6.0-beta1",
         "@vaadin/tabs": "24.6.0-beta1",
@@ -6124,13 +5781,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -6141,13 +5791,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/field-base": "24.6.0-beta1",
@@ -6174,15 +5817,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/combo-box": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/field-base": "24.6.0-beta1",
-        "@vaadin/input-container": "24.6.0-beta1",
-        "@vaadin/item": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -6193,13 +5827,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/overlay": "24.6.0-beta1",
-        "@vaadin/popover": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/overlay": "24.6.0-beta1",
@@ -6224,21 +5851,13 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/a11y-base": "24.6.0-beta1",
-        "@vaadin/button": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/progress-bar": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/vaadin-development-mode-detector": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
-      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
     },
     "node_modules/@vaadin/vaadin-lumo-styles": {
       "version": "24.6.0-beta1",
@@ -6246,9 +5865,6 @@
       "integrity": "sha512-0o0lqHy9jP6ZakC4NXcw/fnsqVo56GSJsysIaQalb4KDThHl1XSUT+QeIgUvfqvVLnLzjF1CjoEK+K7NM0luuQ==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/icon": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/icon": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
@@ -6260,8 +5876,6 @@
       "integrity": "sha512-+TZ7AIKv6zT5FqKtcwoqjrvUk5Pfnt26wgVAFswUQf/sr0Ww+n+WVlPyE62lkRfWpXKPDTgsxOMlRAQcaROlog==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
       }
@@ -6280,7 +5894,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
       "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       },
@@ -6298,10 +5911,6 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -6312,11 +5921,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "24.6.0-beta1",
-        "@vaadin/lit-renderer": "24.6.0-beta1",
-        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
-        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/lit-renderer": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
@@ -6958,8 +6562,7 @@
     "node_modules/@webcomponents/shadycss": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
       "devDependencies": {
         "@nx/js": "^18.0.4",
         "@preact/signals-react-transform": "^0.3.1",
+        "@remcovaes/web-test-runner-vite-plugin": "^1.2.1",
         "@types/karma": "^6.3.8",
         "@types/node": "^20.11.19",
         "@vaadin/react-components": "24.6.0-beta1",
+        "@vaadin/react-components": "24.6.0-beta1",
         "@vitejs/plugin-react": "^4.3.1",
+        "@web/test-runner": "^0.19.0",
         "chai-dom": "^1.12.0",
         "compare-versions": "^6.1.0",
         "concurrently": "^8.2.2",
@@ -45,6 +48,7 @@
         "simple-git-hooks": "^2.9.0",
         "sync-request": "^6.1.0",
         "tsx": "^4.16.2",
+        "type-fest": "^4.28.1",
         "typescript": "5.6.2",
         "vite": "5.4.6"
       },
@@ -3473,6 +3477,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
       "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
       }
@@ -3523,6 +3528,55 @@
         "react": "^16.14.0 || 17.x || 18.x"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.1.tgz",
+      "integrity": "sha512-0kdAbmic3J09I6dT8e9vE2JOCSt13wHCW5x/ly8TSt2bDtuIWe2TgLZZDHdcziw9AVCzflMAXCrVyRIhIs44Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.7",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@remcovaes/web-test-runner-vite-plugin": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@remcovaes/web-test-runner-vite-plugin/-/web-test-runner-vite-plugin-1.2.1.tgz",
+      "integrity": "sha512-zXyTJa4D2Trym3qvBqf3AWEIkZQkm7iFuJbTmDkN/SlqalbP75C9jet+ckwfgtqpFek3SRzhEtapVelp0PU9UA==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "example/**/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
@@ -3530,6 +3584,67 @@
       "peer": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz",
+      "integrity": "sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
+      "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3959,6 +4074,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -4121,6 +4243,13 @@
         "@types/node": "*",
         "@types/qs": "*"
       }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/concat-stream": {
       "version": "1.6.1",
@@ -4392,6 +4521,13 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -4460,6 +4596,17 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4704,6 +4851,7 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4720,6 +4868,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/details": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4729,6 +4883,12 @@
       "integrity": "sha512-qf+IWtWgs7q+AV4DfMGYLNQTL6WDJJZkSmRF9gRXaoGrHHtPAY2KCOKjREQUX4YJvh/YBx4PQnNPBmLWX7z20A==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -4751,6 +4911,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/tooltip": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4760,7 +4926,17 @@
       "integrity": "sha512-CTVNYCYVvMKFSsCfQ6g0Jv8VdvzMepBM3fkVSe9XnlHzSNt+D+j6FqAgITPD1tmlRTKoRjZJ/sJZXQNFvvsuqQ==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
+        "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/avatar": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/list-box": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/avatar": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -4813,6 +4989,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4830,6 +5012,13 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/checkbox": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4840,6 +5029,16 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/field-base": "24.6.0-beta1",
@@ -4890,6 +5089,13 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/dialog": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4900,6 +5106,15 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/list-box": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/item": "24.6.0-beta1",
@@ -4925,6 +5140,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4944,6 +5165,15 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4953,7 +5183,18 @@
       "integrity": "sha512-+EPoBT9VPYFMNsOxKeknsRp0nfdnbmxwMvnezQx7GIgy8cHdT2gXE7nceVUJ/HNTeMApD+ekhq3j8EoW0g6c4g==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
+        "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/custom-field": "24.6.0-beta1",
+        "@vaadin/date-picker": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/time-picker": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "lit": "^3.0.0"
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/custom-field": "24.6.0-beta1",
@@ -4979,6 +5220,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -4989,6 +5236,12 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/lit-renderer": "24.6.0-beta1",
         "@vaadin/overlay": "24.6.0-beta1",
@@ -5009,6 +5262,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/text-field": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5021,6 +5279,8 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5030,6 +5290,12 @@
       "integrity": "sha512-bldewzN84K4PqJDotcQLTCv+swQLskAKR5z1YqlKy1mneLoUL9GjrROQpCRs7msoHEukTpM6ET8kNrv6JCg0PQ==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/overlay": "24.6.0-beta1",
@@ -5050,6 +5316,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
       }
     },
     "node_modules/@vaadin/grid": {
@@ -5059,6 +5330,14 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/checkbox": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/text-field": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/checkbox": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5156,6 +5435,10 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5169,6 +5452,9 @@
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5178,6 +5464,7 @@
       "integrity": "sha512-Za/wfpcE3VUGoBlFVN2JyNdnjCq8QIzCNqLi2tc6LclnawaO+q1LwJiJkMXJ28DwIncLZnw6i1fFB8yxUlYSjg==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/icon": "24.6.0-beta1"
         "@vaadin/icon": "24.6.0-beta1"
       }
     },
@@ -5191,6 +5478,10 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5200,6 +5491,10 @@
       "integrity": "sha512-7fQ48KXj1qEkAJWJJ+ddjtp4cP6zH5PxkYwOnidWUxYTN7NgiTBcD5RgNonhU0C3D4GN8+tFGsif93XEsVOlqw==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/number-field": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1"
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/number-field": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
@@ -5218,6 +5513,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5228,6 +5528,12 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/item": "24.6.0-beta1",
@@ -5260,6 +5566,14 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/password-field": "24.6.0-beta1",
+        "@vaadin/text-field": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5270,6 +5584,16 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/context-menu": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/list-box": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5295,6 +5619,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/text-area": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
       }
     },
     "node_modules/@vaadin/message-list": {
@@ -5303,6 +5633,12 @@
       "integrity": "sha512-vLCDahiuysHA1vlme+u8I8Te671uWyHcNwRolvIHlsaJLvAd64E8bqTDzHzBrM/3l8MWVH5CM6OT671DIlhZnQ==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/avatar": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/avatar": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5318,7 +5654,20 @@
       "integrity": "sha512-q7DH6rhVXkWDSzriIhAZBNwM1zM16fj5yKjzy6D82SundNuKiAVXdMW1txejbWbXMKd1hHmJGhpvDbll2faXhA==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
+        "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/combo-box": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "lit": "^3.0.0"
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/combo-box": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5345,6 +5694,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5355,6 +5709,13 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/field-base": "24.6.0-beta1",
@@ -5377,6 +5738,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5387,6 +5753,14 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/text-field": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5411,6 +5785,13 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5421,6 +5802,10 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
@@ -5441,6 +5826,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5450,6 +5841,65 @@
       "integrity": "sha512-1Td/cN8OsnK1esiGIfdpZR8w49+UYNxlRXP6KgbtCmMOrfyxSjD0xajmLU3076UJ8MBe4h87WI9tp5jv6h4RRw==",
       "dependencies": {
         "@lit/react": "^1.0.5",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/accordion": "24.6.0-beta1",
+        "@vaadin/app-layout": "24.6.0-beta1",
+        "@vaadin/avatar": "24.6.0-beta1",
+        "@vaadin/avatar-group": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/card": "24.6.0-beta1",
+        "@vaadin/checkbox": "24.6.0-beta1",
+        "@vaadin/checkbox-group": "24.6.0-beta1",
+        "@vaadin/combo-box": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/confirm-dialog": "24.6.0-beta1",
+        "@vaadin/context-menu": "24.6.0-beta1",
+        "@vaadin/custom-field": "24.6.0-beta1",
+        "@vaadin/date-picker": "24.6.0-beta1",
+        "@vaadin/date-time-picker": "24.6.0-beta1",
+        "@vaadin/details": "24.6.0-beta1",
+        "@vaadin/dialog": "24.6.0-beta1",
+        "@vaadin/email-field": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/field-highlighter": "24.6.0-beta1",
+        "@vaadin/form-layout": "24.6.0-beta1",
+        "@vaadin/grid": "24.6.0-beta1",
+        "@vaadin/horizontal-layout": "24.6.0-beta1",
+        "@vaadin/icon": "24.6.0-beta1",
+        "@vaadin/icons": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/integer-field": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/list-box": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/login": "24.6.0-beta1",
+        "@vaadin/menu-bar": "24.6.0-beta1",
+        "@vaadin/message-input": "24.6.0-beta1",
+        "@vaadin/message-list": "24.6.0-beta1",
+        "@vaadin/multi-select-combo-box": "24.6.0-beta1",
+        "@vaadin/notification": "24.6.0-beta1",
+        "@vaadin/number-field": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/password-field": "24.6.0-beta1",
+        "@vaadin/popover": "24.6.0-beta1",
+        "@vaadin/progress-bar": "24.6.0-beta1",
+        "@vaadin/radio-group": "24.6.0-beta1",
+        "@vaadin/scroller": "24.6.0-beta1",
+        "@vaadin/select": "24.6.0-beta1",
+        "@vaadin/side-nav": "24.6.0-beta1",
+        "@vaadin/split-layout": "24.6.0-beta1",
+        "@vaadin/tabs": "24.6.0-beta1",
+        "@vaadin/tabsheet": "24.6.0-beta1",
+        "@vaadin/text-area": "24.6.0-beta1",
+        "@vaadin/text-field": "24.6.0-beta1",
+        "@vaadin/time-picker": "24.6.0-beta1",
+        "@vaadin/tooltip": "24.6.0-beta1",
+        "@vaadin/upload": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/vertical-layout": "24.6.0-beta1",
+        "@vaadin/virtual-list": "24.6.0-beta1"
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/accordion": "24.6.0-beta1",
         "@vaadin/app-layout": "24.6.0-beta1",
@@ -5537,6 +5987,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5547,6 +6002,18 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.2.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/list-box": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/button": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
@@ -5573,6 +6040,11 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5583,6 +6055,10 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
@@ -5603,6 +6079,12 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5613,6 +6095,12 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/scroller": "24.6.0-beta1",
+        "@vaadin/tabs": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/scroller": "24.6.0-beta1",
         "@vaadin/tabs": "24.6.0-beta1",
@@ -5636,6 +6124,13 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5646,6 +6141,13 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/field-base": "24.6.0-beta1",
@@ -5672,6 +6174,15 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/combo-box": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/field-base": "24.6.0-beta1",
+        "@vaadin/input-container": "24.6.0-beta1",
+        "@vaadin/item": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5682,6 +6193,13 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/overlay": "24.6.0-beta1",
+        "@vaadin/popover": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/a11y-base": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/overlay": "24.6.0-beta1",
@@ -5706,13 +6224,21 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/a11y-base": "24.6.0-beta1",
+        "@vaadin/button": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/progress-bar": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/vaadin-development-mode-detector": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
-      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@vaadin/vaadin-lumo-styles": {
       "version": "24.6.0-beta1",
@@ -5720,6 +6246,9 @@
       "integrity": "sha512-0o0lqHy9jP6ZakC4NXcw/fnsqVo56GSJsysIaQalb4KDThHl1XSUT+QeIgUvfqvVLnLzjF1CjoEK+K7NM0luuQ==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/icon": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/icon": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
@@ -5731,6 +6260,8 @@
       "integrity": "sha512-+TZ7AIKv6zT5FqKtcwoqjrvUk5Pfnt26wgVAFswUQf/sr0Ww+n+WVlPyE62lkRfWpXKPDTgsxOMlRAQcaROlog==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1"
       }
@@ -5749,6 +6280,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
       "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       },
@@ -5766,6 +6298,10 @@
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
         "@vaadin/vaadin-material-styles": "24.6.0-beta1",
         "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "lit": "^3.0.0"
       }
     },
@@ -5776,6 +6312,11 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "24.6.0-beta1",
+        "@vaadin/lit-renderer": "24.6.0-beta1",
+        "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-material-styles": "24.6.0-beta1",
+        "@vaadin/vaadin-themable-mixin": "24.6.0-beta1",
         "@vaadin/component-base": "24.6.0-beta1",
         "@vaadin/lit-renderer": "24.6.0-beta1",
         "@vaadin/vaadin-lumo-styles": "24.6.0-beta1",
@@ -5810,6 +6351,46 @@
       "dev": true,
       "dependencies": {
         "errorstacks": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/config-loader": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.2.tgz",
+      "integrity": "sha512-Vrjv/FexBGmAdnCYpJKLHX1dfT1UaUdvHmX1JRaWos9OvDf/tFznYJ5SpJwww3Rl87/ewvLSYG7kfsMqEAsizQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.4.6.tgz",
+      "integrity": "sha512-jj/1bcElAy5EZet8m2CcUdzxT+CRvUjIXGh8Lt7vxtthkN9PzY9wlhWx/9WOs5iwlnG1oj0VGo6f/zvbPO0s9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/command-line-args": "^5.0.0",
+        "@web/config-loader": "^0.3.0",
+        "@web/dev-server-core": "^0.7.2",
+        "@web/dev-server-rollup": "^0.6.1",
+        "camelcase": "^6.2.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^7.0.1",
+        "debounce": "^1.2.0",
+        "deepmerge": "^4.2.2",
+        "internal-ip": "^6.2.0",
+        "nanocolors": "^0.2.1",
+        "open": "^8.0.2",
+        "portfinder": "^1.0.32"
+      },
+      "bin": {
+        "wds": "dist/bin.js",
+        "web-dev-server": "dist/bin.js"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5919,6 +6500,84 @@
         }
       }
     },
+    "node_modules/@web/dev-server-rollup": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.4.tgz",
+      "integrity": "sha512-sJZfTGCCrdku5xYnQQG51odGI092hKY9YFM0X3Z0tRY3iXKXcYRaLZrErw5KfCxr6g0JRuhe4BBhqXTA5Q2I3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@web/dev-server-core": "^0.7.2",
+        "nanocolors": "^0.2.1",
+        "parse5": "^6.0.1",
+        "rollup": "^4.4.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server-rollup/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@web/dev-server-rollup/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@web/dev-server-rollup/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@web/dev-server-rollup/node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@web/dev-server/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@web/parse5-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.0.tgz",
@@ -5927,6 +6586,55 @@
       "dependencies": {
         "@types/parse5": "^6.0.1",
         "parse5": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.19.0.tgz",
+      "integrity": "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/browser-logs": "^0.4.0",
+        "@web/config-loader": "^0.3.0",
+        "@web/dev-server": "^0.4.0",
+        "@web/test-runner-chrome": "^0.17.0",
+        "@web/test-runner-commands": "^0.9.0",
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-mocha": "^0.9.0",
+        "camelcase": "^6.2.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^7.0.1",
+        "convert-source-map": "^2.0.0",
+        "diff": "^5.0.0",
+        "globby": "^11.0.1",
+        "nanocolors": "^0.2.1",
+        "portfinder": "^1.0.32",
+        "source-map": "^0.7.3"
+      },
+      "bin": {
+        "web-test-runner": "dist/bin.js",
+        "wtr": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-chrome": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.17.0.tgz",
+      "integrity": "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-coverage-v8": "^0.8.0",
+        "async-mutex": "0.4.0",
+        "chrome-launcher": "^0.15.0",
+        "puppeteer-core": "^23.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6184,10 +6892,74 @@
         "node": ">=8"
       }
     },
+    "node_modules/@web/test-runner-coverage-v8": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.8.0.tgz",
+      "integrity": "sha512-PskiucYpjUtgNfR2zF2AWqWwjXL7H3WW/SnCAYmzUrtob7X9o/+BjdyZ4wKbOxWWSbJO4lEdGIDLu+8X2Xw+lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "lru-cache": "^8.0.4",
+        "picomatch": "^2.2.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-coverage-v8/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@web/test-runner-mocha": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.9.0.tgz",
+      "integrity": "sha512-ZL9F6FXd0DBQvo/h/+mSfzFTSRVxzV9st/AHhpgABtUtV/AIpVE9to6+xdkpu6827kwjezdpuadPfg+PlrBWqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@webcomponents/shadycss": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -6304,6 +7076,19 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -6411,6 +7196,16 @@
       "dev": true,
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -6564,6 +7359,19 @@
         "node": "*"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -6595,6 +7403,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -6662,6 +7480,13 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/babel-plugin-const-enum": {
       "version": "1.2.0",
@@ -6742,6 +7567,57 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bare-events": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
+      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.4.2.tgz",
+      "integrity": "sha512-XZ4ln/KV4KT+PXdIWTKjsLY+quqCaEtqqtgGJVPw9AoM73By03ij64YjepK0aQvHSWDb6AfAZwqKaFu68qkrdA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.20.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6768,6 +7644,16 @@
       "dev": true,
       "engines": {
         "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -6954,6 +7840,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -7187,6 +8083,98 @@
         "node": ">=4"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk-template/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk-template/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk-template/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -7233,6 +8221,53 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/cli-cursor": {
@@ -7514,6 +8549,58 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/commander": {
@@ -8228,6 +9315,16 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -8319,12 +9416,13 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -8334,6 +9432,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decamelize": {
       "version": "4.0.0",
@@ -8412,6 +9517,16 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-gateway": {
       "version": "6.0.3",
@@ -8575,6 +9690,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -8643,6 +9773,13 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -9191,6 +10328,28 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -9914,6 +11073,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10030,6 +11196,43 @@
         "node": "*"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
@@ -10045,6 +11248,13 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.2.7",
@@ -10111,6 +11321,16 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-mock": {
@@ -10255,6 +11475,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/find-up": {
@@ -10571,6 +11804,22 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.2.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -10940,6 +12189,20 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-response-object": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
@@ -10954,6 +12217,20 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -11097,6 +12374,27 @@
         "@formatjs/icu-messageformat-parser": "2.7.8",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/ip-regex": {
       "version": "4.3.0",
@@ -11346,6 +12644,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -11951,6 +13256,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -12532,6 +13844,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
@@ -12766,6 +14106,13 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -13132,6 +14479,13 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/marky": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
+      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -13275,6 +14629,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -13612,6 +14973,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/nise": {
@@ -14396,6 +15767,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -14546,6 +15951,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.0",
@@ -14727,6 +16139,54 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/portfinder/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -15281,6 +16741,16 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -15288,6 +16758,36 @@
       "dev": true,
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.3",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/proxy-from-env": {
@@ -15310,6 +16810,46 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.9.0.tgz",
+      "integrity": "sha512-hLVrav2HYMVdK0YILtfJwtnkBAwNOztUdR4aJ5YKDvgsbtagNr6urUJk9HyjRA9e+PaLI3jzJ0wM7A4jSZ7Qxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.4.1",
+        "chromium-bidi": "0.8.0",
+        "debug": "^4.3.7",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/qjobs": {
       "version": "1.2.0",
@@ -15364,6 +16904,13 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -16212,6 +17759,17 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/socket.io": {
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
@@ -16251,6 +17809,36 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.1",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
@@ -16382,6 +17970,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.2.tgz",
+      "integrity": "sha512-aDGDLU+j9tJcUdPGOaHmVF1u/hhI+CsGkT02V3OKlHDV7IukOI+nTWAGkiZEKCO35rWN1wIr4tS7YFr1f4qSvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -16709,6 +18312,30 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -16716,6 +18343,33 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/tar-stream": {
@@ -16785,6 +18439,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.1.tgz",
+      "integrity": "sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -17093,10 +18754,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.25.0.tgz",
-      "integrity": "sha512-bRkIGlXsnGBRBQRAY56UXBm//9qH4bmJfFvq83gSz41N282df+fjy8ofcEgc1sM8geNt5cl6mC2g9Fht1cs8Aw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.28.1.tgz",
+      "integrity": "sha512-LO/+yb3mf46YqfUC7QkkoAlpa7CTYh//V1Xy9+NQ+pKqDqXIq0NTfPfQRwFfCt+if4Qkwb9gzZfsl6E5TkXZGw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -17190,6 +18852,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -17206,6 +18875,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ua-parser-js": {
@@ -17244,6 +18923,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/undici-types": {
@@ -17366,6 +19056,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.2",
@@ -17676,6 +19373,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/workerpool": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -17968,6 +19675,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/ylru": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
@@ -17996,6 +19714,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/ts/file-router": {
@@ -18756,6 +20484,7 @@
         "@types/sinon": "^10.0.17",
         "@types/sinon-chai": "^3.2.10",
         "@types/validator": "^13.11.2",
+        "@web/test-runner": "^0.19.0",
         "chai-dom": "^1.11.0",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
   "devDependencies": {
     "@nx/js": "^18.0.4",
     "@preact/signals-react-transform": "^0.3.1",
+    "@remcovaes/web-test-runner-vite-plugin": "^1.2.1",
     "@types/karma": "^6.3.8",
     "@types/node": "^20.11.19",
     "@vaadin/react-components": "24.6.0-beta1",
     "@vitejs/plugin-react": "^4.3.1",
+    "@web/test-runner": "^0.19.0",
     "chai-dom": "^1.12.0",
     "compare-versions": "^6.1.0",
     "concurrently": "^8.2.2",
@@ -68,6 +70,7 @@
     "simple-git-hooks": "^2.9.0",
     "sync-request": "^6.1.0",
     "tsx": "^4.16.2",
+    "type-fest": "^4.28.1",
     "typescript": "5.6.2",
     "vite": "5.4.6"
   }

--- a/packages/ts/react-auth/package.json
+++ b/packages/ts/react-auth/package.json
@@ -23,7 +23,7 @@
     "build:copy": "cd src && copyfiles **/*.d.ts ..",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
-    "test": "karma start ../../../karma.config.cjs --port 9877",
+    "test": "npx --node-options=\"--import tsx\" wtr --config ../../../wtr.config.ts",
     "test:coverage": "npm run test -- --coverage",
     "test:watch": "npm run test -- --watch",
     "typecheck": "tsc --noEmit"
@@ -64,6 +64,7 @@
     "@types/sinon": "^10.0.17",
     "@types/sinon-chai": "^3.2.10",
     "@types/validator": "^13.11.2",
+    "@web/test-runner": "^0.19.0",
     "chai-dom": "^1.11.0",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",

--- a/packages/ts/react-auth/tsconfig.json
+++ b/packages/ts/react-auth/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "jsx": "react-jsx"
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", "test.config.js"],
   "exclude": ["test/**/*.snap.ts"]
 }

--- a/scripts/types.d.ts
+++ b/scripts/types.d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/unambiguous */
+
+declare module '@remcovaes/web-test-runner-vite-plugin' {
+  import type { Plugin, UserConfig } from 'vite';
+
+  export function vitePlugin(config?: UserConfig): Plugin;
+  export function removeViteLogging(): (message: string) => boolean;
+}

--- a/scripts/vite/plugins.ts
+++ b/scripts/vite/plugins.ts
@@ -1,0 +1,71 @@
+import { readFile } from 'node:fs/promises';
+import cssnanoPlugin from 'cssnano';
+import MagicString from 'magic-string';
+import postcss from 'postcss';
+import type { Plugin } from 'vite';
+
+export type PluginOptions = Readonly<{
+  root: URL;
+}>;
+
+export type LoadRegisterOptions = PluginOptions;
+
+// This plugin adds "__REGISTER__()" function definition everywhere where it finds
+// the call for that function. It is necessary for a correct code for tests.
+export function loadRegisterJs({ root }: LoadRegisterOptions): Plugin {
+  return {
+    enforce: 'pre',
+    name: 'vite-hilla-register',
+    async transform(code) {
+      if (code.includes('__REGISTER__()') && !code.includes('function __REGISTER__')) {
+        const registerCode = await readFile(new URL('scripts/register.js', root), 'utf8').then((c) =>
+          c.replace('export', ''),
+        );
+
+        const _code = new MagicString(code);
+        _code.prepend(registerCode);
+
+        return {
+          code: _code.toString(),
+          map: _code.generateMap(),
+        };
+      }
+
+      return null;
+    },
+  };
+}
+
+// This plugin transforms CSS to Constructible CSSStyleSheet for easy
+// installation it to the document styles.
+export function constructCss(): Plugin {
+  const cssTransformer = postcss([cssnanoPlugin()]);
+  const css = new Map();
+
+  return {
+    enforce: 'post',
+    name: 'vite-construct-css',
+    async load(id) {
+      if (id.endsWith('.obj.css')) {
+        const content = await readFile(id, 'utf8');
+        css.set(id, content);
+        return {
+          code: '',
+        };
+      }
+
+      return null;
+    },
+    async transform(_, id) {
+      if (id.endsWith('.obj.css')) {
+        const { content } = await cssTransformer.process(css.get(id));
+
+        return {
+          code: `const css = new CSSStyleSheet();css.replaceSync(${JSON.stringify(content)});export default css;`,
+        };
+      }
+
+      return null;
+    },
+  };
+}

--- a/scripts/vite/test-utils.ts
+++ b/scripts/vite/test-utils.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-console */
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type MockConfig = Readonly<Record<string, string>>;
+export type MockConfigLoaderOptions = Readonly<{
+  cwd: URL;
+}>;
+
+export async function loadMockConfig({ cwd }: MockConfigLoaderOptions): Promise<MockConfig> {
+  try {
+    const content = await readFile(new URL('test/mocks/config.json', cwd), 'utf8');
+    return JSON.parse(content);
+  } catch {
+    console.log(`No mock files found for ${basename(fileURLToPath(cwd))}. Skipping...`);
+    return {};
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,66 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import reactPlugin from '@vitejs/plugin-react';
+import type { PackageJson } from 'type-fest';
+import { defineConfig } from 'vite';
+import { constructCss, loadRegisterJs } from './scripts/vite/plugins.js';
+import { loadMockConfig } from './scripts/vite/test-utils.js';
+
+const root = new URL('./', import.meta.url);
+const cwd = pathToFileURL(`${process.cwd()}/`);
+
+const [packageJson, mocks] = await Promise.all([
+  readFile(new URL('./package.json', cwd), 'utf8').then((content) => JSON.parse(content) as PackageJson),
+  loadMockConfig({ cwd }),
+]);
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+  },
+  cacheDir: '.vite',
+  esbuild: {
+    define: {
+      __NAME__: JSON.stringify(packageJson.name ?? '@hilla/unknown'),
+      __VERSION__: JSON.stringify(packageJson.version ?? '0.0.0'),
+    },
+    supported: {
+      decorators: false,
+      'top-level-await': true,
+    },
+  },
+  plugins: [
+    loadRegisterJs({ root }),
+    constructCss(),
+    reactPlugin({
+      include: '**/*.tsx',
+      babel: {
+        plugins: [
+          [
+            'module:@preact/signals-react-transform',
+            {
+              mode: 'all',
+            },
+          ],
+        ],
+      },
+    }),
+  ],
+  resolve: {
+    alias: Object.entries(mocks).map(([find, file]) => {
+      const replacement = fileURLToPath(new URL(`test/mocks/${file}`, cwd));
+
+      return {
+        customResolver(_, importer) {
+          if (importer?.includes('/mocks/')) {
+            return false;
+          }
+
+          return replacement;
+        },
+        find,
+        replacement,
+      };
+    }),
+  },
+});

--- a/wtr.config.ts
+++ b/wtr.config.ts
@@ -1,0 +1,56 @@
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import { vitePlugin, removeViteLogging } from '@remcovaes/web-test-runner-vite-plugin';
+import { chromeLauncher } from '@web/test-runner';
+import viteConfig from './vite.config.js';
+
+const cwd = pathToFileURL(`${process.cwd()}/`);
+
+const {
+  values: { coverage, watch: _watch },
+} = parseArgs({
+  options: {
+    watch: {
+      type: 'boolean',
+      short: 'w',
+    },
+    coverage: {
+      type: 'boolean',
+    },
+  },
+  strict: false,
+});
+
+const isCI = !!process.env.CI;
+const watch = !!_watch && !isCI;
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  concurrency: 10,
+  // nodeResolve: true,
+  watch,
+  coverage,
+  rootDir: fileURLToPath(cwd),
+  files: 'test/**/*.spec.{ts,tsx}',
+  coverageConfig: {
+    include: [fileURLToPath(new URL('src/**/*', cwd))],
+    reportDir: fileURLToPath(new URL('.coverage/', cwd)),
+  },
+  plugins: [vitePlugin(viteConfig)],
+  filterBrowserLogs: removeViteLogging,
+  browsers: [
+    chromeLauncher({
+      launchOptions: {
+        args: [],
+        // eslint-disable-next-line no-undef
+        executablePath: process.env.CHROME_BIN,
+      },
+    }),
+  ],
+  testFramework: {
+    config: {
+      ui: 'bdd',
+      timeout: '4000',
+    },
+  },
+};


### PR DESCRIPTION
Fixes test failures in #2901 by replacing Karma Test Runner (deprecated) with Web Test Runner.

Web Test Runner is applied only to the `react-auth` package. The plan is to incrementally transfer other browser-based packages over time. 