### PR TITLE
test: add fallback for Playwright-provided browser

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -165,6 +165,7 @@ jobs:
 
     steps:
       - name: Install Chrome
+        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
       - name: Checkout Project Code
         uses: actions/checkout@v4

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -184,6 +184,7 @@ jobs:
         run: npm run test:coverage
         env:
           CI: true
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
       - name: Collect Coverage
         run: |
           COVFILES=$(find packages/ts -wholename '*/.coverage/lcov.info' | tr '\n' ',' | sed '$s/,$//')

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,6 +27,8 @@ permissions:
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 jobs:
   init:
     name: Build Java and TypeScript for other tasks
@@ -34,7 +36,6 @@ jobs:
     timeout-minutes: 5
     env:
       NX_SKIP_NX_CACHE: true
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
     steps:
       - uses: actions-cool/check-user-permission@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -2651,31 +2651,36 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.4.tgz",
-      "integrity": "sha512-EsiT7K4beM5fN5Mz6j866EFA9+v9d5o9VUra3hrg8zY4GHmCS8b616FErbdo5eyKoVotBQkHzMIeeKYsKDStDw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.5.tgz",
+      "integrity": "sha512-ZB2Cz8KeMINUvoeDi7IrvghaVkYT2RB0Zb31EaLWOE87u276w4wnApv0SH2qWaJ3r0VSUa3BIuz7qAV2ZvsZlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.5",
-        "@inquirer/type": "^3.0.3"
+        "@inquirer/core": "^10.1.6",
+        "@inquirer/type": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.5.tgz",
-      "integrity": "sha512-/vyCWhET0ktav/mUeBqJRYTwmjFPIKPRYb3COAw7qORULgipGSUO2vL32lQKki3UxDKJ8BvuEbokaoyCA6YlWw==",
+      "version": "10.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.6.tgz",
+      "integrity": "sha512-Bwh/Zk6URrHwZnSSzAZAKH7YgGYi0xICIBDFOqBQoXNNAzBHw/bgXgLmChfp+GyR3PnChcTbiCTZGC6YJNJkMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.3",
+        "@inquirer/type": "^3.0.4",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -2685,6 +2690,14 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/core/node_modules/emoji-regex": {
@@ -2745,9 +2758,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.3.tgz",
-      "integrity": "sha512-I4VIHFxUuY1bshGbXZTxCmhwaaEst9s/lll3ekok+o1Z26/ZUKdx8y1b7lsoG6rtsBDwEGfiBJ2SfirjoISLpg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
+      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2755,6 +2768,11 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2955,9 +2973,9 @@
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.37.5",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
-      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
+      "version": "0.37.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3087,9 +3105,9 @@
       }
     },
     "node_modules/@nx/devkit/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3147,9 +3165,9 @@
       }
     },
     "node_modules/@nx/js/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3477,6 +3495,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
       "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
       }
