### PR TITLE
fix(react-i18n): align with Flow i18n backend behavior

### DIFF
--- a/packages/java/tests/spring/react-i18n/src/main/frontend/views/@layout.tsx
+++ b/packages/java/tests/spring/react-i18n/src/main/frontend/views/@layout.tsx
@@ -1,6 +1,5 @@
 import { createMenuItems } from '@vaadin/hilla-file-router/runtime.js';
 import { i18n, key, translate } from '@vaadin/hilla-react-i18n';
-import { effect } from '@vaadin/hilla-react-signals';
 import { SideNavItem } from '@vaadin/react-components';
 import { AppLayout } from '@vaadin/react-components/AppLayout.js';
 import { DrawerToggle } from '@vaadin/react-components/DrawerToggle.js';
@@ -8,9 +7,7 @@ import { Scroller } from '@vaadin/react-components/Scroller.js';
 import { Outlet } from 'react-router';
 import type { Detail } from '../types/detail.js';
 
-effect(() => {
-  i18n.configure();
-});
+await i18n.configure();
 
 export default function MainLayout() {
   return (

--- a/packages/java/tests/spring/react-i18n/src/main/resources/vaadin-i18n/translations_es_AR.properties
+++ b/packages/java/tests/spring/react-i18n/src/main/resources/vaadin-i18n/translations_es_AR.properties
@@ -1,0 +1,2 @@
+basic.form.name.label=Nombre
+basic.form.address.label=Direccion

--- a/packages/java/tests/spring/react-i18n/src/test/java/com/vaadin/hilla/test/BasicI18NIT.java
+++ b/packages/java/tests/spring/react-i18n/src/test/java/com/vaadin/hilla/test/BasicI18NIT.java
@@ -35,9 +35,9 @@ public class BasicI18NIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void setLangWithoutCountry_onlyLangWithCountryAvailable_shouldUseLangWithCountry()
+    public void setLangWithoutCountry_onlyLangWithCountryAvailable_shouldUseDefaultTranslation()
             throws InterruptedException {
-        assertTranslations("es", "es-ES", "Nombre", "Direccion");
+        assertTranslations("es", "es", "Name", "Address");
     }
 
     @Test
@@ -49,7 +49,7 @@ public class BasicI18NIT extends ChromeBrowserTest {
     @Test
     public void setLangWithCountry_langWithDifferentCountryAvailable_shouldUseLangWithDifferentCountry()
             throws InterruptedException {
-        assertTranslations("es_AR", "es-ES", "Nombre", "Direccion");
+        assertTranslations("es_AR", "es-AR", "Nombre", "Direccion");
     }
 
     @Test
@@ -73,13 +73,15 @@ public class BasicI18NIT extends ChromeBrowserTest {
     @Test
     public void setLangEmpty_defaultTranslationAvailable_shouldUseDefaultTranslation()
             throws InterruptedException {
+        // Change away from default empty value to ensure change event
+        languageField.setValue("nonempty");
         assertTranslations("", "und", "Name", "Address");
     }
 
     @Test
     public void setInvalidLang_defaultTranslationAvailable_shouldUseDefaultTranslation()
             throws InterruptedException {
-        assertTranslations("KLINGON", "und", "Name", "Address");
+        assertTranslations("KLINGON", "klingon", "Name", "Address");
     }
 
     private void assertTranslations(String languageTag,

--- a/packages/ts/react-i18n/src/index.ts
+++ b/packages/ts/react-i18n/src/index.ts
@@ -297,7 +297,7 @@ export class I18n {
   translate(k: I18nKey, params?: Record<string, unknown>): string {
     const translation = this.#translations.value[k];
     if (!translation) {
-      return k.toString();
+      return this.handleMissingTranslation(k);
     }
     const format = this.#formatCache.getFormat(translation);
     return format.format(params) as string;
@@ -337,7 +337,7 @@ export class I18n {
       if (!translation) {
         if (this.#alreadyRequestedKeys.value.has(k)) {
           // No hope to load this key, return it as is
-          return k;
+          return this.handleMissingTranslation(k);
         }
 
         if (this.#language.value) {
@@ -355,6 +355,11 @@ export class I18n {
 
     this.#translationSignalCache.set(k, translationSignal);
     return translationSignal;
+  }
+
+  private handleMissingTranslation(k: string): string {
+    const lang = this.#language.value ? `${this.#language.value.split(/[_-]/u)[0]}: ` : '';
+    return `!${lang}${k}`;
   }
 }
 

--- a/packages/ts/react-i18n/test/i18n.spec.tsx
+++ b/packages/ts/react-i18n/test/i18n.spec.tsx
@@ -237,8 +237,8 @@ describe('@vaadin/hilla-react-i18n', () => {
         await i18n.registerChunk('city');
 
         // Neither chunks are loaded
-        expect(i18n.translate(key`addresses.form.city.label`)).to.equal('addresses.form.city.label');
-        expect(i18n.translate(key`addresses.form.street.label`)).to.equal('addresses.form.street.label');
+        expect(i18n.translate(key`addresses.form.city.label`)).to.equal('!addresses.form.city.label');
+        expect(i18n.translate(key`addresses.form.street.label`)).to.equal('!addresses.form.street.label');
         expect(fetchMock.callHistory.called()).to.be.false;
       });
 
@@ -250,7 +250,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(i18n.translate(key`addresses.form.city.label`)).to.equal('City Chunked');
 
         // Street chunk is not loaded yet
-        expect(i18n.translate(key`addresses.form.street.label`)).to.equal('addresses.form.street.label');
+        expect(i18n.translate(key`addresses.form.street.label`)).to.equal('!en: addresses.form.street.label');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['city']);
@@ -295,7 +295,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         expect(i18n.translate(key`addresses.form.city.label`)).to.equal('Australian City Chunked');
 
         // Street chunk is not loaded yet
-        expect(i18n.translate(key`addresses.form.street.label`)).to.equal('addresses.form.street.label');
+        expect(i18n.translate(key`addresses.form.street.label`)).to.equal('!en: addresses.form.street.label');
         expect(fetchMock.callHistory.called()).to.be.true;
         expect(fetchMock.callHistory.calls()).to.have.length(1);
         expect(getLastUrlParams().getAll('chunks')).to.deep.equal(['city']);
@@ -345,7 +345,7 @@ describe('@vaadin/hilla-react-i18n', () => {
       });
 
       it('should return key when there is no translation', () => {
-        expect(i18n.translate(key`unknown.key`)).to.equal('unknown.key');
+        expect(i18n.translate(key`unknown.key`)).to.equal('!en: unknown.key');
       });
     });
 
@@ -488,7 +488,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         });
 
         // Runs once initially
-        expect(effectSpy.calledOnceWith(undefined, 'addresses.form.city.label')).to.be.true;
+        expect(effectSpy.calledOnceWith(undefined, '!addresses.form.city.label')).to.be.true;
         effectSpy.resetHistory();
 
         // Configure initial language
@@ -542,7 +542,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         const { getByText } = render(<TestTranslateComponent />);
 
         // No language
-        expect(getByText('addresses.form.city.label')).to.exist;
+        expect(getByText('!addresses.form.city.label')).to.exist;
 
         // Configure initial language
         await i18n.configure({ language: 'en-US' });
@@ -566,7 +566,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         render(<TestUseSignalEffectComponent />);
 
         // No language
-        expect(signalEffectResult).to.equal('addresses.form.city.label');
+        expect(signalEffectResult).to.equal('!addresses.form.city.label');
 
         // Configure initial language
         await i18n.configure({ language: 'en-US' });
@@ -588,7 +588,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         const { getByText } = render(<TestUseComputedComponent />);
 
         // No language
-        expect(getByText('Computed translation: addresses.form.city.label')).to.exist;
+        expect(getByText('Computed translation: !addresses.form.city.label')).to.exist;
 
         // Configure initial language
         await i18n.configure({ language: 'en-US' });
@@ -612,7 +612,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         render(<TestUseEffectComponent />);
 
         // No language
-        expect(defaultEffectResult).to.equal('addresses.form.city.label');
+        expect(defaultEffectResult).to.equal('!addresses.form.city.label');
 
         // Configure initial language
         await i18n.configure({ language: 'en-US' });
@@ -635,7 +635,7 @@ describe('@vaadin/hilla-react-i18n', () => {
         const { getByText } = render(<TestUseMemoComponent />);
 
         // No language
-        expect(getByText('Memoized translation: addresses.form.city.label')).to.exist;
+        expect(getByText('Memoized translation: !addresses.form.city.label')).to.exist;
 
         // Configure initial language
         await i18n.configure({ language: 'en-US' });
@@ -758,9 +758,9 @@ describe('@vaadin/hilla-react-i18n', () => {
       }
 
       it('should not update translations if not initialized', async () => {
-        expect(i18n.translate(key`addresses.form.city.label`)).to.equal('addresses.form.city.label');
+        expect(i18n.translate(key`addresses.form.city.label`)).to.equal('!addresses.form.city.label');
         await triggerHmrEvent();
-        expect(i18n.translate(key`addresses.form.city.label`)).to.equal('addresses.form.city.label');
+        expect(i18n.translate(key`addresses.form.city.label`)).to.equal('!addresses.form.city.label');
       });
 
       it('should update translations on HMR event', async () => {


### PR DESCRIPTION
vaadin/flow#21636 changed the backend implementation to enable using non-default `I18nProvider`.

This change updates tests to assert new backend behavior.
