### PR TITLE
fix(engine): lower message level to debug when default annotations are not found

### DIFF
--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
@@ -292,7 +292,8 @@ public class EngineConfiguration {
                                 "com.vaadin.hilla.EndpointExposed", true,
                                 classLoader)));
             } catch (Throwable t) {
-                LOGGER.warn("Default annotations not found", t);
+                LOGGER.debug(
+                        "Default annotations not found. Hilla is probably not in the classpath.");
             }
             return this;
         }


### PR DESCRIPTION
Fixes #3114.