### PR TITLE
chore: Bump preact signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@nx/js": "^20.2.2",
-    "@preact/signals-react-transform": "^0.5.0",
+    "@preact/signals-react-transform": "^0.5.1",
     "@remcovaes/web-test-runner-vite-plugin": "^1.2.2",
     "@types/karma": "^6.3.9",
     "@types/node": "^22.10.2",

--- a/packages/ts/react-signals/package.json
+++ b/packages/ts/react-signals/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@preact/signals-react": "^2.3.0",
+    "@preact/signals-react": "^3.0.0",
     "@vaadin/hilla-frontend": "24.7.0-alpha4",
     "nanoid": "^5.0.9"
   },


### PR DESCRIPTION
Major version 3 drops support for auto tracking, not in use in Hilla anymore
