### PR TITLE
chore: Remove unused jackson version definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
     <swagger.core.version>2.2.26</swagger.core.version>
     <swagger.models.version>2.2.26</swagger.models.version>
     <swagger.parser.v3.version>2.1.15</swagger.parser.v3.version>
-    <jackson.version>2.17.2</jackson.version>
     <junit.version>5.10.1</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>24.7-SNAPSHOT</flow.version>
@@ -200,12 +199,10 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
The version comes from the spring boot import