@@ -3554,9 +3573,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4615,21 +4634,21 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz",
-      "integrity": "sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.23.0.tgz",
+      "integrity": "sha512-vBz65tJgRrA1Q5gWlRfvoH+w943dq9K1p1yDBY2pc+a1nbBLZp7fB9+Hk8DaALUbzjqlMfgaqlVPT1REJdkt/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/type-utils": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.23.0",
+        "@typescript-eslint/type-utils": "8.23.0",
+        "@typescript-eslint/utils": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4645,16 +4664,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.22.0.tgz",
-      "integrity": "sha512-MqtmbdNEdoNxTPzpWiWnqNac54h8JDAmkWtJExBVVnSrSmi9z+sZUt0LfKqk9rjqmKOIeRhO4fHHJ1nQIjduIQ==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.23.0.tgz",
+      "integrity": "sha512-h2lUByouOXFAlMec2mILeELUbME5SZRN/7R9Cw2RD2lRQQY08MWMM+PmVVKKJNK1aIwqTo9t/0CvOxwPbRIE2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.23.0",
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/typescript-estree": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4670,14 +4689,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz",
-      "integrity": "sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.23.0.tgz",
+      "integrity": "sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0"
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4688,16 +4707,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.22.0.tgz",
-      "integrity": "sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.23.0.tgz",
+      "integrity": "sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
+        "@typescript-eslint/typescript-estree": "8.23.0",
+        "@typescript-eslint/utils": "8.23.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4712,9 +4731,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.22.0.tgz",
-      "integrity": "sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.23.0.tgz",
+      "integrity": "sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4726,20 +4745,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz",
-      "integrity": "sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.23.0.tgz",
+      "integrity": "sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4769,9 +4788,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4782,16 +4801,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.22.0.tgz",
-      "integrity": "sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.23.0.tgz",
+      "integrity": "sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0"
+        "@typescript-eslint/scope-manager": "8.23.0",
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/typescript-estree": "8.23.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4806,13 +4825,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz",
-      "integrity": "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.23.0.tgz",
+      "integrity": "sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
+        "@typescript-eslint/types": "8.23.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -4847,6 +4866,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.0-alpha8.tgz",
       "integrity": "sha512-BjfHuUqCMRoXJoDSLBTxQJcqL1zHr4v8xM3yXtVLT2Nj7L2B0bMXNGHZor0iQO9v+fwHSN8WwDh+9I/T/rlROQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4858,6 +4878,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/accordion/-/accordion-24.7.0-alpha8.tgz",
       "integrity": "sha512-mMH1ykAAGCj5JCHZU3KVmi98neULFGMfwRXxr0IE/VkaVttrQsNQul30wxqtgGg2pia3bqza9Fknokk9+VX/0Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4874,6 +4895,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/app-layout/-/app-layout-24.7.0-alpha8.tgz",
       "integrity": "sha512-nZ6rnnZ9x/noYQzoNRo29xZoUK+6Bzdfnj35IyepDi/e7dxLIDz3PuWGgKwikamXFwG1l+2K3hIZzVgOYMdFQg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4890,6 +4912,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/avatar/-/avatar-24.7.0-alpha8.tgz",
       "integrity": "sha512-pwwMFkUQzngG6JhOpntht6jE8Bbybh2/UJ6zAq2qCsW1uzRt7xg7GbFhk9uuNTp+SlVQWdaDFC0W6Ka2lK5VqQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4906,6 +4929,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/avatar-group/-/avatar-group-24.7.0-alpha8.tgz",
       "integrity": "sha512-38MVZAYLyOif9x0EE6BK54CV4zNNYjGSPgOE7Cpz3MvDJYQez/n4TFpDCWpVQF23zdI8W6QY+gjM4vcqKm5YJw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4925,6 +4949,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/button/-/button-24.7.0-alpha8.tgz",
       "integrity": "sha512-xGEH4vUfsxa8Zaz570UqSyPqxdLuQkt2bRMzpTjlHW0d1qgQ/jhdyCbcb5ni6BbTfxhTuGGeXfY13T17YuadpQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4940,6 +4965,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/card/-/card-24.7.0-alpha8.tgz",
       "integrity": "sha512-8KnsTHjsKHaHNGyQmdCAHjbeSAoituV9mlquAI7muzv/EeQgvLkBObIPzv5sUclL32/BF4B43wFubUxWvXrXCw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@vaadin/component-base": "24.7.0-alpha8",
         "@vaadin/vaadin-lumo-styles": "24.7.0-alpha8",
