### PR TITLE
chore: add '@vaadin/vaadin-lumo-styles' to react-crud to fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5468,6 +5468,19 @@
         "lit": "^3.0.0"
       }
     },
+    "node_modules/@vaadin/component-base": {
+      "version": "24.7.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
+      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
     "node_modules/@vaadin/hilla-endpoints-discovery": {
       "resolved": "packages/java/tests/spring/endpoints discovery",
       "link": true
@@ -5551,6 +5564,20 @@
     "node_modules/@vaadin/hilla-react-signals": {
       "resolved": "packages/ts/react-signals",
       "link": true
+    },
+    "node_modules/@vaadin/icon": {
+      "version": "24.7.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
+      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.6",
+        "@vaadin/vaadin-lumo-styles": "~24.7.6",
+        "@vaadin/vaadin-themable-mixin": "~24.7.6",
+        "lit": "^3.0.0"
+      }
     },
     "node_modules/@vaadin/react-components": {
       "version": "24.7.6",
@@ -5740,19 +5767,6 @@
         "lit": "^3.0.0"
       }
     },
-    "node_modules/@vaadin/react-components-pro/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "node_modules/@vaadin/react-components-pro/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -5905,20 +5919,6 @@
         "@vaadin/text-field": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/react-components-pro/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -6108,28 +6108,6 @@
         "lit": "^3.0.0"
       }
     },
-    "node_modules/@vaadin/react-components-pro/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "node_modules/@vaadin/react-components-pro/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "node_modules/@vaadin/react-components/node_modules/@vaadin/a11y-base": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.6.tgz",
@@ -6295,19 +6273,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/react-components/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
         "lit": "^3.0.0"
       }
     },
@@ -6529,20 +6494,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/react-components/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -7036,28 +6987,6 @@
         "lit": "^3.0.0"
       }
     },
-    "node_modules/@vaadin/react-components/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "node_modules/@vaadin/react-components/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "node_modules/@vaadin/react-components/node_modules/@vaadin/vertical-layout": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vertical-layout/-/vertical-layout-24.7.6.tgz",
@@ -7105,6 +7034,18 @@
       "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
       "license": "Apache-2.0"
     },
+    "node_modules/@vaadin/vaadin-lumo-styles": {
+      "version": "24.7.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
+      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.7.6",
+        "@vaadin/icon": "~24.7.6",
+        "@vaadin/vaadin-themable-mixin": "~24.7.6"
+      }
+    },
     "node_modules/@vaadin/vaadin-material-styles": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.7.6.tgz",
@@ -7116,20 +7057,7 @@
         "@vaadin/vaadin-themable-mixin": "~24.7.6"
       }
     },
-    "node_modules/@vaadin/vaadin-material-styles/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/vaadin-material-styles/node_modules/@vaadin/vaadin-themable-mixin": {
+    "node_modules/@vaadin/vaadin-themable-mixin": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
       "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
@@ -20521,33 +20449,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/csrf-context/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/csrf-context/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/csrf-context/node_modules/@vaadin/icons": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/icons/-/icons-24.7.6.tgz",
@@ -20629,28 +20530,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/csrf-context/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/csrf-context/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/csrf/node_modules/@vaadin/a11y-base": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.6.tgz",
@@ -20660,33 +20539,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/csrf/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/csrf/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },
@@ -20771,28 +20623,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/csrf/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/csrf/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/gradle/kotlin-gradle-test": {
       "hasInstallScript": true,
       "license": "UNLICENSED",
@@ -20863,33 +20693,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/gradle/kotlin-gradle-test/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/gradle/kotlin-gradle-test/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },
@@ -20971,28 +20774,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/gradle/kotlin-gradle-test/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/gradle/kotlin-gradle-test/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -21107,33 +20888,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/endpoints discovery/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints discovery/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/endpoints discovery/node_modules/@vaadin/icons": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/icons/-/icons-24.7.6.tgz",
@@ -21215,28 +20969,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/endpoints discovery/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/endpoints discovery/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/endpoints-contextpath": {
       "hasInstallScript": true,
       "license": "UNLICENSED",
@@ -21295,33 +21027,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints-contextpath/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints-contextpath/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },
@@ -21406,28 +21111,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/endpoints-contextpath/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/endpoints-contextpath/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/endpoints-custom-client": {
       "hasInstallScript": true,
       "license": "UNLICENSED",
@@ -21486,33 +21169,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints-custom-client/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints-custom-client/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },
@@ -21597,28 +21253,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/endpoints-custom-client/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/endpoints-custom-client/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/endpoints-latest-java": {
       "hasInstallScript": true,
       "license": "UNLICENSED",
