### PR TITLE
chore(ci): install missing monocart-coverage-reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "meow": "^13.2.0",
         "micromatch": "^4.0.8",
         "mocha": "^10.3.0",
+        "monocart-coverage-reports": "^2.11.6",
         "nx": "^18.0.4",
         "postcss": "^8.4.49",
         "prettier": "^3.2.5",
@@ -6485,10 +6486,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true,
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "devOptional": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6509,7 +6511,7 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.4.0.tgz",
       "integrity": "sha512-M0EUka6rb+QC4l9Z3T0nJEzNOO7JcoJlYMrBlyBCiFSXRyxjLKayd4TbQs2FDRWQU1h9FR7QVNHt+PEaoNL5rQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -6518,10 +6520,11 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
-      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
-      "dev": true,
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -8137,10 +8140,11 @@
       "dev": true
     },
     "node_modules/console-grid": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.2.tgz",
-      "integrity": "sha512-ohlgXexdDTKLNsZz7DSJuCAwmRc8omSS61txOk39W3NOthgKGr1a1jJpZ5BCQe4PlrwMw01OvPQ1Bl3G7Y/uFg==",
-      "dev": true
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.3.tgz",
+      "integrity": "sha512-+mecFacaFxGl+1G31IsCx41taUXuW2FxX+4xIE0TIPhgML+Jb9JFcBWGhhWerd1/vhScubdmHqTwOhB0KCUUAg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -9185,6 +9189,13 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
+    },
+    "node_modules/eight-colors": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
+      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -13360,7 +13371,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.1.0.tgz",
       "integrity": "sha512-CMkfimAypidTtWjNDxY8a1bc1mJdyEh04V2FfEQ5Zh8Nx4v7k850EYa+dOWGn9hKG5xOyHP5MkuduAZCTHRvJw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.15",
@@ -13760,11 +13771,48 @@
         "node": ">=10"
       }
     },
+    "node_modules/monocart-coverage-reports": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.11.6.tgz",
+      "integrity": "sha512-BBKfb3LKjt/Y28t3W2jqMbff2Au5EtKjGn1rScPI7D8FN5QlTw+V9pJBkNSkh+R+FqMXNUeNVoUeNAk1CySchg==",
+      "devOptional": true,
+      "license": "MIT",
+      "workspaces": [
+        "test"
+      ],
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-loose": "^8.4.0",
+        "acorn-walk": "^8.3.4",
+        "commander": "^13.0.0",
+        "console-grid": "^2.2.3",
+        "eight-colors": "^1.3.1",
+        "foreground-child": "^3.3.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.7",
+        "lz-utils": "^2.1.0",
+        "monocart-locator": "^1.0.2"
+      },
+      "bin": {
+        "mcr": "lib/cli.js"
+      }
+    },
+    "node_modules/monocart-coverage-reports/node_modules/commander": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
+      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/monocart-locator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.2.tgz",
       "integrity": "sha512-v8W5hJLcWMIxLCcSi/MHh+VeefI+ycFmGz23Froer9QzWjrbg4J3gFJBuI/T1VLNoYxF47bVPPxq8ZlNX4gVCw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -18697,30 +18745,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-cli/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-cli/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-cli/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -18737,12 +18761,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-cli/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-cli/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -18996,30 +19014,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-core/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-core/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-core/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -19036,12 +19030,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-core/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-core/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -19312,30 +19300,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-backbone/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-backbone/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-backbone/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -19352,12 +19316,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-backbone/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-backbone/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -19615,30 +19573,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-barrel/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-barrel/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-barrel/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -19655,12 +19589,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-barrel/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-barrel/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -19916,30 +19844,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-client/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-client/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-client/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -19956,12 +19860,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-client/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-client/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -20222,30 +20120,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-model/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-model/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-model/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -20262,12 +20136,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-model/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-model/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -20527,30 +20395,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-push/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-push/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-push/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -20567,12 +20411,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-push/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-push/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -20834,30 +20672,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-signals/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-signals/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-signals/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -20910,12 +20724,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-signals/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-signals/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -21280,30 +21088,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-plugin-subtypes/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-plugin-subtypes/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-plugin-subtypes/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -21320,12 +21104,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-plugin-subtypes/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-plugin-subtypes/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -21580,30 +21358,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/ts/generator-utils/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/generator-utils/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/generator-utils/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -21620,12 +21374,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "packages/ts/generator-utils/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/generator-utils/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -22056,30 +21804,6 @@
       "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==",
       "dev": true
     },
-    "packages/ts/models/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "packages/ts/models/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "packages/ts/models/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -22181,12 +21905,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "packages/ts/models/node_modules/eight-colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
-      "integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
-      "dev": true
     },
     "packages/ts/models/node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "meow": "^13.2.0",
     "micromatch": "^4.0.8",
     "mocha": "^10.3.0",
+    "monocart-coverage-reports": "^2.11.6",
     "nx": "^18.0.4",
     "postcss": "^8.4.49",
     "prettier": "^3.2.5",


### PR DESCRIPTION
This should let the tests pass again on GitHub CI