### PR TITLE
fix(file-router): allow extension to apply on a route wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7635,6 +7635,16 @@
         "chai": ">= 2.1.2 < 6"
       }
     },
+    "node_modules/chai-deep-equal-ignore-undefined": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chai-deep-equal-ignore-undefined/-/chai-deep-equal-ignore-undefined-1.1.1.tgz",
+      "integrity": "sha512-BE4nUR2Jbqmmv8A0EuAydFRB/lXgXWAfa9TvO3YzHeGHAU7ZRwPZyu074oDl/CZtNXM7jXINpQxKBOe7N0P4bg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "chai": ">= 4.0.0 < 5"
+      }
+    },
     "node_modules/chai-dom": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/chai-dom/-/chai-dom-1.12.0.tgz",
@@ -19351,6 +19361,7 @@
         "@types/sinon": "^10.0.17",
         "@types/sinon-chai": "^3.2.12",
         "chai-as-promised": "^7.1.1",
+        "chai-deep-equal-ignore-undefined": "^1.1.1",
         "chai-fs": "^2.0.0",
         "chai-like": "^1.1.1",
         "deep-equal-in-any-order": "^2.0.6",

--- a/packages/ts/file-router/package.json
+++ b/packages/ts/file-router/package.json
@@ -26,7 +26,7 @@
     "build:copy": "cd src && copyfiles *.d.ts **/*.d.ts ..",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
-    "test": "mocha test/**/applyLayouts.spec.{ts,tsx} --config ../../../.mocharc.cjs",
+    "test": "mocha test/**/*.spec.{ts,tsx} --config ../../../.mocharc.cjs",
     "test:coverage": "c8 --experimental-monocart -c ../../../.c8rc.json npm test",
     "typecheck": "tsc --noEmit"
   },
@@ -70,6 +70,7 @@
     "@types/sinon": "^10.0.17",
     "@types/sinon-chai": "^3.2.12",
     "chai-as-promised": "^7.1.1",
+    "chai-deep-equal-ignore-undefined": "^1.1.1",
     "chai-fs": "^2.0.0",
     "chai-like": "^1.1.1",
     "deep-equal-in-any-order": "^2.0.6",

--- a/packages/ts/file-router/package.json
+++ b/packages/ts/file-router/package.json
@@ -26,7 +26,7 @@
     "build:copy": "cd src && copyfiles *.d.ts **/*.d.ts ..",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
-    "test": "mocha test/**/*.spec.{ts,tsx} --config ../../../.mocharc.cjs",
+    "test": "mocha test/**/RouterConfigurationBuilder.spec.{ts,tsx} --config ../../../.mocharc.cjs",
     "test:coverage": "c8 --experimental-monocart -c ../../../.c8rc.json npm test",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ts/file-router/package.json
+++ b/packages/ts/file-router/package.json
@@ -26,7 +26,7 @@
     "build:copy": "cd src && copyfiles *.d.ts **/*.d.ts ..",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
-    "test": "mocha test/**/RouterConfigurationBuilder.spec.{ts,tsx} --config ../../../.mocharc.cjs",
+    "test": "mocha test/**/applyLayouts.spec.{ts,tsx} --config ../../../.mocharc.cjs",
     "test:coverage": "c8 --experimental-monocart -c ../../../.c8rc.json npm test",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
+++ b/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
@@ -25,7 +25,14 @@ interface RouteBase {
 }
 
 function isReactRouteModule(module?: Module): module is RouteModule<ComponentType> | undefined {
-  return module ? 'default' in module && typeof module.default === 'function' : true;
+  if (!module) {
+    return true;
+  }
+
+  return (
+    ('default' in module && typeof module.default === 'function') ||
+    ('config' in module && typeof module.config === 'object')
+  );
 }
 
 export type RouteList = readonly RouteObject[];
