### PR TITLE
fix(router): always add children, even if empty

### DIFF
--- a/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
+++ b/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
@@ -178,7 +178,7 @@ export default routes;`.source.statements,
         : module.configId;
     }
 
-    const _children = factory.createArrayLiteralExpression(children ?? [], true);
+    const _children = children ? factory.createArrayLiteralExpression(children, true) : '';
 
     // ```ts
     // createRoute("grandparent", {...grandparentConfig, flowLayout: true}, [

--- a/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
+++ b/packages/ts/file-router/src/vite-plugin/createRoutesFromMeta.ts
@@ -178,7 +178,7 @@ export default routes;`.source.statements,
         : module.configId;
     }
 
-    const _children = children && children.length > 0 ? factory.createArrayLiteralExpression(children, true) : '';
+    const _children = factory.createArrayLiteralExpression(children ?? [], true);
 
     // ```ts
     // createRoute("grandparent", {...grandparentConfig, flowLayout: true}, [

--- a/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/createRoutesFromMeta.spec.ts
@@ -65,7 +65,6 @@ describe('@vaadin/hilla-file-router', () => {
         {
           path: 'profile',
           file: new URL('profile/@index.tsx', dir),
-          children: [],
         },
       ];
       configs = createTestingServerViewConfigs(metaWithDuplicatedPaths);

--- a/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/basic.snap.ts
+++ b/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/basic.snap.ts
@@ -3,35 +3,35 @@ import type { AgnosticRoute as AgnosticRoute_1, RouteModule as RouteModule_1 } f
 import { lazy as lazy_1 } from "react";
 import * as Page_1 from "../views/test/non-lazy.js";
 const routes: readonly AgnosticRoute_1[] = [
-    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }, []),
+    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }),
     createRoute_1("profile", [
-        createRoute_1("", lazy_1(() => import("../views/profile/@index.js")), []),
+        createRoute_1("", lazy_1(() => import("../views/profile/@index.js"))),
         createRoute_1("account", lazy_1(() => import("../views/profile/account/@layout.js")), { "title": "account" }, [
             createRoute_1("security", [
-                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }, []),
-                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" }, [])
+                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }),
+                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" })
             ])
         ]),
         createRoute_1("friends", lazy_1(() => import("../views/profile/friends/@layout.js")), { "title": "friends" }, [
-            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }, []),
-            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" }, [])
+            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }),
+            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" })
         ])
     ]),
     createRoute_1("test", [
-        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }, []),
-        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }, []),
+        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }),
+        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }),
         createRoute_1("issue-002378", [
             createRoute_1(":requiredParam", [
-                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" }, [])
+                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" })
             ])
         ]),
         createRoute_1("issue-002571-empty-layout", lazy_1(() => import("../views/test/issue-002571-empty-layout/@layout.js")), { "title": "issue-002571-empty-layout" }, []),
-        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }, []),
-        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config, [])
+        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }),
+        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config)
     ]),
-    createRoute_1("issue-2928-flow-auto-layout", lazy_1(() => import("../issue-2928-flow-auto-layout.js")), { "title": "issue-2928-flow-auto-layout" }, []),
+    createRoute_1("issue-2928-flow-auto-layout", lazy_1(() => import("../issue-2928-flow-auto-layout.js")), { "title": "issue-2928-flow-auto-layout" }),
     createRoute_1("mod-extension-only", [
-        createRoute_1("mod-extension-only-child", lazy_1(() => import("../mod-extension-only-child.js")), { "title": "mod-extension-only-child" }, [])
+        createRoute_1("mod-extension-only-child", lazy_1(() => import("../mod-extension-only-child.js")), { "title": "mod-extension-only-child" })
     ])
 ];
 export default routes;

--- a/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/basic.snap.ts
+++ b/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/basic.snap.ts
@@ -3,35 +3,35 @@ import type { AgnosticRoute as AgnosticRoute_1, RouteModule as RouteModule_1 } f
 import { lazy as lazy_1 } from "react";
 import * as Page_1 from "../views/test/non-lazy.js";
 const routes: readonly AgnosticRoute_1[] = [
-    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }),
+    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }, []),
     createRoute_1("profile", [
-        createRoute_1("", lazy_1(() => import("../views/profile/@index.js"))),
+        createRoute_1("", lazy_1(() => import("../views/profile/@index.js")), []),
         createRoute_1("account", lazy_1(() => import("../views/profile/account/@layout.js")), { "title": "account" }, [
             createRoute_1("security", [
-                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }),
-                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" })
+                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }, []),
+                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" }, [])
             ])
         ]),
         createRoute_1("friends", lazy_1(() => import("../views/profile/friends/@layout.js")), { "title": "friends" }, [
-            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }),
-            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" })
+            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }, []),
+            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" }, [])
         ])
     ]),
     createRoute_1("test", [
-        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }),
-        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }),
+        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }, []),
+        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }, []),
         createRoute_1("issue-002378", [
             createRoute_1(":requiredParam", [
-                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" })
+                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" }, [])
             ])
         ]),
-        createRoute_1("issue-002571-empty-layout", lazy_1(() => import("../views/test/issue-002571-empty-layout/@layout.js")), { "title": "issue-002571-empty-layout" }),
-        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }),
-        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config)
+        createRoute_1("issue-002571-empty-layout", lazy_1(() => import("../views/test/issue-002571-empty-layout/@layout.js")), { "title": "issue-002571-empty-layout" }, []),
+        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }, []),
+        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config, [])
     ]),
