### PR TITLE
chore: upgrade javaparser to 2.26.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jakarta.activation.api.version>2.1.2</jakarta.activation.api.version>
     <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
     <jaxb.version>4.0.4</jaxb.version>
-    <github.javaparser.core.version>3.26.2</github.javaparser.core.version>
+    <github.javaparser.core.version>3.26.3</github.javaparser.core.version>
     <jetty.version>12.0.3</jetty.version>
     <atmosphere.version>3.0.5.slf4jvaadin1</atmosphere.version>
   </properties>


### PR DESCRIPTION
## Description

This resolves the convergence issue between the vaadin-dev-server and Hilla.