### PR TITLE
feat: update developer instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Follow the tutorials at https://vaadin.com/docs/latest/getting-started
 
 ## Contributing
 
-The best way to contribute is to try out Hilla and provide feedback to the development team in our [Forum](https://vaadin.com/forum/c/hilla/18) or with [GitHub issues](https://github.com/vaadin/hilla/issues).
+The best way to contribute is to try out Hilla and provide feedback to the development team in our [Forum](https://vaadin.com/forum/c/hilla/18) or with [GitHub issues](https://github.com/vaadin/hilla/issues). Those marked with the [good first issue](https://github.com/vaadin/hilla/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) label are a good starting point.
 
 ### Development
 
@@ -93,9 +93,9 @@ If you want to develop Hilla, you can clone the repo and run tests using the fol
 git clone https://github.com/vaadin/hilla.git
 npm install
 npm run build
-mvn install -DskipTests
+mvn clean formatter:format install -DskipTests
 npm test
-mvn verify
+mvn verify -Pproduction
 ```
 
 You need the following versions of SDKs and tools:
@@ -104,6 +104,52 @@ You need the following versions of SDKs and tools:
 - **npm**: `>=10` (`package-lock.json` is of version 3)
 - **JDK**: `>=17`
 - **Maven**: `>=3`
+
+### Testing changes locally
+
+Java modules are located in `./packages/java`. If you make changes to Java code and want to test them in a real application, you can set the Vaadin version to `SNAPSHOT` in the `pom.xml` of your application. This requires using the Vaadin pre-release repositories. Make sure to add the following to your `pom.xml`:
+
+```xml
+<repositories>
+    <repository>
+        <id>vaadin-prereleases</id>
+        <url>https://maven.vaadin.com/vaadin-prereleases</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+    <repository>
+        <id>Vaadin Directory</id>
+        <url>https://maven.vaadin.com/vaadin-addons</url>
+        <snapshots>
+            <enabled>false</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+
+<pluginRepositories>
+    <pluginRepository>
+        <id>vaadin-prereleases</id>
+        <url>https://maven.vaadin.com/vaadin-prereleases</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </pluginRepository>
+</pluginRepositories>
+```
+TypeScript modules are located in `./packages/ts`. If you make changes to the TypeScript code, you can package your changes locally by running the following command in the modified package:
+
+```sh
+npm run build && npm pack
+```
+
+It will create a `.tgz` file in the package root. Then, in your application, you can install that package using the following command:
+
+```sh
+npm install <path-to-tgz>
+```
+
+Remember to delete the line that points to the package in `package.json` when you are done testing. The next run will add back the corresponding default package.
 
 ---
 


### PR DESCRIPTION
Expand the developer instructions in the README to include detailed steps for building local Maven snapshots, the correct order for npm and Maven builds, running tests in Java, TypeScript, and integration tests, and using modified Hilla npm packages in a Hilla application.

Fixes #3347