-    createRoute_1("issue-2928-flow-auto-layout", lazy_1(() => import("../issue-2928-flow-auto-layout.js")), { "title": "issue-2928-flow-auto-layout" }),
+    createRoute_1("issue-2928-flow-auto-layout", lazy_1(() => import("../issue-2928-flow-auto-layout.js")), { "title": "issue-2928-flow-auto-layout" }, []),
     createRoute_1("mod-extension-only", [
-        createRoute_1("mod-extension-only-child", lazy_1(() => import("../mod-extension-only-child.js")), { "title": "mod-extension-only-child" })
+        createRoute_1("mod-extension-only-child", lazy_1(() => import("../mod-extension-only-child.js")), { "title": "mod-extension-only-child" }, [])
     ])
 ];
 export default routes;

--- a/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/duplicated-paths.snap.ts
+++ b/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/duplicated-paths.snap.ts
@@ -4,32 +4,32 @@ import { lazy as lazy_1 } from "react";
 import * as Page_1 from "../views/test/non-lazy.js";
 console.error("Two views share the same path: profile");
 const routes: readonly AgnosticRoute_1[] = [
-    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }),
+    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }, []),
     createRoute_1("profile", [
-        createRoute_1("", lazy_1(() => import("../views/profile/@index.js"))),
+        createRoute_1("", lazy_1(() => import("../views/profile/@index.js")), []),
         createRoute_1("account", lazy_1(() => import("../views/profile/account/@layout.js")), { "title": "account" }, [
             createRoute_1("security", [
-                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }),
-                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" })
+                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }, []),
+                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" }, [])
             ])
         ]),
         createRoute_1("friends", lazy_1(() => import("../views/profile/friends/@layout.js")), { "title": "friends" }, [
-            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }),
-            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" })
+            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }, []),
+            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" }, [])
         ])
     ]),
     createRoute_1("test", [
-        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }),
-        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }),
+        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }, []),
+        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }, []),
         createRoute_1("issue-002378", [
             createRoute_1(":requiredParam", [
-                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" })
+                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" }, [])
             ])
         ]),
-        createRoute_1("issue-002571-empty-layout", lazy_1(() => import("../views/test/issue-002571-empty-layout/@layout.js")), { "title": "issue-002571-empty-layout" }),
-        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }),
-        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config)
+        createRoute_1("issue-002571-empty-layout", lazy_1(() => import("../views/test/issue-002571-empty-layout/@layout.js")), { "title": "issue-002571-empty-layout" }, []),
+        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }, []),
+        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config, [])
     ]),
-    createRoute_1("profile", lazy_1(() => import("../profile/@index.js")), { "title": "profile" })
+    createRoute_1("profile", lazy_1(() => import("../profile/@index.js")), { "title": "profile" }, [])
 ];
 export default routes;

--- a/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/duplicated-paths.snap.ts
+++ b/packages/ts/file-router/test/vite-plugin/fixtures/createRoutesFromMeta/duplicated-paths.snap.ts
@@ -4,32 +4,32 @@ import { lazy as lazy_1 } from "react";
 import * as Page_1 from "../views/test/non-lazy.js";
 console.error("Two views share the same path: profile");
 const routes: readonly AgnosticRoute_1[] = [
-    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }, []),
+    createRoute_1("nameToReplace", lazy_1(() => import("../views/nameToReplace.js")), { "title": "nameToReplace" }),
     createRoute_1("profile", [
-        createRoute_1("", lazy_1(() => import("../views/profile/@index.js")), []),
+        createRoute_1("", lazy_1(() => import("../views/profile/@index.js"))),
         createRoute_1("account", lazy_1(() => import("../views/profile/account/@layout.js")), { "title": "account" }, [
             createRoute_1("security", [
-                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }, []),
-                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" }, [])
+                createRoute_1("password", lazy_1(() => import("../views/profile/account/security/password.js")), { "title": "password" }),
+                createRoute_1("two-factor-auth", lazy_1(() => import("../views/profile/account/security/two-factor-auth.js")), { "title": "two-factor-auth" })
             ])
         ]),
         createRoute_1("friends", lazy_1(() => import("../views/profile/friends/@layout.js")), { "title": "friends" }, [
-            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }, []),
-            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" }, [])
+            createRoute_1("list", lazy_1(() => import("../views/profile/friends/list.js")), { "title": "list" }),
+            createRoute_1(":user", lazy_1(() => import("../views/profile/friends/{user}.js")), { "title": "{user}" })
         ])
     ]),
     createRoute_1("test", [
-        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }, []),
-        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }, []),
+        createRoute_1(":optional?", lazy_1(() => import("../views/test/{{optional}}.js")), { "title": "{{optional}}" }),
+        createRoute_1("*", lazy_1(() => import("../views/test/{...wildcard}.js")), { "title": "{...wildcard}" }),
         createRoute_1("issue-002378", [
             createRoute_1(":requiredParam", [
-                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" }, [])
+                createRoute_1("edit", lazy_1(() => import("../views/test/issue-002378/{requiredParam}/edit.js")), { "title": "edit" })
             ])
         ]),
         createRoute_1("issue-002571-empty-layout", lazy_1(() => import("../views/test/issue-002571-empty-layout/@layout.js")), { "title": "issue-002571-empty-layout" }, []),
-        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }, []),
-        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config, [])
+        createRoute_1("issue-002879-config-below", lazy_1(() => import("../views/test/issue-002879-config-below.js")), { "title": "issue-002879-config-below" }),
+        createRoute_1("non-lazy", Page_1.default, (Page_1 as RouteModule_1).config)
     ]),
-    createRoute_1("profile", lazy_1(() => import("../profile/@index.js")), { "title": "profile" }, [])
+    createRoute_1("profile", lazy_1(() => import("../profile/@index.js")), { "title": "profile" })
 ];
 export default routes;


### PR DESCRIPTION
Always adding children in generated file-router.ts seems not to have side effects and fixes the issue.

Fixes #3563.