### PR TITLE
fix(parser): add a fallback if AOT fails

### DIFF
--- a/packages/java/engine-core/pom.xml
+++ b/packages/java/engine-core/pom.xml
@@ -94,6 +94,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
@@ -101,8 +101,6 @@ class AotBrowserCallableFinder {
         var argsFile = engineConfiguration.getBuildDir()
                 .resolve("hilla-aot-args.txt");
         Files.write(argsFile, settings);
-        var report = engineConfiguration.getBuildDir()
-                .resolve("hilla-aot-report.txt");
 
         var javaExecutable = ProcessHandle.current().info().command()
                 .orElse(Path.of(System.getProperty("java.home"), "bin", "java")
@@ -113,6 +111,8 @@ class AotBrowserCallableFinder {
         var process = new ProcessBuilder().inheritIO()
                 .command(javaExecutable, "@" + argsFile)
                 .redirectErrorStream(true).start();
+        var report = engineConfiguration.getBuildDir()
+                .resolve("hilla-aot-report.txt");
         Files.copy(process.getInputStream(), report);
         int exitCode = process.waitFor();
 

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/AotBrowserCallableFinder.java
@@ -101,7 +101,8 @@ class AotBrowserCallableFinder {
         var argsFile = engineConfiguration.getBuildDir()
                 .resolve("hilla-aot-args.txt");
         Files.write(argsFile, settings);
-
+        var report = engineConfiguration.getBuildDir()
+                .resolve("hilla-aot-report.txt");
         var javaExecutable = ProcessHandle.current().info().command()
                 .orElse(Path.of(System.getProperty("java.home"), "bin", "java")
                         .toString());
@@ -110,10 +111,8 @@ class AotBrowserCallableFinder {
         // reflect-config.json file. This comes from the `process-aot` goal.
         var process = new ProcessBuilder().inheritIO()
                 .command(javaExecutable, "@" + argsFile)
-                .redirectErrorStream(true).start();
-        var report = engineConfiguration.getBuildDir()
-                .resolve("hilla-aot-report.txt");
-        Files.copy(process.getInputStream(), report);
+                .redirectOutput(report.toFile()).redirectErrorStream(true)
+                .start();
         int exitCode = process.waitFor();
 
         if (exitCode != 0) {

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
@@ -135,7 +135,7 @@ public class EngineConfiguration {
         return () -> {
             try {
                 return AotBrowserCallableFinder.findEndpointClasses(this);
-            } catch (IOException | InterruptedException e) {
+            } catch (Exception e) {
                 if (classFinder != null) {
                     LOGGER.info(
                             "AOT-based detection of browser-callable classes failed. Falling back to classpath scan.");

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ public class EngineConfiguration {
     private BrowserCallableFinder browserCallableFinder;
     private boolean productionMode = false;
     private String nodeCommand = "node";
+    private ClassFinder classFinder;
 
     private EngineConfiguration() {
         baseDir = Path.of(System.getProperty("user.dir"));
@@ -107,6 +109,10 @@ public class EngineConfiguration {
         return nodeCommand;
     }
 
+    public ClassFinder getClassFinder() {
+        return classFinder;
+    }
+
     public List<Class<? extends Annotation>> getEndpointAnnotations() {
         return parser.getEndpointAnnotations();
     }
@@ -130,7 +136,14 @@ public class EngineConfiguration {
             try {
                 return AotBrowserCallableFinder.findEndpointClasses(this);
             } catch (IOException | InterruptedException e) {
-                throw new ExecutionFailedException(e);
+                if (classFinder != null) {
+                    LOGGER.info(
+                            "AOT-based detection of browser-callable classes failed. Falling back to classpath scan.");
+                    return LookupBrowserCallableFinder
+                            .findEndpointClasses(classFinder, this);
+                } else {
+                    throw new ExecutionFailedException(e);
+                }
             }
         };
     }
@@ -168,6 +181,7 @@ public class EngineConfiguration {
             this.configuration.browserCallableFinder = configuration.browserCallableFinder;
             this.configuration.productionMode = configuration.productionMode;
             this.configuration.nodeCommand = configuration.nodeCommand;
+            this.configuration.classFinder = configuration.classFinder;
             this.configuration.parser.setEndpointAnnotations(
                     configuration.getEndpointAnnotations());
             this.configuration.parser.setEndpointExposedAnnotations(
@@ -250,6 +264,11 @@ public class EngineConfiguration {
 
         public Builder nodeCommand(String value) {
             configuration.nodeCommand = value;
+            return this;
+        }
+
+        public Builder classFinder(ClassFinder value) {
+            configuration.classFinder = value;
             return this;
         }
 

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
@@ -138,7 +138,9 @@ public class EngineConfiguration {
             } catch (Exception e) {
                 if (classFinder != null) {
                     LOGGER.info(
-                            "AOT-based detection of browser-callable classes failed. Falling back to classpath scan.");
+                            "AOT-based detection of browser-callable classes failed."
+                                    + " Falling back to classpath scan."
+                                    + " Enable debug logging for more information.");
                     return LookupBrowserCallableFinder
                             .findEndpointClasses(classFinder, this);
                 } else {

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/LookupBrowserCallableFinder.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/LookupBrowserCallableFinder.java
@@ -11,13 +11,7 @@ class LookupBrowserCallableFinder {
             EngineConfiguration engineConfiguration) {
         return engineConfiguration.getEndpointAnnotations().stream()
                 .map(classFinder::getAnnotatedClasses).flatMap(Set::stream)
-                .distinct().filter(clazz -> {
-                    var location = clazz.getProtectionDomain().getCodeSource()
-                            .getLocation();
-                    return location != null
-                            && location.getProtocol().equals("file")
-                            && location.getPath().endsWith("/");
-                }).toList();
+                .distinct().toList();
     }
 
 }

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/LookupBrowserCallableFinder.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/LookupBrowserCallableFinder.java
@@ -1,0 +1,23 @@
+package com.vaadin.hilla.engine;
+
+import java.util.List;
+import java.util.Set;
+
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
+class LookupBrowserCallableFinder {
+
+    static List<Class<?>> findEndpointClasses(ClassFinder classFinder,
+            EngineConfiguration engineConfiguration) {
+        return engineConfiguration.getEndpointAnnotations().stream()
+                .map(classFinder::getAnnotatedClasses).flatMap(Set::stream)
+                .distinct().filter(clazz -> {
+                    var location = clazz.getProtectionDomain().getCodeSource()
+                            .getLocation();
+                    return location != null
+                            && location.getProtocol().equals("file")
+                            && location.getPath().endsWith("/");
+                }).toList();
+    }
+
+}

--- a/packages/java/engine-core/src/test/java/com/vaadin/hilla/engine/EngineConfigurationTest.java
+++ b/packages/java/engine-core/src/test/java/com/vaadin/hilla/engine/EngineConfigurationTest.java
@@ -1,0 +1,77 @@
+package com.vaadin.hilla.engine;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
+public class EngineConfigurationTest {
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface BrowserCallableEndpoint {
+    }
+
+    private static class EndpointFromAot {
+    }
+
+    private static class EndpointFromClassFinder {
+    }
+
+    @Test
+    public void shouldUseAot() throws Exception {
+        var classFinder = mock(ClassFinder.class);
+        when(classFinder
+                .getAnnotatedClasses((Class<? extends Annotation>) any()))
+                .thenThrow(RuntimeException.class);
+        var conf = new EngineConfiguration.Builder().classFinder(classFinder)
+                .build();
+        try (var aotMock = mockStatic(AotBrowserCallableFinder.class)) {
+            when(AotBrowserCallableFinder.findEndpointClasses(conf))
+                    .thenReturn(List.of(EndpointFromAot.class));
+            assertEquals(List.of(EndpointFromAot.class),
+                    conf.getBrowserCallableFinder().findBrowserCallables());
+        }
+    }
+
+    @Test
+    public void shouldFallbackToClassFinder() throws Exception {
+        var classFinder = mock(ClassFinder.class);
+        when(classFinder
+                .getAnnotatedClasses((Class<? extends Annotation>) any()))
+                .thenReturn(Set.of(EndpointFromClassFinder.class));
+        var conf = new EngineConfiguration.Builder().classFinder(classFinder)
+                .endpointAnnotations(BrowserCallableEndpoint.class).build();
+        try (var aotMock = mockStatic(AotBrowserCallableFinder.class)) {
+            when(AotBrowserCallableFinder.findEndpointClasses(conf))
+                    .thenThrow(ParserException.class);
+            assertEquals(List.of(EndpointFromClassFinder.class),
+                    conf.getBrowserCallableFinder().findBrowserCallables());
+        }
+    }
+}

--- a/packages/java/engine-core/src/test/java/com/vaadin/hilla/engine/EngineConfigurationTest.java
+++ b/packages/java/engine-core/src/test/java/com/vaadin/hilla/engine/EngineConfigurationTest.java
@@ -1,30 +1,14 @@
 package com.vaadin.hilla.engine;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/packages/java/engine-runtime/src/main/java/com/vaadin/hilla/internal/EndpointGeneratorTaskFactoryImpl.java
+++ b/packages/java/engine-runtime/src/main/java/com/vaadin/hilla/internal/EndpointGeneratorTaskFactoryImpl.java
@@ -97,6 +97,7 @@ public class EndpointGeneratorTaskFactoryImpl
                 .buildDir(options.getBuildDirectoryName())
                 .outputDir(options.getFrontendGeneratedFolder().toPath())
                 .nodeCommand(buildTools(options).getNodeExecutable())
+                .classFinder(options.getClassFinder())
                 .productionMode(options.isProductionMode())
                 .withDefaultAnnotations().build();
     }


### PR DESCRIPTION
While AOT has proved to be reliable in most cases, it can fail on some projects and we don't want users to have to struggle with it just to compile their apps for production.

This PR adds a fallback in case of AOT failure. All browser-callable services found in the classpath will be reported, which could lead to generation of some TypeScript files not needed by the final application, but the build system will discard unused code anyway.

Also, to reduce noise in the logs, the output of the AOT process is redirected to a file and only debug messages are used.

Fixes #3297