### PR TITLE
chore: fix variable used in concurrency group

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -25,7 +25,7 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: $HEAD_REF || $REF_NAME
+  group: ${{ github.head_ref }} || ${{ github.ref_name }}
   cancel-in-progress: true
 env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1


### PR DESCRIPTION
seems the environment variable is not working for concurrency group..

this will lead to unexpected cancelling on jobs.

