### PR TITLE
fix!: rename Hilla's endpointObjectMapper to prevent bean name clashes

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointControllerConfiguration.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointControllerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2023 Vaadin Ltd.
+ * Copyright 2000-2024 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -76,7 +76,7 @@ public class EndpointControllerConfiguration {
      * Registers a default {@link EndpointAccessChecker} bean instance.
      *
      * @param accessAnnotationChecker
-     *            the access controlks checker to use
+     *            the access controls checker to use
      * @return the default Vaadin endpoint access checker bean
      */
     @Bean
@@ -112,7 +112,8 @@ public class EndpointControllerConfiguration {
      *            qualifier to override the mapper.
      */
     @Bean
-    ObjectMapper endpointObjectMapper(ApplicationContext applicationContext,
+    ObjectMapper hillaEndpointObjectMapper(
+            ApplicationContext applicationContext,
             @Autowired(required = false) @Qualifier(EndpointController.ENDPOINT_MAPPER_FACTORY_BEAN_QUALIFIER) JacksonObjectMapperFactory endpointMapperFactory) {
         if (this.endpointMapper == null) {
             this.endpointMapper = endpointMapperFactory != null
@@ -139,7 +140,7 @@ public class EndpointControllerConfiguration {
      *
      * @param applicationContext
      *            The Spring application context
-     * @param endpointObjectMapper
+     * @param hillaEndpointObjectMapper
      *            ObjectMapper instance that is used for Hilla endpoints'
      *            serializing and deserializing request and response bodies.
      * @param explicitNullableTypeChecker
@@ -154,11 +155,12 @@ public class EndpointControllerConfiguration {
      */
     @Bean
     EndpointInvoker endpointInvoker(ApplicationContext applicationContext,
-            ObjectMapper endpointObjectMapper,
+            ObjectMapper hillaEndpointObjectMapper,
             ExplicitNullableTypeChecker explicitNullableTypeChecker,
             ServletContext servletContext, EndpointRegistry endpointRegistry) {
-        return new EndpointInvoker(applicationContext, endpointObjectMapper,
-                explicitNullableTypeChecker, servletContext, endpointRegistry);
+        return new EndpointInvoker(applicationContext,
+                hillaEndpointObjectMapper, explicitNullableTypeChecker,
+                servletContext, endpointRegistry);
     }
 
     /**
@@ -275,9 +277,9 @@ public class EndpointControllerConfiguration {
     }
 
     /**
-     * Can re-generate the TypeScipt code.
+     * Can re-generate the TypeScript code.
      *
-     * @param context
+     * @param servletContext
      *            the servlet context
      * @param endpointController
      *            the endpoint controller

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/config/SignalsConfiguration.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/config/SignalsConfiguration.java
@@ -20,9 +20,9 @@ public class SignalsConfiguration {
     private final EndpointInvoker endpointInvoker;
 
     public SignalsConfiguration(EndpointInvoker endpointInvoker,
-            ObjectMapper endpointObjectMapper) {
+            ObjectMapper hillaEndpointObjectMapper) {
         this.endpointInvoker = endpointInvoker;
-        Signal.setMapper(endpointObjectMapper);
+        Signal.setMapper(hillaEndpointObjectMapper);
     }
 
     /**


### PR DESCRIPTION
Having Hilla related beans prefixed with hilla
prevents clash with other framework or user
beans.

Fixes #2955

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
