### PR TITLE
test: fix flaky signal IT

### DIFF
--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/NumberSignalIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/NumberSignalIT.java
@@ -29,6 +29,9 @@ public class NumberSignalIT extends ChromeBrowserTest {
         waitForElementPresent(By.ById.id("counter"));
         waitUntil(driver -> $("span").id("sharedValue").getText() != null);
         waitUntil(driver -> $("span").id("counter").getText() != null);
+        // Make sure the initial signal subscription round trip
+        // completes (on CI):
+        waitForMillis(1000);
     }
 
     @Test
@@ -76,6 +79,7 @@ public class NumberSignalIT extends ChromeBrowserTest {
 
             // press reset button on the second window
             secondWindowDriver.findElement(By.id("reset")).click();
+            waitForMillis(500);
 
             secondWindowSharedValue = Double.parseDouble(secondWindowDriver
                     .findElement(By.id("sharedValue")).getText());
@@ -87,6 +91,7 @@ public class NumberSignalIT extends ChromeBrowserTest {
 
             // check that the first window is also updated:
             getDriver().switchTo().window(firstWindowHandle);
+            waitForMillis(500);
             Assert.assertEquals(0.5, getSharedValue(), 0.0);
             Assert.assertEquals(0, getCounterValue());
 
@@ -116,5 +121,13 @@ public class NumberSignalIT extends ChromeBrowserTest {
 
     private void clickButton(String id) {
         $(ButtonElement.class).id(id).click();
+    }
+
+    private void waitForMillis(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }


### PR DESCRIPTION
The `NumberSignalIT # shouldUpdateValue_forOtherClients` seems to be flaky on TeamCity snapshot build, probably due to some random slowness in network or the browser agents.

This cannot be reproduced locally (0 failure in more than 20 trials), but from this error log:
```
[ERROR]   NumberSignalIT.shouldUpdateValue_forOtherClients Multiple Failures (2 failures)
  java.lang.AssertionError: expected:<0.0> but was:<0.5>
```
the only scenario that the expected value for `sharedValue` could be defined as `0.0` is reading the `getSharedValue()` at the very beginning of the test, so adding some waits should alleviate the situation. In no valid state of this test, the value of `0.0` could be expected.