@@ -4952,6 +4978,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.7.0-alpha8.tgz",
       "integrity": "sha512-6e28g4lVjooltwNM57NngwISshAJEzJSqeULBnFTxf+c4JwCNAG2y6gTTLz9VOgakUfmRgpj7GRcjPE0RKIluw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4968,6 +4995,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/checkbox-group/-/checkbox-group-24.7.0-alpha8.tgz",
       "integrity": "sha512-M0H97s8aVl6rKNz7GwevWC1+igN9p/mqgBR/vi0fdnzdRdQ+NTIzUkEQTYE0m1Q8yWgs0T6khsWKoYZ0hXcH8g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -4985,6 +5013,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/combo-box/-/combo-box-24.7.0-alpha8.tgz",
       "integrity": "sha512-qW8o2Qd9Wz2QBuF2xCn8f64iDPj05wiAgT0q5Ak17q1WOZzDbLAefovQxFUEdgv55yCNWUeQ/YGIzjwH13AsmQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5017,6 +5046,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.0-alpha8.tgz",
       "integrity": "sha512-Ny7gyicD4LbRHUZ2vUoHyPYpjtAnhL1M9t90sXU4QF65tI3+K8AS2Ltqky7M6bVaASqTPeMg/zRcHcPasuApGg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5029,6 +5059,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.0-alpha8.tgz",
       "integrity": "sha512-CPlDq7s3LZGgpSG4hoGu597FcjspXKCjWs7GpxRcLbDkPsKBuhHsP3lVS/G2h1jAu0iRPAGHzSKPnzeHmFlfkA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5046,6 +5077,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/context-menu/-/context-menu-24.7.0-alpha8.tgz",
       "integrity": "sha512-4Z79xCXibyC/NeSUfHnE0/oKdE5djU67Zg7vkVYfb8W2wbfawI99NbVSbfM96lteELb3WqBETlvZeMieU9ytlA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5065,6 +5097,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/custom-field/-/custom-field-24.7.0-alpha8.tgz",
       "integrity": "sha512-ofqkwwFL/vfZi8jCaw/eM8KS03bx2debf7JFm7bVbcvU/YAKLwlDc5KZ/x3YwnwSNwc5whkMmbZ/M1RYJGf2Gw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5081,6 +5114,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/date-picker/-/date-picker-24.7.0-alpha8.tgz",
       "integrity": "sha512-TL1zxdzv14ii9L5bzeuTzfbns9BzZYqpTj/VcV7vxB7Ft9QZr3dIauO4ppMXEAUW7vrurbJCarLttL1BrTfbzw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.2.0",
@@ -5100,6 +5134,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/date-time-picker/-/date-time-picker-24.7.0-alpha8.tgz",
       "integrity": "sha512-gVahWAyrVyt0ixLR/VhgklQA//AoQ2TfGPaNbDhOn6rmuHjW8k99n78+Z2fQN125Ss8qOl1tLbWVu9sEDkNANw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5119,6 +5154,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/details/-/details-24.7.0-alpha8.tgz",
       "integrity": "sha512-WOjtaAtvrBYFk3YargZo1M7wZNMK6FNwDyaaSWgytGH8XwXgXzrbenhLnXsQIFW+wA+c7ZUMZamGuz9zaEIsQQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5135,6 +5171,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/dialog/-/dialog-24.7.0-alpha8.tgz",
       "integrity": "sha512-3bwi8zqWVUSLE54kEw/HGAthLoNoSypq5SLYzeaHNs+XtrfvrWYPZuUS6YCEj2teMLCXjQ22Z1adOcJmlkUOGQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5151,6 +5188,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/email-field/-/email-field-24.7.0-alpha8.tgz",
       "integrity": "sha512-0Wfa7GbP9K16soASRWPO5IcypISVK5zN8B4YO6NG8Lyvwuta6AKA36YWHC1cyeZvEFsruk46zqBQXk4m9j8kWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5165,6 +5203,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.7.0-alpha8.tgz",
       "integrity": "sha512-N2YAgUeDCSnWZrT27QBX+BzD3OH/Z4NexIXK/tF9IWZGjAWwvpEOLIdRuCJHjY/GW5GAsXZSnSTf5QQ8F2YDZA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5177,6 +5216,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/field-highlighter/-/field-highlighter-24.7.0-alpha8.tgz",
       "integrity": "sha512-2UmEiBDocUsMOk+66KVPUhpRZ1MU8I36xx88IuckpCIWaDSoOsk/Bawy797umOzdN7uZGkrEdsOYsWQZmZP+EQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/a11y-base": "24.7.0-alpha8",
