### PR TITLE
fix(binder): convert property paths in arrays to dot notation

### DIFF
--- a/packages/ts/lit-form/src/BinderRoot.ts
+++ b/packages/ts/lit-form/src/BinderRoot.ts
@@ -219,7 +219,9 @@ export class BinderRoot<M extends AbstractModel = AbstractModel> extends BinderN
           const [property, value, message] = res ? res.splice(2) : [data.parameterName ?? '', undefined, data.message];
           valueErrors.push({
             message,
-            property,
+            // Convert property from bracket notation to dot notation
+            // Example: 'orders[0].description' becomes 'orders.0.description'
+            property: property.replace(/\[(\d+)\]/gu, '.$1'),
             validator: new ServerValidator(message),
             value,
             validatorMessage: data.validatorMessage,


### PR DESCRIPTION
As the square bracket array syntax comes directly from Java valdiation, I preferred not to touch at the generated exception messages.

Instead, the binder now converts the notation on the fly when parsing the error message, so that it will work in the form.

Fixes #3099