### PR TITLE
fix: accept null values as valid vor positive/negative validators

### DIFF
--- a/packages/ts/lit-form/src/Validators.ts
+++ b/packages/ts/lit-form/src/Validators.ts
@@ -268,7 +268,8 @@ export class Negative<T> extends AbstractValidator<T> {
   }
 
   override validate(value: T): boolean {
-    return toFloat(String(value)) < 0;
+    const fv = toFloat(String(value));
+    return isNaN(fv) || fv < 0;
   }
 
   readonly name = 'Negative';
@@ -280,7 +281,7 @@ export class NegativeOrZero<T> extends AbstractValidator<T> {
   }
 
   override validate(value: T): boolean {
-    return toFloat(String(value)) <= 0;
+    return (toFloat(String(value)) || 0) <= 0;
   }
 
   readonly name = 'NegativeOrZero';
@@ -292,7 +293,8 @@ export class Positive<T> extends AbstractValidator<T> {
   }
 
   override validate(value: T): boolean {
-    return toFloat(String(value)) > 0;
+    const fv = toFloat(String(value));
+    return isNaN(fv) || fv > 0;
   }
 
   readonly name = 'Positive';
@@ -304,7 +306,7 @@ export class PositiveOrZero<T> extends AbstractValidator<T> {
   }
 
   override validate(value: T): boolean {
-    return toFloat(String(value)) >= 0;
+    return (toFloat(String(value)) || 0) >= 0;
   }
 
   readonly name = 'PositiveOrZero';

--- a/packages/ts/lit-form/test/Validators.test.ts
+++ b/packages/ts/lit-form/test/Validators.test.ts
@@ -211,6 +211,9 @@ describe('@vaadin/hilla-lit-form', () => {
       assert.isTrue(validator.validate(-0.01));
       assert.isFalse(validator.validate(0));
       assert.isFalse(validator.validate(1));
+      assert.isTrue(validator.validate(undefined));
+      assert.isTrue(validator.validate(null));
+      assert.isTrue(validator.validate(''));
     });
 
     it('NegativeOrZero', () => {
@@ -221,6 +224,9 @@ describe('@vaadin/hilla-lit-form', () => {
       assert.isTrue(validator.validate(-0.01));
       assert.isTrue(validator.validate(0));
       assert.isFalse(validator.validate(1));
+      assert.isTrue(validator.validate(undefined));
+      assert.isTrue(validator.validate(null));
+      assert.isTrue(validator.validate(''));
     });
 
     it('Positive', () => {
@@ -231,6 +237,9 @@ describe('@vaadin/hilla-lit-form', () => {
       assert.isFalse(validator.validate(-0.01));
       assert.isFalse(validator.validate(0));
       assert.isTrue(validator.validate(0.01));
+      assert.isTrue(validator.validate(undefined));
+      assert.isTrue(validator.validate(null));
+      assert.isTrue(validator.validate(''));
     });
 
     it('PositiveOrZero', () => {
@@ -241,6 +250,9 @@ describe('@vaadin/hilla-lit-form', () => {
       assert.isFalse(validator.validate(-0.01));
       assert.isTrue(validator.validate(0));
       assert.isTrue(validator.validate(0.01));
+      assert.isTrue(validator.validate(undefined));
+      assert.isTrue(validator.validate(null));
+      assert.isTrue(validator.validate(''));
     });
 
     it('Size', () => {


### PR DESCRIPTION
Addresses behavior of `Positive`, `Negative`, `PositiveOrZero`, and `NegativeOrZero`, which should accept null values as valid.

As API translates null to `NaN`, it should be accepted here.

Fixes #2826.