@@ -5192,6 +5232,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/form-layout/-/form-layout-24.7.0-alpha8.tgz",
       "integrity": "sha512-c9v+aV+Rk74ibBd8V9eP+onrBWfVSIhdQvEodbe1u9b3y+X/uf7tVMyFbZ9UM9m7lTymDPlqlcxaNg9j9T0FUQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5207,6 +5248,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.7.0-alpha8.tgz",
       "integrity": "sha512-wOm4ocME9Jk08DzFb6IQo7PlRyujhyWAtRihA7pawJtuLnEulMIFuECGVh8pbNx/miX+V8ovRdlRRCQ00dm2bA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5265,6 +5307,10 @@
       "resolved": "packages/ts/generator-plugin-subtypes",
       "link": true
     },
+    "node_modules/@vaadin/hilla-generator-plugin-transfertypes": {
+      "resolved": "packages/ts/generator-plugin-transfertypes",
+      "link": true
+    },
     "node_modules/@vaadin/hilla-generator-utils": {
       "resolved": "packages/ts/generator-utils",
       "link": true
@@ -5301,6 +5347,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/horizontal-layout/-/horizontal-layout-24.7.0-alpha8.tgz",
       "integrity": "sha512-2IFvMo7QHvm2/ClfW+dzuzAPuMmJTcf36PV4T/Vk3COhk+8gO0MwSYNl37LM0mcO4Eip8a8PrMY0UfV3tBePDg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5314,6 +5361,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.0-alpha8.tgz",
       "integrity": "sha512-p5DY85CTfwzjlG4dKIWUOVGC/RKlRAOBTOJhusoi/7JmoTmkzdnAnw51daxW0K9bi3pJ6T/wxL9hEPwd3oc7+A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5327,6 +5375,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/icons/-/icons-24.7.0-alpha8.tgz",
       "integrity": "sha512-lR5bMLHARrtZmPN4TwEX4S7JtU42BqY3e2U19VPjKMOY2GzBmUhlzYsrRuS6K1vgOtRAcD0MMa+wk1eQoZfcDA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/icon": "24.7.0-alpha8"
@@ -5336,6 +5385,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.7.0-alpha8.tgz",
       "integrity": "sha512-1MaD3P4jK0s42WAd0tFkpPRXfy7J0YQpikK9nfsautWKlKbgV0QVzqQUyNOFUFOtM3tIHw+RHQSmIdkzS7suLQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5349,6 +5399,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/integer-field/-/integer-field-24.7.0-alpha8.tgz",
       "integrity": "sha512-0pII5JySOSWoO7R3QRT4kp6UMWVJn4uyrSoe2hjc8O/it5b21VhW7aILaxvdOyFndpcKDFKkcNK+l3yYtlc64w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5361,6 +5412,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/item/-/item-24.7.0-alpha8.tgz",
       "integrity": "sha512-TEkBrQUQrnQ8nTHCuv5pojsWVWOgpNQ/6feTv0JEpXhpwwAd8VVVRhoTcxAjNXfSCW78RihuceUTtJ+IgtrVgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5376,6 +5428,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/list-box/-/list-box-24.7.0-alpha8.tgz",
       "integrity": "sha512-TxXNbKp09b1KQ6rChTPJ8cNqFmIueupPhBoZ+DPz5P0gm1+6SKfFsg6AbNkmq6FOZqu9Z59a5CVpgxmvXaBRXw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5392,6 +5445,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.7.0-alpha8.tgz",
       "integrity": "sha512-ezolm2+wWEh9Py+OWTpon4mXJ/sP296bcXbQE+8aRGPHXLGp/oAmEMZwqcxeRV2bEinnw8rtse9y5E4YqwslWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lit": "^3.0.0"
       }
