### PR TITLE
chore: align dependencies version with Flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.13.0</version>
+        <version>3.17.0</version>
       </dependency>
       <dependency>
         <groupId>jakarta.servlet</groupId>
@@ -255,7 +255,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.16.1</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Hilla pins a couple of dependencies older than the ones defined by Flow. The clash is shown when Vaadin maven plugin fails for some reason and it dumps the project-plugin incompatibilities.

References vaadin/flow#20740