### PR TITLE
build: use Flow versions for React 18

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -341,7 +341,7 @@ jobs:
         if: runner.os == 'Windows'
         run: mvn install -B -ntp -DskipTests -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
       - name: Install React 18
-        run: npm install --save-dev react@18 react-dom@18 @types/react@18 @types/react-dom@18
+        run: npm run build:react-18
       - name: Test
         run: npm run test:react
         env:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "npm run build:align && npm run build:prepare && npm install && npm run build:run",
     "build:align": "mvn -pl com.vaadin:hilla-scripts -q",
     "build:prepare": "tsx scripts/prepare/index.ts",
+    "build:react-18": "npm run build:align -- -Preact-18 && npm run build:prepare && npm install && npm run build:run",
     "build:run": "nx run-many -p packages/ts/* -t build --all --output-style stream",
     "build:nocache": "npm run build",
     "lint": "nx run-many -p packages/ts/* -t lint --all --output-style stream",

--- a/scripts/java/hilla-scripts/pom.xml
+++ b/scripts/java/hilla-scripts/pom.xml
@@ -52,6 +52,7 @@
                 <version>3.5.0</version>
                 <executions>
                     <execution>
+                        <id>updatePackageJson</id>
                         <goals>
                             <goal>java</goal>
                         </goals>
@@ -70,4 +71,35 @@
         </plugins>
         <defaultGoal>compile exec:java</defaultGoal>
     </build>
+
+    <profiles>
+        <profile>
+            <id>react-18</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>updatePackageJson</id>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <mainClass>com.vaadin.hilla.scripts.FlowPackageJsonUpdater</mainClass>
+                            <arguments>
+                                <argument>default</argument>
+                                <argument>react-router</argument>
+                                <argument>vite</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Change the way React 18 is installed in its GHA job to utilize Flow versions and alignment scripts. This way we make sure that the 19 → 18 step gets done for entire workspace simultaneusly and guarantee that the same React 18 is used in testing.