@@ -5400,6 +5454,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/login/-/login-24.7.0-alpha8.tgz",
       "integrity": "sha512-TncrIIqV5wr+IzEpwmfGYS/eSlPmExoguEtrEh0hqolRBIZ/nRjvmEhDVxoE4VlHr3QdmsnWZZLUvy1I+5q/sg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5418,6 +5473,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/menu-bar/-/menu-bar-24.7.0-alpha8.tgz",
       "integrity": "sha512-ZkujEi559wS0Tp1ui7zGqPYmFViqO7VeeuAKPUqE9JMgwOzICTDJkbmu7y9X6LnHYXwxrJVM9aGC2FbgMdjW5g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5438,6 +5494,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/message-input/-/message-input-24.7.0-alpha8.tgz",
       "integrity": "sha512-KzYZfX/xR2XW6p3htUJTyO52iQRh2CKJIQSZuWGhmlcbv+kcnjwjZOlEs+vPFVweptrpwHCvexJo72VHSBRCNA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5454,6 +5511,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/message-list/-/message-list-24.7.0-alpha8.tgz",
       "integrity": "sha512-OhuPj54BndsSOLHVJYUuDnADQzkEnj6PdBzJmJlvawQA4yulUGBF9a8jJqYxrm0UFWKw9MNSAwFcNpvoRuZL/A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5470,6 +5528,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/multi-select-combo-box/-/multi-select-combo-box-24.7.0-alpha8.tgz",
       "integrity": "sha512-QcwlJOrz3oPBP0zbs3G3wevxR0rgO73rpULcpCnkAT/lT5jVMZ8ysLsT6kX6eWaLQxzQ/7P/c4rc0eTtjH/Uyw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5491,6 +5550,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/notification/-/notification-24.7.0-alpha8.tgz",
       "integrity": "sha512-EzuJFFRJAmM6pGPa0yg9E/s4VLrwGuSVxjnWl2kB+2xfelfc9ttPEJWkWn0YYmR4WyVYBhWKO03TZ7obNLde6g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5507,6 +5567,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/number-field/-/number-field-24.7.0-alpha8.tgz",
       "integrity": "sha512-ns7Ak9rzIj2qEnN0Ar1Cs5rL/v3KTjXjFSBGJdnT2uilJ9RqONB+BwcDmLUB2yu01TChTPh63XjFtQEwtVH/+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5524,6 +5585,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/overlay/-/overlay-24.7.0-alpha8.tgz",
       "integrity": "sha512-TjwJLH6TUSVbXGTbynxEWHwhSUoRIrzeAjAunS6te3yU2AhHwKAXVyW0sSyPX+dNKb4xzVChOKBXs7/YPtfrHQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5539,6 +5601,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/password-field/-/password-field-24.7.0-alpha8.tgz",
       "integrity": "sha512-/Jlm2wL8krxO+Cx3/54F1NrWqHmAaNbb7K9wk4jpuc9HhYVgfAI5oXnMByu/sqRZlXyfcEdVdvLtQekItfcRUg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5557,6 +5620,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/popover/-/popover-24.7.0-alpha8.tgz",
       "integrity": "sha512-1EG0iEJiA2eyeaLP2FqnOGLmrwdfo5rNtJ1ivw7p+bWpVVQzEMiEBFL6PeEL/8dlljDOumEZgXo/mqD26D/NJg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@vaadin/a11y-base": "24.7.0-alpha8",
@@ -5573,6 +5637,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/progress-bar/-/progress-bar-24.7.0-alpha8.tgz",
       "integrity": "sha512-F+6gTDryGDgVCSG1mlRbVhGB6/ArO+mB3il8MJd17ddWjbmIVv/cE1NEGIS8sCrnKM7pIHUDAtlQ9Fgh/cqT5g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5587,6 +5652,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/radio-group/-/radio-group-24.7.0-alpha8.tgz",
       "integrity": "sha512-ZUrQwNc4FbnjxCZlP1LbjP+Hd2NxpDeXvGdbj+Xi20yvhO4EZn5Pgnep+GxXhOv9OsNfEQ4RlkH5FsrpQsY0+g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5603,6 +5669,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/react-components/-/react-components-24.7.0-alpha8.tgz",
       "integrity": "sha512-LSnNbouDKEygK8gjrdAqktKQwKpI77b5ZsFsivOE0OeFpRgoSc1Jx+Ap+pZlkpF19Ep3sG6iBWinx4UzXPRP0w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@lit/react": "^1.0.7",
         "@vaadin/a11y-base": "24.7.0-alpha8",
