### PR TITLE
fix(file-router): enable file routes + layout + fallback combination

### DIFF
--- a/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
+++ b/packages/ts/file-router/src/runtime/RouterConfigurationBuilder.ts
@@ -43,8 +43,8 @@ export type RouteTransformer<T> = (opts: RouteTransformerOptions<T>) => RouteObj
 
 type RoutesModifier = (routes: RouteList | undefined) => RouteList | undefined;
 
-function createRouteEntry<T extends RouteBase>(route: T): readonly [key: string, value: T] {
-  return [`${route.path ?? ''}-${route.children ? 'n' : 'i'}`, route];
+function createRouteKey<T extends RouteBase>(route: T): string {
+  return `${route.path ?? ''}-${route.children ? 'n' : 'i'}`;
 }
 
 enum RouteHandleFlags {
@@ -314,14 +314,14 @@ export class RouterConfigurationBuilder {
           if (original && added) {
             // If we have both original and added routes, we have to merge them.
             const final: Array<RouteObject | undefined> = [];
-            const paths = new Set([...original.map(({ path }) => path), ...added.map(({ path }) => path)]);
+            const pathKeys = new Set([...original.map(createRouteKey), ...added.map(createRouteKey)]);
 
-            for (const path of paths) {
+            for (const pathKey of pathKeys) {
               // We can have multiple routes with the same path, so we have to
               // consider all of them.
-              const originalRoutes = original.filter((r) => r.path === path);
+              const originalRoutes = original.filter((r) => createRouteKey(r) === pathKey);
               // We can have only one route with the same path in the added list.
-              const addedRoutes = added.filter((r) => r.path === path);
+              const addedRoutes = added.filter((r) => createRouteKey(r) === pathKey);
 
               if (addedRoutes.length > 1) {
                 throw new Error('Adding multiple routes with the same path is not allowed');

--- a/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
+++ b/packages/ts/file-router/test/runtime/RouterConfigurationBuilder.spec.tsx
@@ -178,6 +178,9 @@ describe('RouterBuilder', () => {
             {
               path: '/test',
               element: <div>Test</div>,
+            },
+            {
+              path: '/test',
               children: [
                 {
                   path: '/child-test',
@@ -874,6 +877,37 @@ describe('RouterBuilder', () => {
             { path: '*', element: <Server /> },
           ],
           handle: { title: 'undefined' },
+        },
+        { path: '*', element: <Server /> },
+        { index: true, element: <Server /> },
+      ]);
+    });
+  });
+
+  describe('combinations', () => {
+    it('should support file routes with server layout and fallback', () => {
+      const { routes } = new RouterConfigurationBuilder()
+        .withFileRoutes([
+          {
+            path: '/next-test',
+            module: {
+              default: NextTest,
+              config: {
+                flowLayout: true,
+              },
+            },
+          },
+        ])
+        .withFallback(Server)
+        .build();
+
+      expect(routes).to.be.like([
+        {
+          element: <Server />,
+          handle: {
+            ignoreFallback: true,
+          },
+          children: [{ path: '/next-test', element: <NextTest /> }],
         },
         { path: '*', element: <Server /> },
         { index: true, element: <Server /> },


### PR DESCRIPTION
The combination use cases with file routes, server layout, and server fallback were broken in #2971. This fixes the combination issue and adds a test.