### PR TITLE
fix: do not initialize ConnectionIndicator in Connect.ts

### DIFF
--- a/packages/ts/frontend/test/Connect.test.ts
+++ b/packages/ts/frontend/test/Connect.test.ts
@@ -70,7 +70,6 @@ describe('@vaadin/hilla-frontend', () => {
     });
 
     afterEach(() => {
-      document.body.querySelector('vaadin-connection-indicator')?.remove();
       delete $wnd.Vaadin;
     });
 
@@ -81,30 +80,6 @@ describe('@vaadin/hilla-frontend', () => {
     it('should instantiate without arguments', () => {
       const client = new ConnectClient();
       expect(client).to.be.instanceOf(ConnectClient);
-    });
-
-    it('should add a global connection indicator', async () => {
-      await new ConnectClient().ready;
-      expect($wnd.Vaadin?.connectionIndicator).is.not.undefined;
-    });
-
-    it('should transition to CONNECTION_LOST on offline and to CONNECTED on subsequent online if Flow.client.TypeScript not loaded', () => {
-      new ConnectClient();
-      expect($wnd.Vaadin?.connectionState?.state).to.equal(ConnectionState.CONNECTED);
-      dispatchEvent(new Event('offline'));
-      expect($wnd.Vaadin?.connectionState?.state).to.equal(ConnectionState.CONNECTION_LOST);
-      dispatchEvent(new Event('online'));
-      expect($wnd.Vaadin?.connectionState?.state).to.equal(ConnectionState.CONNECTED);
-    });
-
-    it('should transition to CONNECTION_LOST on offline and to CONNECTED on subsequent online if Flow is loaded but Flow.client.TypeScript not loaded', () => {
-      new ConnectClient();
-      $wnd.Vaadin!.Flow = {};
-      expect($wnd.Vaadin?.connectionState?.state).to.equal(ConnectionState.CONNECTED);
-      dispatchEvent(new Event('offline'));
-      expect($wnd.Vaadin?.connectionState?.state).to.equal(ConnectionState.CONNECTION_LOST);
-      dispatchEvent(new Event('online'));
-      expect($wnd.Vaadin?.connectionState?.state).to.equal(ConnectionState.CONNECTED);
     });
 
     it('should not transition connection state if Flow loaded', () => {


### PR DESCRIPTION
## Description
Connect.ts should not dynamically import '@vaadin/common-frontend' as this is loaded in Flow.js statically, and this is breaks Safari's module tree somehow.

As currently, the default template for the generated `routes.tsx` is using `Flow.tsx` as the fallback (`Flow.tsx` loads `Flow.js` from jar-resources, that import and initialize the `ConnectionIndicator` statically), this fix is enough to reduce the issues severity. 
However, it should be considered to move the `ConnectionIndicator` initialization to some other shared module (such as `vaadin.ts`) so that when Hilla-only users get rid of the `.withFallback(Flow)` in `routes.tsx` the connection indicator feature doesn't break.

Fixes: #3571

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
