### PR TITLE
feat(engine): refactor HTTP exception handling to avoid direct usage of root exception

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointInvocationException.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointInvocationException.java
@@ -104,6 +104,8 @@ public abstract class EndpointInvocationException extends Exception {
 
     /**
      * Allows to specify the HTTP status code and message to return as error.
+     * While most common specialized exceptions are already provided, other can
+     * be created by extending this class.
      */
     public static abstract class EndpointHttpException
             extends EndpointInvocationException {

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointInvocationException.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/EndpointInvocationException.java
@@ -105,7 +105,7 @@ public abstract class EndpointInvocationException extends Exception {
     /**
      * Allows to specify the HTTP status code and message to return as error.
      */
-    public static class EndpointHttpException
+    public static abstract class EndpointHttpException
             extends EndpointInvocationException {
         private final int httpStatusCode;
 

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/EndpointControllerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/EndpointControllerTest.java
@@ -203,14 +203,26 @@ public class EndpointControllerTest {
                     : "Check multiple files FAILED";
         }
 
-        @AnonymousAllowed
-        public void throwCustomHttpException() throws EndpointHttpException {
-            throw new EndpointHttpException(418, "I'm a teapot");
+        static class TeapotException extends EndpointHttpException {
+            TeapotException() {
+                super(418, "I'm a teapot");
+            }
         }
 
         @AnonymousAllowed
-        public void throwInvalidHttpException() throws EndpointHttpException {
-            throw new EndpointHttpException(200, "All right!");
+        public void throwCustomHttpException() throws TeapotException {
+            throw new TeapotException();
+        }
+
+        static class InvalidHttpException extends EndpointHttpException {
+            InvalidHttpException() {
+                super(200, "All right!");
+            }
+        }
+
+        @AnonymousAllowed
+        public void throwInvalidHttpException() throws InvalidHttpException {
+            throw new InvalidHttpException();
         }
     }
 

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/EndpointInvokerTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/EndpointInvokerTest.java
@@ -178,13 +178,19 @@ public class EndpointInvokerTest {
                 .check(any(Class.class), any(), any());
     }
 
+    static class TeapotException extends EndpointHttpException {
+        TeapotException() {
+            super(418, "I'm a teapot");
+        }
+    }
+
     @Test
     public void httpExceptionIsRethrown() {
         @Endpoint
         class TestEndpoint {
 
-            public String sayHello() throws EndpointHttpException {
-                throw new EndpointHttpException(418, "I'm a teapot");
+            public String sayHello() throws TeapotException {
+                throw new TeapotException();
             }
         }
 
@@ -192,7 +198,7 @@ public class EndpointInvokerTest {
 
         endpointRegistry.registerEndpoint(test);
 
-        var ex = assertThrows(EndpointHttpException.class,
+        var ex = assertThrows(TeapotException.class,
                 () -> endpointInvoker.invoke("TestEndpoint", "sayhello", body,
                         principal, requestMock::isUserInRole));
         assertEquals(418, ex.getHttpStatusCode());


### PR DESCRIPTION
Introduce specific exception classes for HTTP errors, enhancing clarity and maintainability. This change prevents direct instantiation of the root HTTP exception and promotes the use of more descriptive subclasses.

Note that a couple of curly braces is enough to circumvent, but at least the intent is clear.