### PR TITLE
fix: run fallback endpoint finder when nothing found

### DIFF
--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
@@ -134,20 +134,30 @@ public class EngineConfiguration {
 
         return () -> {
             try {
-                return AotBrowserCallableFinder.findEndpointClasses(this);
+                var endpointClasses = AotBrowserCallableFinder.findEndpointClasses(this);
+                if (!endpointClasses.isEmpty()) {
+                    return endpointClasses;
+                }
+                return runFallbackBrowserCallableFinder(
+                        "AOT-based detection of browser-callable classes didn't find any candidates."
+                                + " Falling back to classpath scan.");
             } catch (Exception e) {
                 if (classFinder != null) {
-                    LOGGER.info(
-                            "AOT-based detection of browser-callable classes failed."
-                                    + " Falling back to classpath scan."
-                                    + " Enable debug logging for more information.");
-                    return LookupBrowserCallableFinder
-                            .findEndpointClasses(classFinder, this);
+                    return runFallbackBrowserCallableFinder(
+                        "AOT-based detection of browser-callable classes failed."
+                            + " Falling back to classpath scan."
+                            + " Enable debug logging for more information.");
                 } else {
                     throw new ExecutionFailedException(e);
                 }
             }
         };
+    }
+
+    private List<Class<?>> runFallbackBrowserCallableFinder(String logMessage) {
+        LOGGER.debug(logMessage);
+        return LookupBrowserCallableFinder.findEndpointClasses(classFinder,
+                this);
     }
 
     public static EngineConfiguration getDefault() {

--- a/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
+++ b/packages/java/engine-core/src/main/java/com/vaadin/hilla/engine/EngineConfiguration.java
@@ -134,7 +134,8 @@ public class EngineConfiguration {
 
         return () -> {
             try {
-                var endpointClasses = AotBrowserCallableFinder.findEndpointClasses(this);
+                var endpointClasses = AotBrowserCallableFinder
+                        .findEndpointClasses(this);
                 if (!endpointClasses.isEmpty()) {
                     return endpointClasses;
                 }
@@ -144,9 +145,9 @@ public class EngineConfiguration {
             } catch (Exception e) {
                 if (classFinder != null) {
                     return runFallbackBrowserCallableFinder(
-                        "AOT-based detection of browser-callable classes failed."
-                            + " Falling back to classpath scan."
-                            + " Enable debug logging for more information.");
+                            "AOT-based detection of browser-callable classes failed."
+                                    + " Falling back to classpath scan."
+                                    + " Enable debug logging for more information.");
                 } else {
                     throw new ExecutionFailedException(e);
                 }


### PR DESCRIPTION
## Description
For some reason, when the spring-cloud-context
is in the classpath, the aot endpoint finder
cannot find the endpoints from the current
application classes, but it does not fail with
an error to trigger the fallback mechanism. 
This makes sure to retry with fallback when no
endpoint find by the AotBrowserCallableFinder.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