@@ -5684,6 +5751,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/scroller/-/scroller-24.7.0-alpha8.tgz",
       "integrity": "sha512-SBYI6YxNLWDZZcn1YBFyjcznowD4pJAgtj1ImGz6xFEwEmhw+2bWGnS99km25OQ57HzIc4u/NUw3MuJfbm5omA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5699,6 +5767,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/select/-/select-24.7.0-alpha8.tgz",
       "integrity": "sha512-ReZe19Y0gral52kbb0OOCyCnjBQDcoTC0pf4G28Dvog/RcBVo1z1Wu0TwplV1ibyVVKgxWDsQa1+vTxQhT8xCg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.2.0",
@@ -5721,6 +5790,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/side-nav/-/side-nav-24.7.0-alpha8.tgz",
       "integrity": "sha512-9DmIUz9S7OCFULnwx61LPxSVRG3XwoWufuhpz113bGwdJcu+CZHWnWQTtz0tY8nXMlpC/HfJpZ530BmM9gvyzQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@vaadin/a11y-base": "24.7.0-alpha8",
@@ -5735,6 +5805,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/split-layout/-/split-layout-24.7.0-alpha8.tgz",
       "integrity": "sha512-NfF3492Pl9RmEreDQc4pmFi3fq7a9lrm+wlChrUmvKVrCcyC1qqhXwfryAsWP7Lur4iz3/Pj2RqFLFqpJnk41w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5749,6 +5820,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/tabs/-/tabs-24.7.0-alpha8.tgz",
       "integrity": "sha512-LKIXa49auI1sA/vL9zTrCPPT2JAi5osjEMaIFCB6no0HjPXD21Qc7xi3lwm4IytDeT9S7tn0k7isjlf1diC2bw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5765,6 +5837,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/tabsheet/-/tabsheet-24.7.0-alpha8.tgz",
       "integrity": "sha512-kPymyhY2OanxHVJYIRKPsaGmqLI/h8B8CIrHpuEUP8iCo57qD1aABeIovRxWvXkqbVJvdo3aNBtVQ0Nh+hhrFQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5781,6 +5854,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/text-area/-/text-area-24.7.0-alpha8.tgz",
       "integrity": "sha512-BS67OXxWUdUBEss2k1fxKsTaVWvpZea0P4EZsJRq+QYNuFewvAMH9+6MOlHor34IRnkejOe/0z+RYszbc9QaPw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5798,6 +5872,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.7.0-alpha8.tgz",
       "integrity": "sha512-L+YbhcjIx0Rqaqw0musOhXJ4DoF846BkLvhJ170+jgJp7HqYxI1gGZZcrBxg0GK9+GtMqoCG0ftrGFb4kdQheg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5815,6 +5890,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/time-picker/-/time-picker-24.7.0-alpha8.tgz",
       "integrity": "sha512-/SOoTi/ZdyVd45e4fEgQLZQ/6Sq5UlS2qYhdwoNJKJk4AMSHsZO9Jbg7mPEqzYl7FafndCUvRk4avbupkD2PWw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5834,6 +5910,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/tooltip/-/tooltip-24.7.0-alpha8.tgz",
       "integrity": "sha512-NOsrEmx9bLXh4ssZSflFP5yS+gjNFVLSDv8yHPvfDrPcEV1NspWPIXJbPWJTZY/l9fyTeHxgHwpIrSgxWvKtNA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5851,6 +5928,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/upload/-/upload-24.7.0-alpha8.tgz",
       "integrity": "sha512-jYsm+36IRsXQPvgEudW+7Z1avrRUyFtcTH8HmIHIBfh9a1eGG2+ZGGPWS+BbuJ9RhW65imPIGzTkbV+vZTN92A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -5867,12 +5945,14 @@
     "node_modules/@vaadin/vaadin-development-mode-detector": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
