### PR TITLE
chore: add jcip test dependency

### DIFF
--- a/packages/java/endpoint/pom.xml
+++ b/packages/java/endpoint/pom.xml
@@ -216,6 +216,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.lucee</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/packages/java/tests/pom.xml
+++ b/packages/java/tests/pom.xml
@@ -136,6 +136,11 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.lucee</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.lucee</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-reflect</artifactId>
         <version>${kotlin.version}</version>


### PR DESCRIPTION
Do not rely on transitive dependency to use jcip annotations