### PR TITLE
feat(i18n): add tagged template and require for translations

### DIFF
--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -247,10 +247,10 @@ export class I18n {
    * @param key - The translation key to translate
    * @param params - Optional object with placeholder values
    */
-  translate(key: string, params?: Record<string, unknown>): string {
+  translate(key: I18nKey, params?: Record<string, unknown>): string {
     const translation = this.#translations.value[key];
     if (!translation) {
-      return key;
+      return key.toString();
     }
     const format = this.#formatCache.getFormat(translation);
     return format.format(params) as string;
@@ -261,7 +261,7 @@ export class I18n {
  * The global I18n instance that is used to initialize translations, change the
  * current language, and translate strings.
  */
-export const i18n: I18n = new I18n();
+const i18nInstance: I18n = new I18n();
 
 /**
  * Returns a translated string for the given translation key. The key should
@@ -286,6 +286,33 @@ export const i18n: I18n = new I18n();
  *
  * @param key - The translation key to translate
  * @param params - Optional object with placeholder values
- */ export function translate(key: string, params?: Record<string, unknown>): string {
-  return i18n.translate(key, params);
+ */
+export function translate(key: I18nKey, params?: Record<string, unknown>): string {
+  return i18nInstance.translate(key, params);
 }
+
+const i18nLiteralMarker: unique symbol = Symbol('i18nMarker');
+export type I18nKey = string & { [i18nLiteralMarker]: unknown };
+export type I18nFunction = ((strings: readonly string[], ..._values: never[]) => I18nKey) & InstanceType<typeof I18n>;
+
+function i18nTag(strings: readonly string[], ..._values: never[]): I18nKey {
+  return Object.assign(strings[0], { [i18nLiteralMarker]: undefined }) as I18nKey;
+}
+
+const i18n = i18nTag as I18nFunction;
+
+Object.defineProperty(i18n, 'initialized', {
+  get: () => i18nInstance.initialized,
+});
+Object.defineProperty(i18n, 'language', {
+  get: () => i18nInstance.language,
+});
+Object.defineProperty(i18n, 'resolvedLanguage', {
+  get: () => i18nInstance.resolvedLanguage,
+});
+i18n.configure = i18nInstance.configure.bind(i18nInstance);
+i18n.setLanguage = i18nInstance.setLanguage.bind(i18nInstance);
+i18n.registerChunk = i18nInstance.registerChunk.bind(i18nInstance);
+i18n.translate = i18nInstance.translate.bind(i18nInstance);
+
+export { i18n };

--- a/packages/ts/react-i18n/test/i18n.spec.tsx
+++ b/packages/ts/react-i18n/test/i18n.spec.tsx
@@ -10,14 +10,14 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { afterAll, afterEach, beforeAll, beforeEach, chai, describe, expect, it } from 'vitest';
 import { FormatCache } from '../src/FormatCache.js';
-import { i18n as globalI18n, I18n, translate as globalTranslate } from '../src/index.js';
+import { I18n, i18n, translate as globalTranslate } from '../src/index.js';
 import type { LanguageSettings } from '../src/settings.js';
 
 chai.use(sinonChai);
 
 describe('@vaadin/hilla-react-i18n', () => {
   describe('i18n', () => {
-    let i18n: I18n;
+    let localI18n: I18n;
 
     function getSettingsCookie(): LanguageSettings | undefined {
       const cookie = CookieManager.get('vaadinLanguageSettings');
@@ -51,7 +51,7 @@ describe('@vaadin/hilla-react-i18n', () => {
 
     beforeEach(() => {
       clearSettingsCookie();
-      i18n = new I18n();
+      localI18n = new I18n();
       fetchMock
         .get(/\?v-r=i18n&langtag=de-DE$/u, {
           body: {
@@ -85,64 +85,64 @@ describe('@vaadin/hilla-react-i18n', () => {
 
     describe('configure', () => {
       it('should use browser language by default', async () => {
-        await i18n.configure();
+        await localI18n.configure();
 
-        expect(i18n.language.value).to.equal(navigator.language);
+        expect(localI18n.language.value).to.equal(navigator.language);
         verifyLoadTranslations(navigator.language);
       });
 
       it('should use last used language if defined', async () => {
         setSettingsCookie({ language: 'zh-Hant' });
-        await i18n.configure();
+        await localI18n.configure();
 
-        expect(i18n.language.value).to.equal('zh-Hant');
-        expect(i18n.resolvedLanguage.value).to.equal('und');
+        expect(localI18n.language.value).to.equal('zh-Hant');
+        expect(localI18n.resolvedLanguage.value).to.equal('und');
         verifyLoadTranslations('zh-Hant');
       });
 
       it('should use browser language if settings cookie is invalid', async () => {
         setInvalidSettingsCookie();
-        await i18n.configure();
+        await localI18n.configure();
 
-        expect(i18n.language.value).to.equal(navigator.language);
+        expect(localI18n.language.value).to.equal(navigator.language);
         verifyLoadTranslations(navigator.language);
       });
 
       it('should use explicitly configured language if specified', async () => {
-        await i18n.configure({ language: 'zh-Hant' });
+        await localI18n.configure({ language: 'zh-Hant' });
 
-        expect(i18n.language.value).to.equal('zh-Hant');
-        expect(i18n.resolvedLanguage.value).to.equal('und');
+        expect(localI18n.language.value).to.equal('zh-Hant');
+        expect(localI18n.resolvedLanguage.value).to.equal('und');
         verifyLoadTranslations('zh-Hant');
       });
 
       it('should prefer explicitly configured language over last used language', async () => {
         setSettingsCookie({ language: 'de-DE' });
-        await i18n.configure({ language: 'zh-Hant' });
+        await localI18n.configure({ language: 'zh-Hant' });
 
-        expect(i18n.language.value).to.equal('zh-Hant');
-        expect(i18n.resolvedLanguage.value).to.equal('und');
+        expect(localI18n.language.value).to.equal('zh-Hant');
+        expect(localI18n.resolvedLanguage.value).to.equal('und');
         verifyLoadTranslations('zh-Hant');
       });
 
       it('should not store last used language when initializing', async () => {
-        await i18n.configure();
+        await localI18n.configure();
 
         expect(getSettingsCookie()?.language).to.not.exist;
       });
 
       it('should not throw when loading translations fails', async () => {
-        const initialLanguage = i18n.language.value;
-        await i18n.configure({ language: 'not-found' });
+        const initialLanguage = localI18n.language.value;
+        await localI18n.configure({ language: 'not-found' });
 
-        expect(i18n.language.value).to.equal(initialLanguage);
-        expect(i18n.resolvedLanguage.value).to.equal(initialLanguage);
+        expect(localI18n.language.value).to.equal(initialLanguage);
+        expect(localI18n.resolvedLanguage.value).to.equal(initialLanguage);
       });
 
       it('should mark itself as initialized after configuration', async () => {
-        expect(i18n.initialized.value).to.be.false;
-        await i18n.configure();
-        expect(i18n.initialized.value).to.be.true;
+        expect(localI18n.initialized.value).to.be.false;
+        await localI18n.configure();
+        expect(localI18n.initialized.value).to.be.true;
       });
     });
 
@@ -151,42 +151,42 @@ describe('@vaadin/hilla-react-i18n', () => {
       const initialResolvedLanguage = 'und';
 
       beforeEach(async () => {
-        await i18n.configure({ language: initialLanguage });
+        await localI18n.configure({ language: initialLanguage });
         fetchMock.clearHistory();
       });
 
       it('should return current language', () => {
-        expect(i18n.language.value).to.equal(initialLanguage);
-        expect(i18n.resolvedLanguage.value).to.equal(initialResolvedLanguage);
+        expect(localI18n.language.value).to.equal(initialLanguage);
+        expect(localI18n.resolvedLanguage.value).to.equal(initialResolvedLanguage);
       });
 
       it('should set language and load translations', async () => {
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
 
-        expect(i18n.language.value).to.equal('de-DE');
-        expect(i18n.resolvedLanguage.value).to.equal('de-DE');
+        expect(localI18n.language.value).to.equal('de-DE');
+        expect(localI18n.resolvedLanguage.value).to.equal('de-DE');
         verifyLoadTranslations('de-DE');
       });
 
       it('should store last used language', async () => {
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
 
         expect(getSettingsCookie()?.language).to.equal('de-DE');
       });
 
       it('should not load translations if language is unchanged', async () => {
-        await i18n.setLanguage(initialLanguage);
+        await localI18n.setLanguage(initialLanguage);
 
-        expect(i18n.language.value).to.equal(initialLanguage);
-        expect(i18n.resolvedLanguage.value).to.equal(initialResolvedLanguage);
+        expect(localI18n.language.value).to.equal(initialLanguage);
+        expect(localI18n.resolvedLanguage.value).to.equal(initialResolvedLanguage);
         expect(fetchMock.callHistory.called()).to.be.false;
       });
 
       it('should still load translations if resolved language is empty', async () => {
-        await i18n.setLanguage('unknown');
+        await localI18n.setLanguage('unknown');
 
-        expect(i18n.language.value).to.equal('unknown');
-        expect(i18n.resolvedLanguage.value).to.equal(undefined);
+        expect(localI18n.language.value).to.equal('unknown');
+        expect(localI18n.resolvedLanguage.value).to.equal(undefined);
         verifyLoadTranslations('unknown');
       });
     });
@@ -237,100 +237,100 @@ describe('@vaadin/hilla-react-i18n', () => {
       }
 
       it('should not load chunks unless configured', async () => {
-        await i18n.registerChunk('city');
+        await localI18n.registerChunk('city');
 
         // Neither chunks are loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('addresses.form.city.label');
-        expect(i18n.translate('addresses.form.street.label')).to.equal('addresses.form.street.label');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('addresses.form.city.label');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('addresses.form.street.label');
         expect(fetchMock.callHistory.called()).to.be.false;
       });
 
       it('should load registered chunk after configured', async () => {
-        await i18n.registerChunk('city');
-        await i18n.configure({ language });
+        await localI18n.registerChunk('city');
+        await localI18n.configure({ language });
 
         // City chunk is loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('City Chunked');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('City Chunked');
 
         // Street chunk is not loaded yet
-        expect(i18n.translate('addresses.form.street.label')).to.equal('addresses.form.street.label');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('addresses.form.street.label');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['city']);
       });
 
       it('should load all chunks after configured', async () => {
-        await i18n.registerChunk('city');
-        await i18n.registerChunk('street');
-        await i18n.configure({ language });
+        await localI18n.registerChunk('city');
+        await localI18n.registerChunk('street');
+        await localI18n.configure({ language });
 
         // Both chunks are loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('City Chunked');
-        expect(i18n.translate('addresses.form.street.label')).to.equal('Street Chunked');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('City Chunked');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('Street Chunked');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['city', 'street']);
       });
 
       it('should load additional chunks after configured', async () => {
-        await i18n.registerChunk('city');
-        await i18n.configure({ language });
+        await localI18n.registerChunk('city');
+        await localI18n.configure({ language });
         fetchMock.clearHistory();
 
-        await i18n.registerChunk('street');
+        await localI18n.registerChunk('street');
 
         // Both chunks are loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('City Chunked');
-        expect(i18n.translate('addresses.form.street.label')).to.equal('Street Chunked');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('City Chunked');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('Street Chunked');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['street']);
       });
 
       it('should load registered chunk when switching language', async () => {
-        await i18n.registerChunk('city');
-        await i18n.configure({ language });
+        await localI18n.registerChunk('city');
+        await localI18n.configure({ language });
         fetchMock.clearHistory();
 
-        await i18n.setLanguage('en-AU');
+        await localI18n.setLanguage('en-AU');
 
         // City chunk is loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('Australian City Chunked');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('Australian City Chunked');
 
         // Street chunk is not loaded yet
-        expect(i18n.translate('addresses.form.street.label')).to.equal('addresses.form.street.label');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('addresses.form.street.label');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['city']);
       });
 
       it('should load all chunks when switching language', async () => {
-        await i18n.registerChunk('city');
-        await i18n.configure({ language });
-        await i18n.registerChunk('street');
+        await localI18n.registerChunk('city');
+        await localI18n.configure({ language });
+        await localI18n.registerChunk('street');
         fetchMock.clearHistory();
 
-        await i18n.setLanguage('en-AU');
+        await localI18n.setLanguage('en-AU');
 
         // Both chunks are loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('Australian City Chunked');
-        expect(i18n.translate('addresses.form.street.label')).to.equal('Australian Street Chunked');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('Australian City Chunked');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('Australian Street Chunked');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['city', 'street']);
       });
 
       it('should load additional chunks after switching language', async () => {
-        await i18n.registerChunk('city');
-        await i18n.configure({ language });
-        await i18n.setLanguage('en-AU');
+        await localI18n.registerChunk('city');
+        await localI18n.configure({ language });
+        await localI18n.setLanguage('en-AU');
         fetchMock.clearHistory();
 
-        await i18n.registerChunk('street');
+        await localI18n.registerChunk('street');
 
         // Both chunks are loaded
-        expect(i18n.translate('addresses.form.city.label')).to.equal('Australian City Chunked');
-        expect(i18n.translate('addresses.form.street.label')).to.equal('Australian Street Chunked');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('Australian City Chunked');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('Australian Street Chunked');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['street']);
@@ -339,16 +339,16 @@ describe('@vaadin/hilla-react-i18n', () => {
 
     describe('translate', () => {
       beforeEach(async () => {
-        await i18n.configure();
+        await localI18n.configure();
       });
 
       it('should return translated string', () => {
-        expect(i18n.translate('addresses.form.city.label')).to.equal('City');
-        expect(i18n.translate('addresses.form.street.label')).to.equal('Street');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('City');
+        expect(localI18n.translate(i18n`addresses.form.street.label`)).to.equal('Street');
       });
 
       it('should return key when there is no translation', () => {
-        expect(i18n.translate('unknown.key')).to.equal('unknown.key');
+        expect(localI18n.translate(i18n`unknown.key`)).to.equal('unknown.key');
       });
     });
 
@@ -357,7 +357,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         const effectSpy = sinon.spy();
         effect(() => {
           // Use multiple signals in the effect to verify signals are updated in batch
-          effectSpy(i18n.language.value, i18n.translate('addresses.form.city.label'));
+          effectSpy(localI18n.language.value, localI18n.translate(i18n`addresses.form.city.label`));
         });
 
         // Runs once initially
@@ -365,19 +365,19 @@ describe('@vaadin/hilla-react-i18n', () => {
         effectSpy.resetHistory();
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(effectSpy.calledOnceWith('en-US', 'City')).to.be.true;
         effectSpy.resetHistory();
 
         // Change language
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
         expect(effectSpy.calledOnceWith('de-DE', 'Stadt')).to.be.true;
       });
 
       it('should run effects when initialized changes', async () => {
         const effectSpy = sinon.spy();
         effect(() => {
-          effectSpy(i18n.initialized.value);
+          effectSpy(localI18n.initialized.value);
         });
 
         // Runs once initially
@@ -385,30 +385,31 @@ describe('@vaadin/hilla-react-i18n', () => {
         effectSpy.resetHistory();
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(effectSpy.calledOnceWith(true)).to.be.true;
       });
     });
 
     describe('global instance', () => {
       it('should expose a global I18n instance', () => {
-        expect(globalI18n).to.exist;
-        expect(globalI18n).to.be.instanceof(I18n);
+        expect(i18n).to.exist;
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(i18n.registerChunk).to.be.a('function');
       });
 
       it('should expose a global translate function that delegates to global I18n instance', async () => {
-        await globalI18n.configure({ language: 'en-US' });
-        expect(globalTranslate('addresses.form.city.label')).to.equal('City');
+        await i18n.configure({ language: 'en-US' });
+        expect(globalTranslate(i18n`addresses.form.city.label`)).to.equal('City');
 
-        await globalI18n.setLanguage('de-DE');
-        expect(globalTranslate('addresses.form.city.label')).to.equal('Stadt');
+        await i18n.setLanguage('de-DE');
+        expect(globalTranslate(i18n`addresses.form.city.label`)).to.equal('Stadt');
       });
     });
 
     describe('react integration', () => {
       it('should re-render when language changes', async () => {
         function TestTranslateComponent() {
-          return <div>{i18n.translate('addresses.form.city.label')}</div>;
+          return <div>{localI18n.translate(i18n`addresses.form.city.label`)}</div>;
         }
 
         const { getByText } = render(<TestTranslateComponent />);
@@ -417,11 +418,11 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(getByText('addresses.form.city.label')).to.exist;
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(getByText('City')).to.exist;
 
         // Change language
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
         expect(getByText('Stadt')).to.exist;
       });
 
@@ -430,7 +431,7 @@ describe('@vaadin/hilla-react-i18n', () => {
 
         function TestUseSignalEffectComponent() {
           useSignalEffect(() => {
-            signalEffectResult = i18n.translate('addresses.form.city.label');
+            signalEffectResult = localI18n.translate(i18n`addresses.form.city.label`);
           });
           return <div></div>;
         }
@@ -441,18 +442,18 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(signalEffectResult).to.equal('addresses.form.city.label');
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(signalEffectResult).to.equal('City');
 
         // Change language
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
         expect(signalEffectResult).to.equal('Stadt');
       });
 
       it('should update computed signals when language changes', async () => {
         function TestUseComputedComponent() {
           const computedTranslation = useComputed(
-            () => `Computed translation: ${i18n.translate('addresses.form.city.label')}`,
+            () => `Computed translation: ${localI18n.translate(i18n`addresses.form.city.label`)}`,
           );
           return <div>{computedTranslation.value}</div>;
         }
@@ -463,11 +464,11 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(getByText('Computed translation: addresses.form.city.label')).to.exist;
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(getByText('Computed translation: City')).to.exist;
 
         // Change language
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
         expect(getByText('Computed translation: Stadt')).to.exist;
       });
 
@@ -476,8 +477,8 @@ describe('@vaadin/hilla-react-i18n', () => {
 
         function TestUseEffectComponent() {
           useEffect(() => {
-            defaultEffectResult = i18n.translate('addresses.form.city.label');
-          }, [i18n.language.value]);
+            defaultEffectResult = localI18n.translate(i18n`addresses.form.city.label`);
+          }, [localI18n.language.value]);
           return <div></div>;
         }
 
@@ -487,19 +488,19 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(defaultEffectResult).to.equal('addresses.form.city.label');
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(defaultEffectResult).to.equal('City');
 
         // Change language
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
         expect(defaultEffectResult).to.equal('Stadt');
       });
 
       it('should update memoizations when language changes', async () => {
         function TestUseMemoComponent() {
           const memoizedTranslation = useMemo(
-            () => `Memoized translation: ${i18n.translate('addresses.form.city.label')}`,
-            [i18n.language.value],
+            () => `Memoized translation: ${localI18n.translate(i18n`addresses.form.city.label`)}`,
+            [localI18n.language.value],
           );
           return <div>{memoizedTranslation}</div>;
         }
@@ -510,23 +511,23 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(getByText('Memoized translation: addresses.form.city.label')).to.exist;
 
         // Configure initial language
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(getByText('Memoized translation: City')).to.exist;
 
         // Change language
-        await i18n.setLanguage('de-DE');
+        await localI18n.setLanguage('de-DE');
         expect(getByText('Memoized translation: Stadt')).to.exist;
       });
 
       it('should allow rendering a placeholder while i18n is not initialized', async () => {
         function TestPlaceholderComponent() {
-          return <div>{i18n.initialized.value ? 'Ready' : 'Loading'}</div>;
+          return <div>{localI18n.initialized.value ? 'Ready' : 'Loading'}</div>;
         }
 
         const { getByText } = render(<TestPlaceholderComponent />);
 
         expect(getByText('Loading')).to.exist;
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
         expect(getByText('Ready')).to.exist;
       });
     });
@@ -557,62 +558,70 @@ describe('@vaadin/hilla-react-i18n', () => {
             'You are { value, selectordinal,one {#st} two {#nd} few {#rd} other {#th}} in the queue',
           'param.escaping': "No need to escape 'this'. But '{this}'",
         });
-        await i18n.configure({ language: 'en-US' });
+        await localI18n.configure({ language: 'en-US' });
       });
 
       it('should support ICU message format', () => {
         const sampleDate = new Date(2024, 10, 12, 22, 33, 44);
-        expect(i18n.translate('param.basic', { value: 'foo' })).to.equal('Value: foo');
+        expect(localI18n.translate(i18n`param.basic`, { value: 'foo' })).to.equal('Value: foo');
 
-        expect(i18n.translate('param.number', { value: 123.456 })).to.equal('Value: 123.456');
-        expect(i18n.translate('param.number.integer', { value: 123.456 })).to.equal('Value: 123');
-        expect(i18n.translate('param.number.skeleton', { value: 123.456 })).to.equal('Value: 123.46');
-        expect(i18n.translate('param.number.currency', { value: 123.456 })).to.equal('Value: $123.46');
+        expect(localI18n.translate(i18n`param.number`, { value: 123.456 })).to.equal('Value: 123.456');
+        expect(localI18n.translate(i18n`param.number.integer`, { value: 123.456 })).to.equal('Value: 123');
+        expect(localI18n.translate(i18n`param.number.skeleton`, { value: 123.456 })).to.equal('Value: 123.46');
+        expect(localI18n.translate(i18n`param.number.currency`, { value: 123.456 })).to.equal('Value: $123.46');
 
-        expect(i18n.translate('param.date', { value: sampleDate })).to.equal('Value: 11/12/2024');
-        expect(i18n.translate('param.date.short', { value: sampleDate })).to.equal('Value: 11/12/24');
-        expect(i18n.translate('param.date.medium', { value: sampleDate })).to.equal('Value: Nov 12, 2024');
-        expect(i18n.translate('param.date.long', { value: sampleDate })).to.equal('Value: November 12, 2024');
-        expect(i18n.translate('param.date.full', { value: sampleDate })).to.equal('Value: Tuesday, November 12, 2024');
-        expect(i18n.translate('param.date.skeleton', { value: sampleDate })).to.equal('Value: Tue, Nov 12, 24');
+        expect(localI18n.translate(i18n`param.date`, { value: sampleDate })).to.equal('Value: 11/12/2024');
+        expect(localI18n.translate(i18n`param.date.short`, { value: sampleDate })).to.equal('Value: 11/12/24');
+        expect(localI18n.translate(i18n`param.date.medium`, { value: sampleDate })).to.equal('Value: Nov 12, 2024');
+        expect(localI18n.translate(i18n`param.date.long`, { value: sampleDate })).to.equal('Value: November 12, 2024');
+        expect(localI18n.translate(i18n`param.date.full`, { value: sampleDate })).to.equal(
+          'Value: Tuesday, November 12, 2024',
+        );
+        expect(localI18n.translate(i18n`param.date.skeleton`, { value: sampleDate })).to.equal(
+          'Value: Tue, Nov 12, 24',
+        );
 
-        expect(i18n.translate('param.time', { value: sampleDate })).to.equal('Value: 10:33:44 PM');
-        expect(i18n.translate('param.time.short', { value: sampleDate })).to.equal('Value: 10:33 PM');
-        expect(i18n.translate('param.time.medium', { value: sampleDate })).to.equal('Value: 10:33:44 PM');
-        expect(i18n.translate('param.time.long', { value: sampleDate })).to.match(/Value: 10:33:44 PM (GMT|UTC)/u);
-        expect(i18n.translate('param.time.full', { value: sampleDate })).to.match(/Value: 10:33:44 PM (GMT|UTC)/u);
+        expect(localI18n.translate(i18n`param.time`, { value: sampleDate })).to.equal('Value: 10:33:44 PM');
+        expect(localI18n.translate(i18n`param.time.short`, { value: sampleDate })).to.equal('Value: 10:33 PM');
+        expect(localI18n.translate(i18n`param.time.medium`, { value: sampleDate })).to.equal('Value: 10:33:44 PM');
+        expect(localI18n.translate(i18n`param.time.long`, { value: sampleDate })).to.match(
+          /Value: 10:33:44 PM (GMT|UTC)/u,
+        );
+        expect(localI18n.translate(i18n`param.time.full`, { value: sampleDate })).to.match(
+          /Value: 10:33:44 PM (GMT|UTC)/u,
+        );
 
-        expect(i18n.translate('param.plural', { value: 0 })).to.equal('You have no new messages');
-        expect(i18n.translate('param.plural', { value: 1 })).to.equal('You have one new message');
-        expect(i18n.translate('param.plural', { value: 2 })).to.equal('You have 2 new messages');
-        expect(i18n.translate('param.plural', { value: 10 })).to.equal('You have 10 new messages');
+        expect(localI18n.translate(i18n`param.plural`, { value: 0 })).to.equal('You have no new messages');
+        expect(localI18n.translate(i18n`param.plural`, { value: 1 })).to.equal('You have one new message');
+        expect(localI18n.translate(i18n`param.plural`, { value: 2 })).to.equal('You have 2 new messages');
+        expect(localI18n.translate(i18n`param.plural`, { value: 10 })).to.equal('You have 10 new messages');
 
-        expect(i18n.translate('param.select', { value: 'male' })).to.equal('He liked this');
-        expect(i18n.translate('param.select', { value: 'female' })).to.equal('She liked this');
-        expect(i18n.translate('param.select', { value: 'other' })).to.equal('They liked this');
-        expect(i18n.translate('param.select', { value: 'diverse' })).to.equal('They liked this');
+        expect(localI18n.translate(i18n`param.select`, { value: 'male' })).to.equal('He liked this');
+        expect(localI18n.translate(i18n`param.select`, { value: 'female' })).to.equal('She liked this');
+        expect(localI18n.translate(i18n`param.select`, { value: 'other' })).to.equal('They liked this');
+        expect(localI18n.translate(i18n`param.select`, { value: 'diverse' })).to.equal('They liked this');
 
-        expect(i18n.translate('param.selectordinal', { value: 1 })).to.equal('You are 1st in the queue');
-        expect(i18n.translate('param.selectordinal', { value: 2 })).to.equal('You are 2nd in the queue');
-        expect(i18n.translate('param.selectordinal', { value: 3 })).to.equal('You are 3rd in the queue');
-        expect(i18n.translate('param.selectordinal', { value: 4 })).to.equal('You are 4th in the queue');
-        expect(i18n.translate('param.selectordinal', { value: 10 })).to.equal('You are 10th in the queue');
+        expect(localI18n.translate(i18n`param.selectordinal`, { value: 1 })).to.equal('You are 1st in the queue');
+        expect(localI18n.translate(i18n`param.selectordinal`, { value: 2 })).to.equal('You are 2nd in the queue');
+        expect(localI18n.translate(i18n`param.selectordinal`, { value: 3 })).to.equal('You are 3rd in the queue');
+        expect(localI18n.translate(i18n`param.selectordinal`, { value: 4 })).to.equal('You are 4th in the queue');
+        expect(localI18n.translate(i18n`param.selectordinal`, { value: 10 })).to.equal('You are 10th in the queue');
 
-        expect(i18n.translate('param.escaping')).to.equal("No need to escape 'this'. But {this}");
+        expect(localI18n.translate(i18n`param.escaping`)).to.equal("No need to escape 'this'. But {this}");
       });
 
       it('should update formats when changing language', async () => {
         const sampleDate = new Date(2024, 10, 12, 22, 33, 44);
 
-        expect(i18n.translate('param.number', { value: 123.456 })).to.equal('Value: 123.456');
-        expect(i18n.translate('param.date.medium', { value: sampleDate })).to.equal('Value: Nov 12, 2024');
-        expect(i18n.translate('param.time', { value: sampleDate })).to.equal('Value: 10:33:44 PM');
+        expect(localI18n.translate(i18n`param.number`, { value: 123.456 })).to.equal('Value: 123.456');
+        expect(localI18n.translate(i18n`param.date.medium`, { value: sampleDate })).to.equal('Value: Nov 12, 2024');
+        expect(localI18n.translate(i18n`param.time`, { value: sampleDate })).to.equal('Value: 10:33:44 PM');
 
-        await i18n.setLanguage('de');
+        await localI18n.setLanguage('de');
 
-        expect(i18n.translate('param.number', { value: 123.456 })).to.equal('Value: 123,456');
-        expect(i18n.translate('param.date.medium', { value: sampleDate })).to.equal('Value: 12. Nov. 2024');
-        expect(i18n.translate('param.time', { value: sampleDate })).to.equal('Value: 22:33:44');
+        expect(localI18n.translate(i18n`param.number`, { value: 123.456 })).to.equal('Value: 123,456');
+        expect(localI18n.translate(i18n`param.date.medium`, { value: sampleDate })).to.equal('Value: 12. Nov. 2024');
+        expect(localI18n.translate(i18n`param.time`, { value: sampleDate })).to.equal('Value: 22:33:44');
       });
     });
 
@@ -628,14 +637,14 @@ describe('@vaadin/hilla-react-i18n', () => {
       }
 
       it('should not update translations if not initialized', async () => {
-        expect(i18n.translate('addresses.form.city.label')).to.equal('addresses.form.city.label');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('addresses.form.city.label');
         await triggerHmrEvent();
-        expect(i18n.translate('addresses.form.city.label')).to.equal('addresses.form.city.label');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('addresses.form.city.label');
       });
 
       it('should update translations on HMR event', async () => {
-        await i18n.configure({ language: 'en-US' });
-        expect(i18n.translate('addresses.form.city.label')).to.equal('City');
+        await localI18n.configure({ language: 'en-US' });
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('City');
 
         fetchMock
           .removeRoutes()
@@ -650,12 +659,12 @@ describe('@vaadin/hilla-react-i18n', () => {
 
         await triggerHmrEvent();
 
-        expect(i18n.translate('addresses.form.city.label')).to.equal('City updated');
+        expect(localI18n.translate(i18n`addresses.form.city.label`)).to.equal('City updated');
       });
 
       it('should update resolved language on HMR event', async () => {
-        await i18n.configure({ language: 'en-US' });
-        expect(i18n.resolvedLanguage.value).to.equal('und');
+        await localI18n.configure({ language: 'en-US' });
+        expect(localI18n.resolvedLanguage.value).to.equal('und');
 
         fetchMock
           .removeRoutes()
@@ -668,7 +677,7 @@ describe('@vaadin/hilla-react-i18n', () => {
 
         await triggerHmrEvent();
 
-        expect(i18n.resolvedLanguage.value).to.equal('en');
+        expect(localI18n.resolvedLanguage.value).to.equal('en');
       });
     });
   });


### PR DESCRIPTION
At the moment, the idea is to keep the `i18n` name for the existing use and also use it as a tag for translation strings.

Closes #3486.