### PR TITLE
fix: make Gradle plugin able to build projects that use Crud services

### DIFF
--- a/packages/java/gradle-plugin/build.gradle
+++ b/packages/java/gradle-plugin/build.gradle
@@ -67,7 +67,6 @@ repositories {
 
 dependencies {
     implementation('org.jetbrains.kotlin:kotlin-stdlib:1.9.20')
-    implementation("com.vaadin:hilla-endpoint:$version")
     implementation("com.vaadin:hilla-engine-core:$version")
     implementation("com.vaadin:flow-gradle-plugin:$flowVersion")
     implementation("org.springframework.boot:spring-boot-loader-tools:$springBootVersion")

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/EndpointExposedPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/EndpointExposedPlugin.java
@@ -92,9 +92,11 @@ public final class EndpointExposedPlugin
     private Node<?, ?> createEndpointHierarchyClassNode(
             ClassInfoModel classInfo) {
         var endpointExposedAnnotations = getStorage().getParserConfig()
-                .getEndpointExposedAnnotations();
+                .getEndpointExposedAnnotations().stream().map(Class::getName)
+                .toList();
         var exposed = classInfo.getAnnotations().stream()
                 .map(annInfo -> ((Annotation) annInfo.get()).annotationType())
+                .map(Class::getName)
                 .anyMatch(endpointExposedAnnotations::contains);
         var classInfoNode = exposed ? EndpointExposedNode.of(classInfo)
                 : EndpointNonExposedNode.of(classInfo);

--- a/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/EndpointExposedPlugin.java
+++ b/packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/EndpointExposedPlugin.java
@@ -91,6 +91,7 @@ public final class EndpointExposedPlugin
      */
     private Node<?, ?> createEndpointHierarchyClassNode(
             ClassInfoModel classInfo) {
+        // annotations are compared by name as Gradle can proxy them
         var endpointExposedAnnotations = getStorage().getParserConfig()
                 .getEndpointExposedAnnotations().stream().map(Class::getName)
                 .toList();


### PR DESCRIPTION
This pull request fixes the production mode build of application using Crud services and possibly other cases.

### Dependency Management:

* [`packages/java/gradle-plugin/build.gradle`](diffhunk://#diff-11e376bdc8ba82f59018f258fef4347682f62c30ce8b1b4183ee5b1fcd8ad89bL70): Removed the `com.vaadin:hilla-endpoint` dependency as it is probably a leftover.

### Code Enhancements:

* [`packages/java/parser-jvm-plugin-backbone/src/main/java/com/vaadin/hilla/parser/plugins/backbone/EndpointExposedPlugin.java`](diffhunk://#diff-e39d2a245ce2536e21481655b3897f52ea848d08fabeb2045013034343c94c16R94-R100): Compare annotations by name as Gradle can proxy them.