@@ -126,7 +133,9 @@ export class RouterConfigurationBuilder {
       if (added) {
         const { module, path, flowLayout } = added;
         if (!isReactRouteModule(module)) {
-          throw new Error(`The module for the "${path}" section doesn't have the React component exported by default`);
+          throw new Error(
+            `The module for the "${path}" section doesn't have the React component exported by default or a ViewConfig object exported as "config"`,
+          );
         }
 
         const element = module?.default ? createElement(module.default) : undefined;

--- a/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
+++ b/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
@@ -191,7 +191,7 @@ export class RouterConfigurationBuilder {
         ambivalent: T;
       }>;
 
-      const result = transformTree<RouteList, Accumulator<RouteList>>(originalRoutes, (routes, next) =>
+      const result = transformTree<RouteList, Accumulator<RouteList>>(originalRoutes, null, (routes, next) =>
         // Split a single routes list onto three separate lists:
         // - A list of server routes
         // - A list of client routes
@@ -199,7 +199,7 @@ export class RouterConfigurationBuilder {
         // list. It depends on the parent route.
         routes.reduce<Accumulator<WritableRouteList>>(
           (lists, route) => {
-            const { server, client, ambivalent } = next(...(route.children ?? []));
+            const { server, client, ambivalent } = next(route.children ?? []);
 
             const flag = getRouteHandleFlag(route, RouteHandleFlags.FLOW_LAYOUT);
 
@@ -302,6 +302,7 @@ export class RouterConfigurationBuilder {
     this.#modifiers.push((existingRoutes) =>
       transformTree<[RouteList | undefined, readonly T[] | undefined], RouteList | undefined>(
         [existingRoutes, routes],
+        null,
         ([original, added], next) => {
           if (original && added) {
             const originalMap = new Map(original.map((route) => createRouteEntry(route)));
@@ -315,11 +316,11 @@ export class RouterConfigurationBuilder {
 
               let route: RouteObject | undefined;
               if (originalRoute && addedRoute) {
-                route = callback(originalRoute, addedRoute, next(originalRoute.children, addedRoute.children));
+                route = callback(originalRoute, addedRoute, next([originalRoute.children, addedRoute.children]));
               } else if (originalRoute) {
-                route = callback(originalRoute, undefined, next(originalRoute.children, undefined));
+                route = callback(originalRoute, undefined, next([originalRoute.children, undefined]));
               } else {
-                route = callback(undefined, addedRoute, next(undefined, addedRoute!.children));
+                route = callback(undefined, addedRoute, next([undefined, addedRoute!.children]));
               }
 
               if (route) {
@@ -330,11 +331,11 @@ export class RouterConfigurationBuilder {
             return [...originalMap.values()];
           } else if (original) {
             return original
-              .map((route) => callback(route, undefined, next(route.children, undefined)))
+              .map((route) => callback(route, undefined, next([route.children, undefined])))
               .filter((r) => r != null);
           } else if (added) {
             return added
-              .map((route) => callback(undefined, route, next(undefined, route.children)))
+              .map((route) => callback(undefined, route, next([undefined, route.children])))
               .filter((r) => r != null);
           }
 
@@ -384,7 +385,7 @@ export class RouterConfigurationBuilder {
         regular: T;
       }>;
 
-      const result = transformTree<RouteList, Accumulator<RouteList>>(originalRoutes, (routes, next) =>
+      const result = transformTree<RouteList, Accumulator<RouteList>>(originalRoutes, null, (routes, next) =>
         // Split a single routes list onto two separate lists.
         routes.reduce<Accumulator<WritableRouteList>>(
           (lists, route) => {
@@ -401,7 +402,7 @@ export class RouterConfigurationBuilder {
             }
 
             // As of children, we have to split them into two lists as well.
-            const { skipped, regular } = next(...(route.children ?? []));
+            const { skipped, regular } = next(route.children ?? []);
 
             // If we have `skipped` list of children, we have to remove the
             // `element` property of the router to prevent the layout from

--- a/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
+++ b/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
@@ -233,7 +233,10 @@ export class RouterConfigurationBuilder {
             // The route without the flag go to the `default` list. Then it will
             // be moved to either server or client list based on the parent
             // route.
-            if (flag === undefined && lists.server.every(({ path }) => path !== route.path)) {
+            if (
+              flag === undefined &&
+              (lists.server.every(({ path }) => path !== route.path) || ambivalent.length > 0)
+            ) {
               lists.ambivalent.push({
                 ...route,
                 children: ambivalent.length > 0 ? ambivalent : undefined,

--- a/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
+++ b/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
@@ -249,8 +249,9 @@ export class RouterConfigurationBuilder {
       return [
         ...(result.server.length
           ? [
-              // The server subtree is wrapped with the server layout component,
-              // which applies the top-level server layout to all matches.
+              // The server routes are wrapped with the route that has a layout
+              // element. It also has the `IGNORE_FALLBACK` flag to remove the
+              // fallback route from reach.
               {
                 element: createElement(layoutComponent),
                 children: result.server as RouteObject[],
@@ -260,9 +261,9 @@ export class RouterConfigurationBuilder {
               },
             ]
           : []),
-        // The client route subtree is preserved without wrapping.
+        // The client routes are preserved without wrapping.
         ...result.client,
-        // The default routes are considered as client routes.
+        // The ambivalent routes are considered as client routes.
         ...result.ambivalent,
       ];
     });

--- a/packages/ts/file-router/src/runtime/createRoute.ts
+++ b/packages/ts/file-router/src/runtime/createRoute.ts
@@ -8,12 +8,12 @@ import type { AgnosticRoute, Module, ViewConfig } from '../types.js';
  * @param config - The extension config.
  * @returns
  */
-export function extendModule(module: Module, config?: ViewConfig): Module {
+export function extendModule(module: Module | null, config?: ViewConfig): Module {
   return {
     ...module,
     config: {
       ...config,
-      ...(module.config as ViewConfig),
+      ...(module?.config as ViewConfig),
     },
   };
 }

--- a/packages/ts/file-router/src/shared/transformTree.ts
+++ b/packages/ts/file-router/src/shared/transformTree.ts
@@ -1,6 +1,7 @@
-export function transformTree<T extends readonly unknown[], U>(
+export function transformTree<T extends readonly unknown[], U, C extends object | null = null>(
   nodes: T,
-  transformer: (nodes: T, next: (...nodes: T) => U) => U,
+  context: C,
+  transformer: (nodes: T, next: (nodes: T, ctx?: C) => U, context: C) => U,
 ): U {
-  return transformer(nodes, (...n) => transformTree(n, transformer));
+  return transformer(nodes, (n, ctx = context) => transformTree(n, ctx, transformer), context);
 }

--- a/packages/ts/file-router/src/vite-plugin/applyLayouts.ts
+++ b/packages/ts/file-router/src/vite-plugin/applyLayouts.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path/posix';
+import { join, relative } from 'node:path/posix';
 import { transformTree } from '../shared/transformTree.js';
 import type { RouteMeta } from './collectRoutesFromFS.js';
 
@@ -38,7 +38,7 @@ export default async function applyLayouts(
           const currentPath = join(ctx.path, strip(meta.path));
           const children = meta.children ? next(meta.children, { path: currentPath }) : undefined;
 
-          return layoutPaths.some((path) => currentPath.includes(path))
+          return layoutPaths.some((path) => !relative(path, currentPath).startsWith('..'))
             ? { ...meta, flowLayout: true, children }
             : { ...meta, children };
         }),

--- a/packages/ts/file-router/src/vite-plugin/applyLayouts.ts
+++ b/packages/ts/file-router/src/vite-plugin/applyLayouts.ts
@@ -1,5 +1,6 @@
-import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { join } from 'node:path/posix';
+import { transformTree } from '../shared/transformTree.js';
 import type { RouteMeta } from './collectRoutesFromFS.js';
 
 /**
@@ -9,43 +10,8 @@ export type LayoutMeta = Readonly<{
   path: string;
 }>;
 
-function stripLeadingSlash(path: string) {
-  return path.startsWith('/') ? path.slice(1) : path;
-}
-
-function enableFlowLayout(route: RouteMeta): RouteMeta {
-  return {
-    ...route,
-    flowLayout: true,
-  };
-}
-
-/**
- * Check if there is a layout available that can handle the given path.
- * Layouts match the starting parts of the path so '/' will match all paths
- * and '/home' matches '/home' anything with the start path '/home/*'
- *
- * @param layoutPaths - available layout paths
- * @param path - to check for layout
- */
-function layoutExists(layoutPaths: string[], path: string) {
-  const splitPath: string[] = path.split('/');
-
-  return layoutPaths.some((layout) => {
-    if (layout.length === 0) {
-      return true;
-    }
-    const splitLayout: string[] = layout.split('/');
-    if (splitLayout.length > splitPath.length) {
-      return false;
-    }
-    for (let i = 0; i < splitLayout.length; i++) {
-      if (splitPath[i] !== splitLayout[i]) {
-        return false;
-      }
-    }
-    return true;
-  });
+function strip(path: string) {
+  return path.replace(/^\/*(.+)\/*$/u, '$1');
 }
 
 /**
@@ -62,12 +28,26 @@ export default async function applyLayouts(
   try {
     const layoutContents = await readFile(layoutsFile, 'utf-8');
     const availableLayouts: readonly LayoutMeta[] = JSON.parse(layoutContents);
-    const layoutPaths = availableLayouts.map((layout) => stripLeadingSlash(layout.path));
+    const layoutPaths = availableLayouts.map((layout) => strip(layout.path));
 
-    return routeMeta.map((route) =>
-      layoutExists(layoutPaths, stripLeadingSlash(route.path)) ? enableFlowLayout(route) : route,
+    return transformTree<readonly RouteMeta[], readonly RouteMeta[], { path: string }>(
+      routeMeta,
+      { path: '' },
+      (metas, next, ctx) =>
+        metas.map((meta) => {
+          const currentPath = join(ctx.path, strip(meta.path));
+          const children = meta.children ? next(meta.children, { path: currentPath }) : undefined;
+
+          return layoutPaths.some((path) => currentPath.includes(path))
+            ? { ...meta, flowLayout: true, children }
+            : { ...meta, children };
+        }),
     );
   } catch (e: unknown) {
-    return routeMeta;
+    if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+      return routeMeta;
+    }
+
+    throw e;
   }
 }

--- a/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
+++ b/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
@@ -17,7 +17,7 @@ class RouteFromMetaProcessor {
   readonly #manager: DependencyManager;
   readonly #views: readonly RouteMeta[];
 
-  constructor(views: readonly RouteMeta[], { code: codeFile }: RuntimeFileUrls) {
+  constructor(views: readonly RouteMeta[], { json: jsonFile, code: codeFile }: RuntimeFileUrls) {
     this.#views = views;
 
     const codeDir = new URL('./', codeFile);
@@ -37,7 +37,7 @@ class RouteFromMetaProcessor {
     } = this.#manager;
     const errors: string[] = [];
 
-    const routes = transformTree<readonly RouteMeta[], readonly CallExpression[]>(this.#views, (metas, next) => {
+    const routes = transformTree<readonly RouteMeta[], readonly CallExpression[]>(this.#views, null, (metas, next) => {
       errors.push(
         ...metas
           .map((route) => route.path)
@@ -49,7 +49,7 @@ class RouteFromMetaProcessor {
         let _children: readonly CallExpression[] | undefined;
 
         if (children) {
-          _children = next(...children);
+          _children = next(children);
         }
 
         let mod: Identifier | undefined;

--- a/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
+++ b/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
@@ -1,10 +1,8 @@
-import { relative, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { template, transform as transformer } from '@vaadin/hilla-generator-utils/ast.js';
 import createSourceFile from '@vaadin/hilla-generator-utils/createSourceFile.js';
 import DependencyManager from '@vaadin/hilla-generator-utils/dependencies/DependencyManager.js';
 import PathManager from '@vaadin/hilla-generator-utils/dependencies/PathManager.js';
-import ts, { type CallExpression, type Identifier, type StringLiteral, type VariableStatement } from 'typescript';
+import ts, { type CallExpression, type Identifier, type VariableStatement } from 'typescript';
 
 import { transformTree } from '../shared/transformTree.js';
 import type { RouteMeta } from './collectRoutesFromFS.js';
@@ -13,7 +11,7 @@ import { convertFSRouteSegmentToURLPatternFormat } from './utils.js';
 
 const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 
-const extensions = ['.ts', '.tsx', '.js', '.jsx'];
+const fileExtensions = ['.ts', '.tsx', '.js', '.jsx'];
 
 class RouteFromMetaProcessor {
   readonly #manager: DependencyManager;
@@ -56,16 +54,16 @@ class RouteFromMetaProcessor {
 
         let mod: Identifier | undefined;
         if (file) {
-          const extension = extensions.find((ext) => file.pathname.endsWith(ext));
-          mod = namespace.add(paths.createRelativePath(file, extension), `Page`);
+          const fileExt = fileExtensions.find((ext) => file.pathname.endsWith(ext));
+          mod = namespace.add(paths.createRelativePath(file, fileExt), `Page`);
         } else if (layout) {
-          const extension = extensions.find((ext) => layout.pathname.endsWith(ext));
-          mod = namespace.add(paths.createRelativePath(layout, extension), `Layout`);
+          const fileExt = fileExtensions.find((ext) => layout.pathname.endsWith(ext));
+          mod = namespace.add(paths.createRelativePath(layout, fileExt), `Layout`);
         }
 
-        const extension = flowLayout ? { flowLayout } : undefined;
+        const moduleExtension = flowLayout ? { flowLayout } : undefined;
 
-        return this.#createRouteData(convertFSRouteSegmentToURLPatternFormat(path), mod, extension, _children);
+        return this.#createRouteData(convertFSRouteSegmentToURLPatternFormat(path), mod, moduleExtension, _children);
       });
     });
 
@@ -113,15 +111,13 @@ export default routes;
     let extendModuleId: Identifier | undefined;
     let modNode = '';
 
-    if (mod) {
-      if (extension) {
-        extendModuleId =
-          named.getIdentifier('@vaadin/hilla-file-router/runtime.js', 'extendModule') ??
-          named.add('@vaadin/hilla-file-router/runtime.js', 'extendModule');
-        modNode = `, EXTEND_MODULE(MOD, ${JSON.stringify(extension)})`;
-      } else {
-        modNode = `, MOD`;
-      }
+    if (extension) {
+      extendModuleId =
+        named.getIdentifier('@vaadin/hilla-file-router/runtime.js', 'extendModule') ??
+        named.add('@vaadin/hilla-file-router/runtime.js', 'extendModule');
+      modNode = `, EXTEND_MODULE(MOD, ${JSON.stringify(extension)})`;
+    } else if (mod) {
+      modNode = `, MOD`;
     }
 
     const createRouteId =
@@ -137,7 +133,7 @@ export default routes;
             ? ts.factory.createArrayLiteralExpression(children, true)
             : node,
         ),
-        transformer((node) => (ts.isIdentifier(node) && node.text === 'MOD' ? mod : node)),
+        transformer((node) => (ts.isIdentifier(node) && node.text === 'MOD' ? (mod ?? ts.factory.createNull()) : node)),
         transformer((node) => (ts.isIdentifier(node) && node.text === 'EXTEND_MODULE' ? extendModuleId : node)),
         transformer((node) => (ts.isIdentifier(node) && node.text === 'CREATE_ROUTE' ? createRouteId : node)),
       ],

--- a/packages/ts/file-router/src/vite-plugin/createViewConfigJson.ts
+++ b/packages/ts/file-router/src/vite-plugin/createViewConfigJson.ts
@@ -30,10 +30,11 @@ function* walkAST(node: Node): Generator<Node> {
 export default async function createViewConfigJson(views: readonly RouteMeta[]): Promise<string> {
   const res = await transformTree<readonly RouteMeta[], Promise<readonly ServerViewConfig[]>>(
     views,
+    null,
     async (routes, next) =>
       await Promise.all(
         routes.map(async ({ path, file, layout, children, flowLayout }) => {
-          const newChildren = children ? await next(...children) : undefined;
+          const newChildren = children ? await next(children) : undefined;
 
           if (!file && !layout) {
             return {

--- a/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
+++ b/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { Logger } from 'vite';
 import applyLayouts from './applyLayouts.js';

--- a/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
+++ b/packages/ts/file-router/src/vite-plugin/generateRuntimeFiles.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import type { Logger } from 'vite';
 import applyLayouts from './applyLayouts.js';
-import collectRoutesFromFS from './collectRoutesFromFS.js';
+import collectRoutesFromFS, { type RouteMeta } from './collectRoutesFromFS.js';
 import createRoutesFromMeta from './createRoutesFromMeta.js';
 import createViewConfigJson from './createViewConfigJson.js';
 
@@ -72,7 +72,17 @@ export async function generateRuntimeFiles(
   logger: Logger,
   debug: boolean,
 ): Promise<void> {
-  let routeMeta = existsSync(viewsDir) ? await collectRoutesFromFS(viewsDir, { extensions, logger }) : [];
+  let routeMeta: readonly RouteMeta[];
+  try {
+    routeMeta = await collectRoutesFromFS(viewsDir, { extensions, logger });
+  } catch (e: unknown) {
+    if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+      routeMeta = [];
+    } else {
+      throw e;
+    }
+  }
+
   if (debug) {
     logger.info('Collected file-based routes');
   }

--- a/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
+++ b/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
@@ -322,74 +322,6 @@ describe('RouterBuilder', () => {
   });
 
   describe('withLayout', () => {
-    it('should add layout routes under layout component', () => {
-      const { routes } = builder
-        .withReactRoutes([
-          {
-            path: '',
-            handle: {
-              flowLayout: true,
-            },
-          },
-          {
-            path: '/test',
-            handle: {
-              flowLayout: true,
-            },
-            children: [
-              {
-                path: '/child',
-                handle: {
-                  flowLayout: true,
-                },
-              },
-            ],
-          },
-        ])
-        .withLayout(Server)
-        .build();
-
-      expect(routes).to.be.like([
-        {
-          children: [
-            {
-              path: '',
-              handle: {
-                flowLayout: true,
-              },
-            },
-            {
-              children: [
-                {
-                  path: '/child',
-                  handle: {
-                    flowLayout: true,
-                  },
-                },
-              ],
-              path: '/test',
-              handle: {
-                flowLayout: true,
-              },
-            },
-          ],
-          element: createElement(Server),
-          handle: {
-            ignoreFallback: true,
-          },
-        },
-        {
-          children: [
-            {
-              path: '/test',
-              element: <div>Test</div>,
-            },
-          ],
-          path: '',
-        },
-      ]);
-    });
-
     it('empty flowLayout array should not generate element', () => {
       const { routes } = new RouterConfigurationBuilder()
         .withReactRoutes([
@@ -407,54 +339,95 @@ describe('RouterBuilder', () => {
       ]);
     });
 
-    it('should add layout routes for nested folder layout component', () => {
+    it('should separate flow layouts and regular layouts', () => {
       const { routes } = builder
         .withReactRoutes([
           {
-            path: 'nest',
+            path: 'mixed-nested-layouts',
             children: [
               {
-                path: '',
+                path: 'parent-flow-layout',
                 handle: {
                   flowLayout: true,
                 },
-              },
-              {
-                path: '/nested',
-                handle: {
-                  flowLayout: true,
-                },
-              },
-              {
-                path: '/outside',
-                handle: {
-                  flowLayout: false,
-                },
-              },
-              {
-                path: '/nested-empty-layout',
-                children: [],
+                children: [
+                  {
+                    path: 'flow-layout',
+                    handle: {
+                      flowLayout: true,
+                    },
+                  },
+                  {
+                    path: 'regular-layout-1',
+                    handle: {
+                      flowLayout: false,
+                    },
+                  },
+                  {
+                    path: 'not-specified-layout-1',
+                  },
+                  {
+                    path: 'not-specified-layout-2',
+                    children: [
+                      {
+                        path: 'child-regular-layout',
+                        handle: {
+                          flowLayout: false,
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    path: 'not-specified-layout-3',
+                    children: [
+                      {
+                        path: 'child-not-specifed-layout',
+                      },
+                    ],
+                  },
+                  {
+                    path: 'not-specified-layout-4',
+                    children: [
+                      {
+                        path: 'child-flow-layout-1',
+                        handle: {
+                          flowLayout: true,
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    path: 'regular-layout-2',
+                    handle: {
+                      flowLayout: false,
+                    },
+                    children: [
+                      {
+                        path: 'child-flow-layout-2',
+                        handle: {
+                          flowLayout: true,
+                        },
+                      },
+                    ],
+                  },
+                ],
               },
             ],
           },
           {
-            path: '/test',
+            path: 'flow-layout-another-branch',
             handle: {
               flowLayout: true,
             },
-            children: [
-              {
-                path: '/child',
-              },
-              {
-                path: '/empty-layout',
-                children: [],
-              },
-            ],
           },
           {
-            path: '/empty-layout-outside',
-            children: [],
+            path: 'regular-layout-outside',
+            handle: {
+              flowLayout: false,
+            },
+          },
+          {
+            path: 'not-specified-layout-outside',
           },
         ])
         .withLayout(Server)
@@ -462,72 +435,130 @@ describe('RouterBuilder', () => {
 
       expect(routes).to.be.like([
         {
+          element: createElement(Server),
+          handle: {
+            ignoreFallback: true,
+          },
           children: [
             {
+              path: 'mixed-nested-layouts',
               children: [
                 {
+                  path: 'parent-flow-layout',
                   handle: {
                     flowLayout: true,
                   },
-                  path: '',
-                },
-                {
-                  handle: {
-                    flowLayout: true,
-                  },
-                  path: '/nested',
+                  children: [
+                    {
+                      path: 'flow-layout',
+                      handle: {
+                        flowLayout: true,
+                      },
+                    },
+                    {
+                      path: 'not-specified-layout-4',
+                      children: [
+                        {
+                          path: 'child-flow-layout-1',
+                          handle: {
+                            flowLayout: true,
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      path: 'regular-layout-2',
+                      handle: {
+                        flowLayout: false,
+                      },
+                      children: [
+                        {
+                          path: 'child-flow-layout-2',
+                          handle: {
+                            flowLayout: true,
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      path: 'not-specified-layout-1',
+                    },
+                    {
+                      path: 'not-specified-layout-2',
+                    },
+                    {
+                      path: 'not-specified-layout-3',
+                      children: [
+                        {
+                          path: 'child-not-specifed-layout',
+                        },
+                      ],
+                    },
+                  ],
                 },
               ],
-              path: 'nest',
             },
             {
-              children: [
-                {
-                  path: '/child',
-                },
-                {
-                  path: '/empty-layout',
-                  children: [],
-                },
-              ],
-              path: '/test',
+              path: 'flow-layout-another-branch',
               handle: {
                 flowLayout: true,
               },
             },
           ],
-          element: createElement(Server),
+        },
+        {
+          path: 'mixed-nested-layouts',
+          children: [
+            {
+              path: 'parent-flow-layout',
+              handle: {
+                flowLayout: true,
+              },
+              children: [
+                {
+                  path: 'regular-layout-1',
+                  handle: {
+                    flowLayout: false,
+                  },
+                },
+                {
+                  path: 'not-specified-layout-2',
+                  children: [
+                    {
+                      path: 'child-regular-layout',
+                      handle: {
+                        flowLayout: false,
+                      },
+                    },
+                  ],
+                },
+                {
+                  path: 'regular-layout-2',
+                  handle: {
+                    flowLayout: false,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          path: 'regular-layout-outside',
           handle: {
-            ignoreFallback: true,
+            flowLayout: false,
           },
         },
         {
+          path: '',
           children: [
             {
               path: '/test',
               element: <div>Test</div>,
             },
           ],
-          path: '',
         },
         {
-          children: [
-            {
-              path: '/outside',
-              handle: {
-                flowLayout: false,
-              },
-            },
-            {
-              path: '/nested-empty-layout',
-              children: [],
-            },
-          ],
-          path: 'nest',
-        },
-        {
-          path: '/empty-layout-outside',
-          children: [],
+          path: 'not-specified-layout-outside',
         },
       ]);
     });

--- a/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
+++ b/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
@@ -319,6 +319,81 @@ describe('RouterBuilder', () => {
         `The module for the "test" section doesn't have the React component exported by default or a ViewConfig object exported as "config"`,
       );
     });
+
+    it('should not lose a route from the result', () => {
+      const { routes } = builder
+        .withReactRoutes([
+          {
+            path: 'home',
+            children: [
+              {
+                path: 'deep',
+                children: [
+                  {
+                    path: 'hello',
+                    handle: {
+                      flowLayout: true,
+                    },
+                  },
+                ],
+                handle: { flowLayout: true },
+              },
+              {
+                path: 'deepend',
+                children: [{ path: 'deep' }],
+              },
+            ],
+          },
+        ])
+        .withLayout(Server)
+        .build();
+
+      expect(routes).to.be.like([
+        {
+          element: createElement(Server),
+          handle: {
+            ignoreFallback: true,
+          },
+          children: [
+            {
+              path: 'home',
+              children: [
+                {
+                  path: 'deep',
+                  children: [
+                    {
+                      path: 'hello',
+                      handle: {
+                        flowLayout: true,
+                      },
+                    },
+                  ],
+                  handle: { flowLayout: true },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          path: '',
+          children: [
+            {
+              path: '/test',
+              element: <div>Test</div>,
+            },
+          ],
+        },
+        {
+          path: 'home',
+          children: [
+            {
+              path: 'deepend',
+              children: [{ path: 'deep' }],
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('withLayout', () => {

--- a/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
+++ b/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
@@ -303,6 +303,22 @@ describe('RouterBuilder', () => {
         },
       ]);
     });
+
+    it('should accept a file route module with a config only', () => {
+      expect(() =>
+        builder.withFileRoutes([{ path: 'test', module: { config: { flowLayout: true } } }]).build(),
+      ).to.not.throw();
+    });
+
+    it('should accept an undefined file route module', () => {
+      expect(() => builder.withFileRoutes([{ path: 'test', module: undefined }]).build()).to.not.throw();
+    });
+
+    it('should throw if a file route module has no component or config', () => {
+      expect(() => builder.withFileRoutes([{ path: 'test', module: {} }]).build()).to.throw(
+        `The module for the "test" section doesn't have the React component exported by default or a ViewConfig object exported as "config"`,
+      );
+    });
   });
 
   describe('withLayout', () => {

--- a/packages/ts/file-router/test/vite-plugin/applyLayouts.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/applyLayouts.spec.ts
@@ -96,5 +96,10 @@ describe('@vaadin/hilla-file-router', () => {
         { path: '/flow' },
       ]);
     });
+
+    it('should throw an error in an unexpected case', async () => {
+      await writeFile(layoutsFile, '[{path: "/flow');
+      await expect(applyLayouts([{ path: '/flow' }], layoutsFile)).to.be.rejectedWith(Error);
+    });
   });
 });

--- a/packages/ts/file-router/test/vite-plugin/applyLayouts.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/applyLayouts.spec.ts
@@ -48,7 +48,7 @@ describe('@vaadin/hilla-file-router', () => {
       const result = await applyLayouts(meta, layoutsFile);
 
       expect(result).to.deepEqualIgnoreUndefined([
-        { path: '', children: undefined },
+        { path: '' },
         {
           path: 'flow',
           flowLayout: true,

--- a/packages/ts/file-router/test/vite-plugin/applyLayouts.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/applyLayouts.spec.ts
@@ -1,0 +1,100 @@
+import { writeFile } from 'node:fs/promises';
+import { expect, use } from '@esm-bundle/chai';
+import chaiAsPromised from 'chai-as-promised';
+import chaiLike from 'chai-like';
+import applyLayouts from '../../src/vite-plugin/applyLayouts.js';
+import type { RouteMeta } from '../../src/vite-plugin/collectRoutesFromFS.js';
+import { createTmpDir } from '../utils.js';
+
+use(chaiLike);
+use(chaiAsPromised);
+
+describe('@vaadin/hilla-file-router', () => {
+  describe('applyLayouts', () => {
+    let tmp: URL;
+    let layoutsFile: URL;
+
+    before(async () => {
+      tmp = await createTmpDir();
+      layoutsFile = new URL('./layouts.json', tmp);
+      await writeFile(layoutsFile, JSON.stringify([{ path: '/flow' }, { path: '/hilla/some/deep' }]));
+    });
+
+    it('should enable flow layout for matching routes', async () => {
+      const meta: readonly RouteMeta[] = [
+        { path: '' },
+        {
+          path: 'flow',
+          children: [{ path: '' }, { path: 'hello-hilla' }],
+        },
+        {
+          path: 'hilla',
+          children: [
+            { path: '' },
+            { path: 'admin' },
+            { path: 'hello-react' },
+            { path: 'user' },
+            {
+              path: 'some',
+              children: [
+                {
+                  path: 'deep',
+                  children: [
+                    {
+                      path: 'flow',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { path: 'login' },
+      ];
+
+      const result = await applyLayouts(meta, layoutsFile);
+
+      expect(result).to.be.like([
+        { path: '' },
+        {
+          path: 'flow',
+          flowLayout: true,
+          children: [
+            { path: '', flowLayout: true },
+            { path: 'hello-hilla', flowLayout: true },
+          ],
+        },
+        {
+          path: 'hilla',
+          children: [
+            { path: '' },
+            { path: 'admin' },
+            { path: 'hello-react' },
+            { path: 'user' },
+            {
+              path: 'some',
+              children: [
+                {
+                  path: 'deep',
+                  children: [
+                    {
+                      path: 'flow',
+                      flowLayout: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { path: 'login' },
+      ]);
+    });
+
+    it('should return original route metas if the file is not found', async () => {
+      await expect(applyLayouts([{ path: '/flow' }], new URL('./non-existing.json', tmp))).to.eventually.be.like([
+        { path: '/flow' },
+      ]);
+    });
+  });
+});

--- a/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
@@ -48,44 +48,45 @@ describe('@vaadin/hilla-file-router', () => {
         .equal(`import { createRoute as createRoute_1, extendModule as extendModule_1 } from "@vaadin/hilla-file-router/runtime.js";
 import type { AgnosticRoute as AgnosticRoute_1 } from "@vaadin/hilla-file-router/types.js";
 import * as Page_1 from "../issue-2928-flow-auto-layout.js";
-import * as Page_2 from "../views/nameToReplace.js";
-import * as Page_3 from "../views/profile/@index.js";
+import * as Page_2 from "../mod-extension-only-child.js";
+import * as Page_3 from "../views/nameToReplace.js";
+import * as Page_4 from "../views/profile/@index.js";
 import * as Layout_1 from "../views/profile/account/@layout.js";
-import * as Page_4 from "../views/profile/account/security/password.js";
-import * as Page_5 from "../views/profile/account/security/two-factor-auth.js";
-import * as Page_6 from "../views/profile/friends/{user}.js";
+import * as Page_5 from "../views/profile/account/security/password.js";
+import * as Page_6 from "../views/profile/account/security/two-factor-auth.js";
+import * as Page_7 from "../views/profile/friends/{user}.js";
 import * as Layout_2 from "../views/profile/friends/@layout.js";
-import * as Page_7 from "../views/profile/friends/list.js";
-import * as Page_8 from "../views/test/{...wildcard}.js";
-import * as Page_9 from "../views/test/{{optional}}.js";
-import * as Page_10 from "../views/test/issue-002378/{requiredParam}/edit.js";
+import * as Page_8 from "../views/profile/friends/list.js";
+import * as Page_9 from "../views/test/{...wildcard}.js";
+import * as Page_10 from "../views/test/{{optional}}.js";
+import * as Page_11 from "../views/test/issue-002378/{requiredParam}/edit.js";
 import * as Layout_3 from "../views/test/issue-002571-empty-layout/@layout.js";
-import * as Page_11 from "../views/test/issue-002879-config-below.js";
+import * as Page_12 from "../views/test/issue-002879-config-below.js";
 const routes: readonly AgnosticRoute_1[] = [
-    createRoute_1("nameToReplace", Page_2),
+    createRoute_1("nameToReplace", Page_3),
     createRoute_1("profile", [
-        createRoute_1("", Page_3),
+        createRoute_1("", Page_4),
         createRoute_1("account", Layout_1, [
             createRoute_1("security", [
-                createRoute_1("password", Page_4),
-                createRoute_1("two-factor-auth", Page_5)
+                createRoute_1("password", Page_5),
+                createRoute_1("two-factor-auth", Page_6)
             ])
         ]),
         createRoute_1("friends", Layout_2, [
-            createRoute_1("list", Page_7),
-            createRoute_1(":user", Page_6)
+            createRoute_1("list", Page_8),
+            createRoute_1(":user", Page_7)
         ])
     ]),
     createRoute_1("test", [
-        createRoute_1(":optional?", Page_9),
-        createRoute_1("*", Page_8),
+        createRoute_1(":optional?", Page_10),
+        createRoute_1("*", Page_9),
         createRoute_1("issue-002378", [
             createRoute_1(":requiredParam", [
-                createRoute_1("edit", Page_10)
+                createRoute_1("edit", Page_11)
             ])
         ]),
         createRoute_1("issue-002571-empty-layout", Layout_3, []),
-        createRoute_1("issue-002879-config-below", Page_11)
+        createRoute_1("issue-002879-config-below", Page_12)
     ]),
     createRoute_1("issue-2928-flow-auto-layout", extendModule_1(Page_1, { "flowLayout": true })),
     createRoute_1("mod-extension-only", extendModule_1(null, { "flowLayout": true }), [

--- a/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
@@ -28,8 +28,18 @@ describe('@vaadin/hilla-file-router', () => {
         ...meta,
         {
           path: 'issue-2928-flow-auto-layout',
-          file: new URL('test/issue-2928-flow-auto-layout.tsx', dir),
+          file: new URL('issue-2928-flow-auto-layout.tsx', dir),
           flowLayout: true,
+        },
+        {
+          path: 'mod-extension-only',
+          flowLayout: true,
+          children: [
+            {
+              path: 'mod-extension-only-child',
+              file: new URL('mod-extension-only-child.tsx', dir),
+            },
+          ],
         },
       ];
       const generated = createRoutesFromMeta(meta, runtimeUrls);
@@ -37,7 +47,7 @@ describe('@vaadin/hilla-file-router', () => {
       expect(generated).to
         .equal(`import { createRoute as createRoute_1, extendModule as extendModule_1 } from "@vaadin/hilla-file-router/runtime.js";
 import type { AgnosticRoute as AgnosticRoute_1 } from "@vaadin/hilla-file-router/types.js";
-import * as Page_1 from "../test/issue-2928-flow-auto-layout.js";
+import * as Page_1 from "../issue-2928-flow-auto-layout.js";
 import * as Page_2 from "../views/nameToReplace.js";
 import * as Page_3 from "../views/profile/@index.js";
 import * as Layout_1 from "../views/profile/account/@layout.js";
@@ -77,7 +87,10 @@ const routes: readonly AgnosticRoute_1[] = [
         createRoute_1("issue-002571-empty-layout", Layout_3, []),
         createRoute_1("issue-002879-config-below", Page_11)
     ]),
-    createRoute_1("issue-2928-flow-auto-layout", extendModule_1(Page_1, { "flowLayout": true }))
+    createRoute_1("issue-2928-flow-auto-layout", extendModule_1(Page_1, { "flowLayout": true })),
+    createRoute_1("mod-extension-only", extendModule_1(null, { "flowLayout": true }), [
+        createRoute_1("mod-extension-only-child", Page_2)
+    ])
 ];
 export default routes;
 `);


### PR DESCRIPTION
In case `layouts.json` contains a module extension (`flowLayout: true`) for a specific route that is not represented by either regular file or a `@layout.tsx`, we should be able to apply that extension on the route. This PR allows the route `module` to be null though still have the extension.