### PR TITLE
fix(frontend): make doFormLayout async and waiting

### DIFF
--- a/packages/ts/frontend/src/Authentication.ts
+++ b/packages/ts/frontend/src/Authentication.ts
@@ -79,6 +79,9 @@ async function doFormLogout(url: URL | string, parameters: Record<string, string
   // Append form to page and submit it to perform logout and redirect
   document.body.appendChild(form);
 
+  // No code should run after a form submission, as it will navigate away.
+  // The promise will reject after a long timeout to avoid executing code after
+  // (old user code has a `reload` call that could happen before the form submission).
   return new Promise((_, reject) => {
     setTimeout(() => {
       reject(new Error('Form submission did not navigate away after 10 seconds.'));

--- a/packages/ts/frontend/test/Authentication.test.ts
+++ b/packages/ts/frontend/test/Authentication.test.ts
@@ -2,7 +2,7 @@ import chaiDom from 'chai-dom';
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { expect, chai, describe, it, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { expect, chai, describe, it, beforeEach, afterEach, beforeAll, afterAll, vi, assert } from 'vitest';
 import CookieManager from '../src/CookieManager.js';
 import { VAADIN_CSRF_HEADER } from '../src/CsrfUtils.js';
 import {
@@ -330,7 +330,9 @@ describe('@vaadin/hilla-frontend', () => {
           // noop to prevent navigation
         });
         try {
-          originalLogout().catch(() => {});
+          originalLogout().catch(() => {
+            assert.fail('Logout should not throw an error');
+          });
           expect(fetchMock.callHistory.calls()).to.have.lengthOf(0);
           expect(submitSpy).toHaveBeenCalled();
           verifySpringCsrfToken(TEST_SPRING_CSRF_TOKEN_VALUE);

--- a/packages/ts/frontend/test/Authentication.test.ts
+++ b/packages/ts/frontend/test/Authentication.test.ts
@@ -325,12 +325,12 @@ describe('@vaadin/hilla-frontend', () => {
         expect(navigate).to.be.calledOnceWithExactly('logout?login');
       });
 
-      it('should perform a form submit when LogoutOptions does not contain navigate and onSuccess', async () => {
+      it('should perform a form submit when LogoutOptions does not contain navigate and onSuccess', () => {
         const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {
           // noop to prevent navigation
         });
         try {
-          await originalLogout();
+          originalLogout().catch(() => {});
           expect(fetchMock.callHistory.calls()).to.have.lengthOf(0);
           expect(submitSpy).toHaveBeenCalled();
           verifySpringCsrfToken(TEST_SPRING_CSRF_TOKEN_VALUE);


### PR DESCRIPTION
Transform the `doFormLogout` function to be asynchronous, adding a timeout mechanism to allow existing code to await.

Update related test.

The secondary effect is that users need to continue awaiting if they don't want to ignore the promise.

Fixes #3487