### PR TITLE
build: stop using "react19" Flow dependencies

### DIFF
--- a/scripts/java/hilla-scripts/pom.xml
+++ b/scripts/java/hilla-scripts/pom.xml
@@ -63,7 +63,6 @@
                     <arguments>
                         <argument>default</argument>
                         <argument>react-router</argument>
-                        <argument>react19</argument>
                         <argument>vite</argument>
                     </arguments>
                 </configuration>


### PR DESCRIPTION
Removes the usage of the `react19` Flow dependencies spec, which was merged with defaults in https://github.com/vaadin/flow/pull/21523