-      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@vaadin/vaadin-lumo-styles": {
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.0-alpha8.tgz",
       "integrity": "sha512-nIwOZ9VFo3A4IQ+HmNk1WccidwNBuEdb84dSF7aJTEgkF6XZdjH6miJlSP9jr9gnBlrVqMB9x4qa1pAJK0nANA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5884,6 +5964,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.7.0-alpha8.tgz",
       "integrity": "sha512-UPPQFRFC42HAmfLvJ1ftsJvSDhoI09+CCQefyL2M7KZckUX2KfUi+o4qEaRwyoc+rroyG/5LSDtVD8s1WOa/Qw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5894,6 +5975,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.0-alpha8.tgz",
       "integrity": "sha512-vTQ5RTJO5sLkUMES1XZuNpBd1pAzxd68dFHVsL9FH/dJiT5xvsBPNY3qYkMG8FnhyOIjsu45Yw//kPyVOYcRIA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
@@ -5904,6 +5986,7 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
       "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       },
@@ -5915,6 +5998,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/vertical-layout/-/vertical-layout-24.7.0-alpha8.tgz",
       "integrity": "sha512-IJNR/jIcUcn73gt4FDVQba9+9Yqk4h1NKl1A9Z0PAQAP1S73qFccJ5ojLzFkj6zdtxQhN4uh1Bl0CRfxJTh8+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "24.7.0-alpha8",
@@ -5928,6 +6012,7 @@
       "version": "24.7.0-alpha8",
       "resolved": "https://registry.npmjs.org/@vaadin/virtual-list/-/virtual-list-24.7.0-alpha8.tgz",
       "integrity": "sha512-W5s5X6X2psMiql71/H+BNuZpfcFVwMwOhMzXoPXmPUqq/rxPFGPVBVLDEx+RhRsKdUwUA+ROFZ0lPuB8AdcVlA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -6455,7 +6540,8 @@
     "node_modules/@webcomponents/shadycss": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -7139,9 +7225,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.4.tgz",
-      "integrity": "sha512-G6i3A74FjNq4nVrrSTUz5h3vgXzBJnjmWAVlBWaZETkgu+LgKd7AiyOml3EDJY1AHlIbBHKDXE+TUT53Ff8OaA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -7494,9 +7580,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "dev": true,
       "funding": [
         {
@@ -9108,9 +9194,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.90",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
-      "integrity": "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==",
+      "version": "1.5.92",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
+      "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -9141,9 +9227,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
-      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10142,6 +10228,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -11157,33 +11250,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-assert/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-assert/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/http-basic": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
@@ -11201,30 +11267,30 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
+        "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -11326,9 +11392,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11523,13 +11589,13 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -11550,9 +11616,9 @@
       }
     },
     "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11950,13 +12016,13 @@
       }
     },
     "node_modules/is-weakref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
-      "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12431,33 +12497,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/koa-send/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa-send/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/koa-static": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
@@ -12480,33 +12519,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/koa/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/levn": {
@@ -12826,13 +12838,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13245,9 +13250,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13640,9 +13645,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13768,9 +13773,9 @@
       }
     },
     "node_modules/nx/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13796,9 +13801,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14607,9 +14612,9 @@
       }
     },
     "node_modules/postcss-calc": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.0.tgz",
