### PR TITLE
fix(aot): change how parent classloader is chosen

### DIFF
--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
@@ -152,8 +152,15 @@ class AotBrowserCallableFinder {
         var annotationNames = engineConfiguration.getParser()
                 .getEndpointAnnotations().stream().map(Class::getName).toList();
 
-        try (var classLoader = new URLClassLoader(urls,
-                AotBrowserCallableFinder.class.getClassLoader())) {
+        ClassLoader parent;
+        try {
+            parent = Class.forName("com.vaadin.hilla.BrowserCallable")
+                    .getClassLoader();
+        } catch (Throwable t) {
+            parent = AotBrowserCallableFinder.class.getClassLoader();
+        }
+
+        try (var classLoader = new URLClassLoader(urls, parent)) {
             return candidates.stream().map(name -> {
                 try {
                     return Class.forName(name, false, classLoader);


### PR DESCRIPTION
Could fix #3117 although it was working when using snapshots compiled locally.