### PR TITLE
feat(gradle-plugin): add check for Spring Boot plugin

### DIFF
--- a/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/HillaPlugin.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/HillaPlugin.kt
@@ -42,15 +42,18 @@ public class HillaPlugin : Plugin<Project> {
         // to leverage from vaadinPrepareFrontend and vaadinBuildFrontend:
         project.pluginManager.apply(VaadinPlugin::class.java)
 
-        project.tasks.replace("vaadinBuildFrontend", EngineBuildFrontendTask::class.java)
+        // only register Hilla tasks in projects that use Spring Boot
+        if (project.plugins.hasPlugin("org.springframework.boot")) {
+            project.tasks.replace("vaadinBuildFrontend", EngineBuildFrontendTask::class.java)
 
-        project.tasks.apply {
-            register("hillaConfigure", EngineConfigureTask::class.java)
-            register("hillaGenerate", EngineGenerateTask::class.java)
-        }
+            project.tasks.apply {
+                register("hillaConfigure", EngineConfigureTask::class.java)
+                register("hillaGenerate", EngineGenerateTask::class.java)
+            }
 
-        project.tasks.named("vaadinBuildFrontend") {
-            it.dependsOn("hillaConfigure")
+            project.tasks.named("vaadinBuildFrontend") {
+                it.dependsOn("hillaConfigure")
+            }
         }
 
         project.tasks.withType(Jar::class.java) { task: Jar ->


### PR DESCRIPTION
To avoid loading Hilla Gradle tasks in projects without Spring, this PR adds a check in the plugin declaration.