### PR TITLE
chore: upgrade jackson.version to 2.18.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <swagger.core.version>2.2.25</swagger.core.version>
     <swagger.models.version>2.2.25</swagger.models.version>
     <swagger.parser.v3.version>2.1.15</swagger.parser.v3.version>
-    <jackson.version>2.17.2</jackson.version>
+    <jackson.version>2.18.2</jackson.version>
     <junit.version>5.10.1</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>24.6-SNAPSHOT</flow.version>


### PR DESCRIPTION
keep jackson.version aligned with flow 24.6

