### PR TITLE
chore: simplify the jspecify version management in hilla

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>hilla-engine-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-        </dependency>
 
         <!-- API DEPENDENCIES -->
 

--- a/packages/java/engine-core/pom.xml
+++ b/packages/java/engine-core/pom.xml
@@ -49,10 +49,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/packages/java/engine-runtime/pom.xml
+++ b/packages/java/engine-runtime/pom.xml
@@ -44,10 +44,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -49,10 +49,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>hilla-engine-core</artifactId>
       <version>${project.version}</version>

--- a/packages/java/parser-jvm-core/pom.xml
+++ b/packages/java/parser-jvm-core/pom.xml
@@ -20,10 +20,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
     </dependency>

--- a/packages/java/parser-jvm-plugin-backbone/pom.xml
+++ b/packages/java/parser-jvm-plugin-backbone/pom.xml
@@ -32,10 +32,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/packages/java/parser-jvm-plugin-model/pom.xml
+++ b/packages/java/parser-jvm-plugin-model/pom.xml
@@ -21,10 +21,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
     </dependency>

--- a/packages/java/parser-jvm-plugin-nonnull/pom.xml
+++ b/packages/java/parser-jvm-plugin-nonnull/pom.xml
@@ -26,10 +26,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
     </dependency>

--- a/packages/java/parser-jvm-plugin-subtypes/pom.xml
+++ b/packages/java/parser-jvm-plugin-subtypes/pom.xml
@@ -26,10 +26,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
     </dependency>

--- a/packages/java/parser-jvm-plugin-transfertypes/pom.xml
+++ b/packages/java/parser-jvm-plugin-transfertypes/pom.xml
@@ -26,10 +26,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
         </dependency>

--- a/packages/java/parser-jvm-test-utils/pom.xml
+++ b/packages/java/parser-jvm-test-utils/pom.xml
@@ -25,10 +25,6 @@
       <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/packages/java/parser-jvm-utils/pom.xml
+++ b/packages/java/parser-jvm-utils/pom.xml
@@ -20,8 +20,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -286,11 +286,6 @@
         <version>1.3</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.jspecify</groupId>
-        <artifactId>jspecify</artifactId>
-        <version>1.0.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
flow and hilla are using the same version of `org.jspecify:jspecify`. so use the transitive dependency from flow-server is simpler for maintenance 