### PR TITLE
fix(crud): use `noNewButton` name and fix form visibility

### DIFF
--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -218,7 +218,7 @@ export function AutoCrud<TModel extends AbstractModel>({
     </div>
   );
 
-  // If the "new" button is visible, the form is always shown.
+  // If the "New" button is visible, the form is always shown.
   // Otherwise, the form is only shown when an item is being edited.
   const formEnabled = noNewButton !== true || (item && item !== emptyItem);
   return formEnabled ? editableGrid : mainSection;

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -218,6 +218,8 @@ export function AutoCrud<TModel extends AbstractModel>({
     </div>
   );
 
+  // If the "new" button is visible, the form is always shown.
+  // Otherwise, the form is only shown when an item is being edited.
   const formEnabled = noNewButton !== true || (item && item !== emptyItem);
   return formEnabled ? editableGrid : mainSection;
 }

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -77,14 +77,14 @@ export type AutoCrudProps<TModel extends AbstractModel = AbstractModel> = Compon
      */
     itemIdProperty?: string;
     /**
-     * Determines whether to display the "New" button in the toolbar. By default,
-     * this is set to `true`, meaning the button will be shown.
+     * Determines whether to hide the "New" button in the toolbar. By default,
+     * this is set to `false`, meaning the button will be shown.
      *
      * NOTE: This setting only hides the button; it does not prevent new items
      * from being sent to the service. Ensure your backend Java service is
      * properly secured to prevent unauthorized creation of new items.
      */
-    newButton?: boolean;
+    noNewButton?: boolean;
     /**
      * Props to pass to the form. See the `AutoForm` component for details.
      */
@@ -119,7 +119,7 @@ export function AutoCrud<TModel extends AbstractModel>({
   service,
   model,
   itemIdProperty,
-  newButton,
+  noNewButton,
   formProps,
   gridProps,
   style,
@@ -162,7 +162,7 @@ export function AutoCrud<TModel extends AbstractModel>({
       ></AutoGrid>
       {/* As the toolbar only contains the "New" button at the moment, and as an empty toolbar
           renders as a half-height bar, let's hide it completely when the button is hidden */}
-      {newButton !== false && (
+      {noNewButton !== true && (
         <div className="auto-crud-toolbar">
           <Button theme="primary" onClick={() => setItem(emptyItem)}>
             + New
@@ -197,7 +197,7 @@ export function AutoCrud<TModel extends AbstractModel>({
     />
   );
 
-  return (
+  const editableGrid = (
     <div className={`auto-crud ${className ?? ''}`} id={id} style={style}>
       {fullScreen ? (
         <>
@@ -217,4 +217,7 @@ export function AutoCrud<TModel extends AbstractModel>({
       )}
     </div>
   );
+
+  const formEnabled = noNewButton !== true || (item && item !== emptyItem);
+  return formEnabled ? editableGrid : mainSection;
 }

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -77,12 +77,13 @@ export type AutoCrudProps<TModel extends AbstractModel = AbstractModel> = Compon
      */
     itemIdProperty?: string;
     /**
-     * Determines whether to hide the "New" button in the toolbar. By default,
-     * this is set to `false`, meaning the button will be shown.
+     * Determines whether to hide the "New" button in the toolbar.
      *
      * NOTE: This setting only hides the button; it does not prevent new items
      * from being sent to the service. Ensure your backend Java service is
      * properly secured to prevent unauthorized creation of new items.
+     *
+     * @defaultValue `false` meaning the button will be shown.
      */
     noNewButton?: boolean;
     /**

--- a/packages/ts/react-crud/src/autocrud.tsx
+++ b/packages/ts/react-crud/src/autocrud.tsx
@@ -162,7 +162,7 @@ export function AutoCrud<TModel extends AbstractModel>({
       ></AutoGrid>
       {/* As the toolbar only contains the "New" button at the moment, and as an empty toolbar
           renders as a half-height bar, let's hide it completely when the button is hidden */}
-      {noNewButton !== true && (
+      {!noNewButton && (
         <div className="auto-crud-toolbar">
           <Button theme="primary" onClick={() => setItem(emptyItem)}>
             + New
@@ -197,29 +197,30 @@ export function AutoCrud<TModel extends AbstractModel>({
     />
   );
 
-  const editableGrid = (
-    <div className={`auto-crud ${className ?? ''}`} id={id} style={style}>
-      {fullScreen ? (
-        <>
-          {mainSection}
-          <AutoCrudDialog opened={!!item} header={formHeader} onClose={handleCancel}>
-            {autoForm}
-          </AutoCrudDialog>
-        </>
-      ) : (
-        <SplitLayout theme="small">
-          {mainSection}
-          <div className="auto-crud-form">
-            <div className="auto-crud-form-header">{formHeader}</div>
-            {autoForm}
-          </div>
-        </SplitLayout>
-      )}
-    </div>
-  );
-
   // If the "New" button is visible, the form is always shown.
   // Otherwise, the form is only shown when an item is being edited.
-  const formEnabled = noNewButton !== true || (item && item !== emptyItem);
-  return formEnabled ? editableGrid : mainSection;
+  if (!noNewButton || (item && item !== emptyItem)) {
+    return (
+      <div className={`auto-crud ${className ?? ''}`} id={id} style={style}>
+        {fullScreen ? (
+          <>
+            {mainSection}
+            <AutoCrudDialog opened={!!item} header={formHeader} onClose={handleCancel}>
+              {autoForm}
+            </AutoCrudDialog>
+          </>
+        ) : (
+          <SplitLayout theme="small">
+            {mainSection}
+            <div className="auto-crud-form">
+              <div className="auto-crud-form-header">{formHeader}</div>
+              {autoForm}
+            </div>
+          </SplitLayout>
+        )}
+      </div>
+    );
+  }
+
+  return mainSection;
 }

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -109,9 +109,9 @@ describe('@vaadin/hilla-react-crud', () => {
     it('can hide new button', async () => {
       const { rerender } = render(<AutoCrud service={personService()} model={PersonModel} />);
       await waitFor(() => expect(screen.queryByText('+ New')).to.exist);
-      rerender(<AutoCrud service={personService()} model={PersonModel} newButton={true} />);
+      rerender(<AutoCrud service={personService()} model={PersonModel} noNewButton={false} />);
       await waitFor(() => expect(screen.queryByText('+ New')).to.exist);
-      rerender(<AutoCrud service={personService()} model={PersonModel} newButton={false} />);
+      rerender(<AutoCrud service={personService()} model={PersonModel} noNewButton />);
       await waitFor(() => expect(screen.queryByText('+ New')).to.be.null);
     });
 
@@ -298,6 +298,12 @@ describe('@vaadin/hilla-react-crud', () => {
       // Edit existing item
       await grid.toggleRowSelected(0);
       await expect(result.findByRole('heading', { name: 'Edit person' })).to.eventually.exist;
+    });
+
+    it('does not show the form if the New button is hidden', () => {
+      const result = render(<TestAutoCrud noNewButton />);
+      const hiddenForm = result.queryByTestId('auto-form');
+      expect(hiddenForm).to.not.exist;
     });
 
     describe('mobile layout', () => {

--- a/packages/ts/react-crud/test/autocrud.spec.tsx
+++ b/packages/ts/react-crud/test/autocrud.spec.tsx
@@ -306,6 +306,13 @@ describe('@vaadin/hilla-react-crud', () => {
       expect(hiddenForm).to.not.exist;
     });
 
+    it('shows the form if the New button is hidden, but an item is selected', async () => {
+      const grid = await GridController.init(render(<TestAutoCrud noNewButton />), user);
+      await grid.toggleRowSelected(1);
+      const form = await FormController.init(user);
+      expect(form.instance).to.exist;
+    });
+
     describe('mobile layout', () => {
       let saveSpy: sinon.SinonSpy;
       let service: ReturnType<typeof personService>;


### PR DESCRIPTION
Changes the recently introduced `newButton` property to `noNewButton` and hides the empty form when the new property is `true`.

Fixes #3324