### PR TITLE
fix: add new `transfertypes` plugin to new projects

### DIFF
--- a/scripts/prepare/templates/components/lit/package.json
+++ b/scripts/prepare/templates/components/lit/package.json
@@ -21,6 +21,7 @@
     "@vaadin/hilla-generator-plugin-model": "{{version}}",
     "@vaadin/hilla-generator-plugin-push": "{{version}}",
     "@vaadin/hilla-generator-plugin-signals": "{{version}}",
-    "@vaadin/hilla-generator-plugin-subtypes": "{{version}}"
+    "@vaadin/hilla-generator-plugin-subtypes": "{{version}}",
+    "@vaadin/hilla-generator-plugin-transfertypes": "{{version}}"
   }
 }

--- a/scripts/prepare/templates/components/react/package.json
+++ b/scripts/prepare/templates/components/react/package.json
@@ -27,6 +27,7 @@
     "@vaadin/hilla-generator-plugin-model": "{{version}}",
     "@vaadin/hilla-generator-plugin-push": "{{version}}",
     "@vaadin/hilla-generator-plugin-signals": "{{version}}",
-    "@vaadin/hilla-generator-plugin-subtypes": "{{version}}"
+    "@vaadin/hilla-generator-plugin-subtypes": "{{version}}",
+    "@vaadin/hilla-generator-plugin-transfertypes": "{{version}}"
   }
 }


### PR DESCRIPTION
Adds new plugin to templates so that new projects get it added automatically.