### PR TITLE
feat(parser): add support for Spring nullability annotations

### DIFF
--- a/packages/java/parser-jvm-plugin-nonnull/src/main/java/com/vaadin/hilla/parser/plugins/nonnull/NonnullPluginConfig.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/main/java/com/vaadin/hilla/parser/plugins/nonnull/NonnullPluginConfig.java
@@ -56,25 +56,18 @@ public class NonnullPluginConfig
                 // only matter when they are used in conjunction with
                 // package-level annotations
                 new AnnotationMatcher("jakarta.annotation.Nullable", true, 20),
-                new AnnotationMatcher("org.jetbrains.annotations.Nullable",
-                        true, 20),
-                new AnnotationMatcher("androidx.annotation.Nullable", true, 20),
-                new AnnotationMatcher("org.eclipse.jdt.annotation.Nullable",
-                        true, 20),
                 new AnnotationMatcher("com.vaadin.hilla.Nullable", true, 20),
+                new AnnotationMatcher("org.springframework.lang.Nullable", true,
+                        20),
                 new AnnotationMatcher("org.jspecify.annotations.Nullable", true,
                         20),
                 // Nonnull-like annotations have the highest score for
                 // compatibility with the old generator
                 new AnnotationMatcher("jakarta.annotation.Nonnull", false, 30),
                 new AnnotationMatcher("javax.annotation.Nonnull", false, 30),
-                new AnnotationMatcher("org.jetbrains.annotations.NotNull",
-                        false, 30),
-                new AnnotationMatcher("lombok.NonNull", false, 30),
-                new AnnotationMatcher("androidx.annotation.NonNull", false, 30),
-                new AnnotationMatcher("org.eclipse.jdt.annotation.NonNull",
-                        false, 30),
                 new AnnotationMatcher("com.vaadin.hilla.Nonnull", false, 30),
+                new AnnotationMatcher("org.springframework.lang.NonNull", false,
+                        30),
                 new AnnotationMatcher("org.jspecify.annotations.NonNull", false,
                         30));
 

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/com/vaadin/hilla/parser/plugins/nonnull/nullable/NullableEndpoint.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/com/vaadin/hilla/parser/plugins/nonnull/nullable/NullableEndpoint.java
@@ -16,5 +16,14 @@ public class NullableEndpoint {
         public String id;
         @Version
         public Long version;
+
+        @jakarta.annotation.Nonnull
+        public String jakartaNonnull;
+
+        @org.jspecify.annotations.NonNull
+        public String jspecifyNonnull;
+
+        @org.springframework.lang.NonNull
+        public String springNonnull;
     }
 }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/java/com/vaadin/hilla/parser/plugins/nonnull/nullable/nonNullApi/NullableNonNullEndpoint.java
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/java/com/vaadin/hilla/parser/plugins/nonnull/nullable/nonNullApi/NullableNonNullEndpoint.java
@@ -22,5 +22,15 @@ public class NullableNonNullEndpoint {
         @Version
         @Nonnull
         public Long notNullVersion;
+
+        // it's easier to test nullability inside @NonNullApi context
+        @jakarta.annotation.Nullable
+        public String jakartaNullable;
+
+        @org.jspecify.annotations.Nullable
+        public String jspecifyNullable;
+
+        @org.springframework.lang.Nullable
+        public String springNullable;
     }
 }

--- a/packages/java/parser-jvm-plugin-nonnull/src/test/resources/com/vaadin/hilla/parser/plugins/nonnull/nullable/openapi.json
+++ b/packages/java/parser-jvm-plugin-nonnull/src/test/resources/com/vaadin/hilla/parser/plugins/nonnull/nullable/openapi.json
@@ -121,6 +121,15 @@
             "type" : "integer",
             "format" : "int64",
             "nullable" : true
+          },
+          "jakartaNonnull" : {
+            "type" : "string"
+          },
+          "jspecifyNonnull" : {
+            "type" : "string"
+          },
+          "springNonnull" : {
+            "type" : "string"
           }
         }
       },
@@ -142,6 +151,18 @@
           "notNullVersion" : {
             "type" : "integer",
             "format" : "int64"
+          },
+          "jakartaNullable" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "jspecifyNullable" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "springNullable" : {
+            "type" : "string",
+            "nullable" : true
           }
         }
       }


### PR DESCRIPTION
Adds support for Spring nullability annotations.

Also removes from the list those that cannot be detected as not available at runtime anyway.

Closes #3205