-      "integrity": "sha512-uQ/LDGsf3mgsSUEXmAt3VsCSHR3aKqtEIkmB+4PhzYwRYOW5MZs/GhCCFpsOtJJkP6EC6uGipbrnaTjqaJZcJw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15300,16 +15305,6 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
-    "node_modules/psl/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -15318,6 +15313,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer-core": {
@@ -15339,13 +15344,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -15407,6 +15412,33 @@
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -17379,26 +17411,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/tr46": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
@@ -17412,16 +17424,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/tr46/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -17433,9 +17435,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17825,6 +17827,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -17884,16 +17896,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/url-parse": {
@@ -18818,6 +18820,23 @@
         "@vaadin/hilla-generator-utils": "24.7.0-alpha10",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3",
+        "typescript": "5.7.3"
+      },
+      "engines": {
+        "node": ">= 16.13"
+      }
+    },
+    "packages/ts/generator-plugin-transfertypes": {
+      "name": "@vaadin/hilla-generator-plugin-transfertypes",
+      "version": "24.7.0-alpha10",
+      "license": "Apache 2.0",
+      "dependencies": {
+        "@vaadin/hilla-generator-core": "24.7.0-alpha10",
+        "@vaadin/hilla-generator-plugin-client": "24.7.0-alpha10",
+        "@vaadin/hilla-generator-plugin-model": "24.7.0-alpha10",
+        "@vaadin/hilla-generator-utils": "24.7.0-alpha10",
+        "fast-deep-equal": "3.1.3",
+        "openapi-types": "12.1.3",
         "typescript": "5.7.3"
       },
       "engines": {

--- a/scripts/vite/browser.vitest.config.ts
+++ b/scripts/vite/browser.vitest.config.ts
@@ -11,6 +11,8 @@ export { root, cwd, isCI, packageJson };
 function getBrowserProviderOptions(): BrowserProviderOptions {
   const { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, CHROME_BIN } = process.env;
 
+  console.log({ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, CHROME_BIN });
+
   if (PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
     if (typeof CHROME_BIN === 'string') {
       return {

--- a/scripts/vite/browser.vitest.config.ts
+++ b/scripts/vite/browser.vitest.config.ts
@@ -11,8 +11,6 @@ export { root, cwd, isCI, packageJson };
 function getBrowserProviderOptions(): BrowserProviderOptions {
   const { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, CHROME_BIN } = process.env;
 
-  console.log({ PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, CHROME_BIN });
-
   if (PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
     if (typeof CHROME_BIN === 'string') {
       return {

--- a/scripts/vite/browser.vitest.config.ts
+++ b/scripts/vite/browser.vitest.config.ts
@@ -2,10 +2,32 @@
 /// <reference types="vitest/node" />
 import react from '@vitejs/plugin-react';
 import { mergeConfig, type ViteUserConfig } from 'vitest/config';
+import type { BrowserProviderOptions } from 'vitest/node';
 import nodeConfig, { isCI, packageJson, root, cwd } from './node.vitest.config.js';
 import { constructCss } from './plugins.js';
 
 export { root, cwd, isCI, packageJson };
+
+function getBrowserProviderOptions(): BrowserProviderOptions {
+  const { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD, CHROME_BIN } = process.env;
+
+  if (PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
+    if (typeof CHROME_BIN === 'string') {
+      return {
+        launch: {
+          executablePath: CHROME_BIN,
+        },
+      };
+    }
+
+    throw new Error(
+      'You have to set CHROME_BIN along with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD to make tests working,' +
+        'or disable PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD to use browser provided by Playwright',
+    );
+  }
+
+  return {};
+}
 
 export default mergeConfig(nodeConfig, {
   plugins: [
@@ -35,9 +57,7 @@ export default mergeConfig(nodeConfig, {
       instances: [
         {
           browser: 'chromium',
-          launch: {
-            executablePath: process.env.CHROME_BIN,
-          },
+          ...getBrowserProviderOptions(),
         },
       ],
     },


### PR DESCRIPTION
If you want to get rid of an additional Chrome binary in your `node_modules`, you can add the following environment variables:
```
PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
CHROME_BIN=/opt/google/chrome/chrome # or any other path to your Chrome binary
```
**Note**: if you have `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` set without `CHROME_BIN`, it will throw an error.
**Note**: for this change to take effect you have to run `npm ci`.