### PR TITLE
feat(connect): add `mute` option to `init` for connection state control

### DIFF
--- a/packages/ts/frontend/test/Connect.test.ts
+++ b/packages/ts/frontend/test/Connect.test.ts
@@ -207,6 +207,14 @@ describe('@vaadin/hilla-frontend', () => {
         expect(stateChangeListener).to.be.calledWithExactly(ConnectionState.LOADING, ConnectionState.CONNECTED);
       });
 
+      it('should not set connection state for muted requests', async () => {
+        const stateChangeListener = sinon.fake();
+        $wnd.Vaadin?.connectionState?.addStateChangeListener(stateChangeListener);
+
+        await client.call('FooEndpoint', 'fooMethod', {}, { mute: true });
+        expect(stateChangeListener).to.not.be.called;
+      });
+
       it('should set connection state to CONNECTION_LOST on network failure', async () => {
         const stateChangeListener = sinon.fake();
         $wnd.Vaadin?.connectionState?.addStateChangeListener(stateChangeListener);


### PR DESCRIPTION
Introduce a `mute` option that prevents updating the connection state during requests.

This can be used to not show the progress indicator for calls that are expected to take time.

Closes #2405.