### PR TITLE
chore: use LoginFormElement directly

### DIFF
--- a/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
+++ b/packages/java/tests/spring/security/src/test/java/com/vaadin/flow/spring/fusionsecurity/SecurityIT.java
@@ -15,7 +15,6 @@ import org.openqa.selenium.JavascriptExecutor;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.login.testbench.LoginFormElement;
-import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.TestBenchElement;
@@ -328,7 +327,7 @@ public class SecurityIT extends ChromeBrowserTest {
 
     protected void assertLoginViewShown() {
         assertPathShown("login");
-        waitUntil(driver -> $(LoginOverlayElement.class).exists());
+        waitUntil(driver -> $(LoginFormElement.class).exists());
     }
 
     private void assertRootPageShown() {
@@ -389,13 +388,12 @@ public class SecurityIT extends ChromeBrowserTest {
     private void login(String username, String password) {
         assertLoginViewShown();
 
-        LoginFormElement form = $(LoginOverlayElement.class).first()
-                .getLoginForm();
+        LoginFormElement form = $(LoginFormElement.class).first();
         form.getUsernameField().setValue(username);
         form.getPasswordField().setValue(password);
         form.submit();
         waitForDocumentReady();
-        waitUntilNot(driver -> $(LoginOverlayElement.class).exists());
+        waitUntilNot(driver -> $(LoginFormElement.class).exists());
         waitForDocumentReady();
     }
 


### PR DESCRIPTION
Following the changes in the `LoginOverlayElement` component TestBench API from https://github.com/vaadin/flow-components/pull/7783 and the underlying overlay changes in Vaadin components, this PR changes the test code to use LoginFormElement directly instead of finding it in the overlay.
