### PR TITLE
fix(gradle): deprecate `hillaConfigure`

### DIFF
--- a/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineBuildFrontendTask.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineBuildFrontendTask.kt
@@ -15,8 +15,20 @@
  */
 package com.vaadin.hilla.gradle.plugin
 
+import com.vaadin.gradle.VaadinFlowPluginExtension
+import com.vaadin.hilla.engine.EngineConfiguration
+import org.gradle.api.tasks.TaskAction
+
 /**
  * Extend the VaadinBuildFrontendTask so that frontend files are not cleaned after build.
  */
 public open class EngineBuildFrontendTask : com.vaadin.gradle.VaadinBuildFrontendTask() {
+    @TaskAction
+    public fun hillaBuildFrontend() {
+        val vaadinExtension = VaadinFlowPluginExtension.get(project)
+        val engineConfiguration = HillaPlugin.createEngineConfiguration(project, vaadinExtension)
+        EngineConfiguration.setDefault(engineConfiguration)
+
+        vaadinBuildFrontend()
+    }
 }

--- a/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineConfigureTask.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineConfigureTask.kt
@@ -25,6 +25,7 @@ import com.vaadin.hilla.engine.*
  * Task that generates the configuration json which is needed
  * for next task of generating the endpoints and model classes.
  */
+@Deprecated("The 'configure' goal is no longer used and will be removed in a future version.")
 public open class EngineConfigureTask : DefaultTask() {
 
     init {
@@ -34,8 +35,6 @@ public open class EngineConfigureTask : DefaultTask() {
 
     @TaskAction
     public fun engineConfigure() {
-        val vaadinExtension = VaadinFlowPluginExtension.get(project)
-        val engineConfiguration = HillaPlugin.createEngineConfiguration(project, vaadinExtension)
-        EngineConfiguration.setDefault(engineConfiguration)
+        logger.warn("The 'configure' goal is no longer used and will be removed in a future version.")
     }
 }

--- a/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineGenerateTask.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineGenerateTask.kt
@@ -34,7 +34,7 @@ public open class EngineGenerateTask : DefaultTask() {
         description = "Hilla Generate Task"
 
         // we need the compiled classes:
-        dependsOn("classes", "hillaConfigure")
+        dependsOn("classes")
 
         // Make sure to run this task before the `war`/`jar` tasks, so that
         // generated endpoints and models will end up packaged in the war/jar archive.

--- a/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/HillaPlugin.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/HillaPlugin.kt
@@ -47,10 +47,6 @@ public class HillaPlugin : Plugin<Project> {
             register("hillaGenerate", EngineGenerateTask::class.java)
         }
 
-        project.tasks.named("vaadinBuildFrontend") {
-            it.dependsOn("hillaConfigure")
-        }
-
         project.tasks.withType(Jar::class.java) { task: Jar ->
             task.mustRunAfter("vaadinBuildFrontend")
         }


### PR DESCRIPTION
`hillaConfigure` task is now deprecated as in Maven. Nothing depends on it anymore.

This requires overriding in build task.

Fixes #3108.