### PR TITLE
feat: show output of external commands

### DIFF
--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/commandrunner/CommandRunner.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/commandrunner/CommandRunner.java
@@ -3,8 +3,10 @@ package com.vaadin.hilla.engine.commandrunner;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import org.slf4j.Logger;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
@@ -148,6 +150,19 @@ public interface CommandRunner {
                 }
             }
 
+            try (var reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()));
+                    var errorReader = new BufferedReader(
+                            new InputStreamReader(process.getErrorStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+                while ((line = errorReader.readLine()) != null) {
+                    System.err.println(line);
+                }
+            }
+
             exitCode = process.waitFor();
         } catch (IOException | InterruptedException e) {
             // Tries to figure out if the command is not found. This is not a
@@ -196,8 +211,8 @@ public interface CommandRunner {
         builder.environment().putAll(environment());
 
         if (stdOut) {
-            builder.redirectOutput(ProcessBuilder.Redirect.INHERIT)
-                    .redirectError(ProcessBuilder.Redirect.INHERIT);
+            builder.redirectOutput(ProcessBuilder.Redirect.PIPE)
+                    .redirectError(ProcessBuilder.Redirect.PIPE);
         }
 
         return builder;

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/commandrunner/CommandRunner.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/commandrunner/CommandRunner.java
@@ -150,16 +150,19 @@ public interface CommandRunner {
                 }
             }
 
-            try (var reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()));
-                    var errorReader = new BufferedReader(
-                            new InputStreamReader(process.getErrorStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    System.out.println(line);
-                }
-                while ((line = errorReader.readLine()) != null) {
-                    System.err.println(line);
+            if (stdOut) {
+                try (var reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream()));
+                        var errorReader = new BufferedReader(
+                                new InputStreamReader(
+                                        process.getErrorStream()))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        System.out.println(line);
+                    }
+                    while ((line = errorReader.readLine()) != null) {
+                        System.err.println(line);
+                    }
                 }
             }
 

--- a/packages/java/engine-core/src/test/java/com/vaadin/hilla/engine/commandrunner/CommandRunnerTest.java
+++ b/packages/java/engine-core/src/test/java/com/vaadin/hilla/engine/commandrunner/CommandRunnerTest.java
@@ -106,6 +106,8 @@ public class CommandRunnerTest {
             };
 
             assertThrows(CommandRunnerException.class, () -> runner.run(null));
+            // On Windows, the error message does not necessarily contain the
+            // name of the missing directory
             assertFalse(errContent.toString().isEmpty());
         } finally {
             System.setErr(originalErr);


### PR DESCRIPTION
When running commands using `CommandRunner`, their output is easily lost.

This PR modifies `CommandRunner` so that the output goes to the console.

This can be useful when there's an error in the `node` command run by the generator.