### PR TITLE
fix(aot): don't auto-close class loader

### DIFF
--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
@@ -152,20 +152,19 @@ class AotBrowserCallableFinder {
         var annotationNames = engineConfiguration.getParser()
                 .getEndpointAnnotations().stream().map(Class::getName).toList();
 
-        try (var classLoader = new URLClassLoader(urls,
-                AotBrowserCallableFinder.class.getClassLoader())) {
-            return candidates.stream().map(name -> {
-                try {
-                    return Class.forName(name, false, classLoader);
-                } catch (Throwable t) {
-                    return null;
-                }
-            }).filter(Objects::nonNull)
-                    .filter(cls -> Arrays.stream(cls.getAnnotations())
-                            .map(Annotation::annotationType).map(Class::getName)
-                            .anyMatch(annotationNames::contains))
-                    .collect(Collectors.toList());
-        }
+        var classLoader = new URLClassLoader(urls,
+                AotBrowserCallableFinder.class.getClassLoader());
+        return candidates.stream().map(name -> {
+            try {
+                return Class.forName(name, false, classLoader);
+            } catch (Throwable t) {
+                return null;
+            }
+        }).filter(Objects::nonNull)
+                .filter(cls -> Arrays.stream(cls.getAnnotations())
+                        .map(Annotation::annotationType).map(Class::getName)
+                        .anyMatch(annotationNames::contains))
+                .collect(Collectors.toList());
     }
 
     private static String quotePath(Path path) {


### PR DESCRIPTION
Fixes #3117 by allowing the class loader used to load endpoints to stay available during class parsing.