@@ -21677,33 +21311,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints-latest-java/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints-latest-java/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },
@@ -21788,28 +21395,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/endpoints-latest-java/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/endpoints-latest-java/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/endpoints/node_modules/@vaadin/a11y-base": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.7.6.tgz",
@@ -21819,33 +21404,6 @@
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },
@@ -21927,28 +21485,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/endpoints/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/endpoints/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -22552,19 +22088,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/react-grid-test/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/react-grid-test/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -22890,20 +22413,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/react-grid-test/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -23504,28 +23013,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/react-grid-test/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/react-grid-test/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -24163,19 +23650,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/react-i18n/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/react-i18n/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -24501,20 +23975,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/react-i18n/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -25115,28 +24575,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/react-i18n/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/react-i18n/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -25774,19 +25212,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/react-signals/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/react-signals/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -26244,20 +25669,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/react-signals/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -26858,28 +26269,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/react-signals/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/react-signals/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -27669,19 +27058,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/security-contextpath/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/security-contextpath/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -27973,20 +27349,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security-contextpath/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -28525,28 +27887,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security-contextpath/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/security-contextpath/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -29216,19 +28556,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/security-jwt/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/security-jwt/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -29520,20 +28847,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security-jwt/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -30072,28 +29385,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security-jwt/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/security-jwt/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -30763,19 +30054,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/security-urlmapping/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/security-urlmapping/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -31067,20 +30345,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security-urlmapping/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -31619,28 +30883,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security-urlmapping/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/security-urlmapping/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
       }
     },
@@ -32189,19 +31431,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/security/node_modules/@vaadin/component-base": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.7.6.tgz",
-      "integrity": "sha512-DCwSNObDgf6CZ6c3oMjEVqs2OY8qc+YgPSTdl0jiaIoKRPJW0+XAFojAmlRKS1iJfM+E4sB5XG0AIlsg7MkzJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/security/node_modules/@vaadin/confirm-dialog": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
@@ -32493,20 +31722,6 @@
         "@vaadin/component-base": "~24.7.6",
         "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-material-styles": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6",
-        "lit": "^3.0.0"
-      }
-    },
-    "packages/java/tests/spring/security/node_modules/@vaadin/icon": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.7.6.tgz",
-      "integrity": "sha512-tH0qudszMlsgtoIw41Ai0f17LqNg33kYgxZDS/2ItUsoRo4GfJofyOuvZrcYBZkJwlfE0LLcPMEkm/U8gnwJvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/vaadin-lumo-styles": "~24.7.6",
         "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
@@ -33048,28 +32263,6 @@
         "lit": "^3.0.0"
       }
     },
-    "packages/java/tests/spring/security/node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.7.6.tgz",
-      "integrity": "sha512-1WR8gnzmWRFbQFfmRFBJ9yYTjqwA8Sp7J46lfiurZUaXf9XFYe+4kxKjsUyVmUayh0k0fSysSitmyaSECUqrgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.7.6",
-        "@vaadin/icon": "~24.7.6",
-        "@vaadin/vaadin-themable-mixin": "~24.7.6"
-      }
-    },
-    "packages/java/tests/spring/security/node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.7.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.7.6.tgz",
-      "integrity": "sha512-HZzjsAnOD6aXWH2jF3zgaolyAuwjj4WnosEauJjp6UohX2Db048+eGOsWUXGUp/Br+NT3NGl2Aw/Dpgu8IGayw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "lit": "^3.0.0"
-      }
-    },
     "packages/java/tests/spring/security/node_modules/@vaadin/vertical-layout": {
       "version": "24.7.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vertical-layout/-/vertical-layout-24.7.6.tgz",
@@ -33347,7 +32540,8 @@
         "@vaadin/hilla-frontend": "24.7.4",
         "@vaadin/hilla-lit-form": "24.7.4",
         "@vaadin/hilla-react-form": "24.7.4",
-        "@vaadin/react-components": "24.7.6"
+        "@vaadin/react-components": "24.7.6",
+        "@vaadin/vaadin-lumo-styles": "24.7.6"
       },
       "peerDependencies": {
         "react": "18 || 19",

--- a/packages/ts/react-crud/package.json
+++ b/packages/ts/react-crud/package.json
@@ -57,7 +57,8 @@
     "@vaadin/hilla-frontend": "24.7.4",
     "@vaadin/hilla-lit-form": "24.7.4",
     "@vaadin/hilla-react-form": "24.7.4",
-    "@vaadin/react-components": "24.7.6"
+    "@vaadin/react-components": "24.7.6",
+    "@vaadin/vaadin-lumo-styles": "24.7.6"
   },
   "peerDependencies": {
     "react": "18 || 19",


### PR DESCRIPTION
Fixes errors in the 24.7 tests due to the absence of `@vaadin/vaadin-lumo-styles`.