### PR TITLE
fix: improve JSON comparison to provide easier to read errors

### DIFF
--- a/packages/java/parser-jvm-test-utils/pom.xml
+++ b/packages/java/parser-jvm-test-utils/pom.xml
@@ -19,6 +19,33 @@
     <formatter.basedir>${project.parent.basedir}</formatter.basedir>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <!-- Allow reading all unnamed modules for JSONAssert -->
+            <arg>--add-reads</arg>
+            <arg>com.vaadin.hilla.parser.testutils=ALL-UNNAMED</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <additionalJOptions>
+            <!-- Allow reading all unnamed modules for JSONAssert -->
+            <additionalJOption>--add-reads</additionalJOption>
+            <additionalJOption>com.vaadin.hilla.parser.testutils=ALL-UNNAMED</additionalJOption>
+          </additionalJOptions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -27,6 +54,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.1</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>

--- a/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
+++ b/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
@@ -1,6 +1,8 @@
 package com.vaadin.hilla.parser.testutils;
 
-import org.junit.jupiter.api.Assertions;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -11,7 +13,35 @@ public final class JsonAssertions {
 
     public static void assertEquals(Object expected, Object actual)
             throws JsonProcessingException {
-        Assertions.assertEquals(printer.pretty().writeAsString(expected),
-                printer.pretty().writeAsString(actual));
+        try {
+            String expectedJson = printer.writeAsString(expected);
+            String actualJson = printer.writeAsString(actual);
+
+            // Use JSONAssert for comparison - ignores whitespace and provides
+            // precise diffs
+            JSONAssert.assertEquals(expectedJson, actualJson,
+                    JSONCompareMode.STRICT);
+        } catch (JSONException | AssertionError e) {
+            // Enhance error message with more context around the differing
+            // field
+            String originalMessage = e.getMessage();
+            String enhancedMessage = enhanceErrorMessage(originalMessage,
+                    expected, actual);
+            throw new AssertionError(enhancedMessage, e);
+        }
+    }
+
+    private static String enhanceErrorMessage(String originalMessage,
+            Object expected, Object actual) throws JsonProcessingException {
+        StringBuilder enhanced = new StringBuilder();
+        enhanced.append("JSON comparison failed:\n");
+        enhanced.append(originalMessage);
+        enhanced.append(
+                "\n\nFor better context, here are the complete JSON structures:\n\n");
+        enhanced.append("Expected:\n");
+        enhanced.append(printer.pretty().writeAsString(expected));
+        enhanced.append("\n\nActual:\n");
+        enhanced.append(printer.pretty().writeAsString(actual));
+        return enhanced.toString();
     }
 }

--- a/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
+++ b/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
@@ -1,10 +1,9 @@
 package com.vaadin.hilla.parser.testutils;
 
+import com.fasterxml.jackson.core.JacksonException;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.vaadin.hilla.parser.utils.JsonPrinter;
 
@@ -12,7 +11,7 @@ public final class JsonAssertions {
     private final static JsonPrinter printer = new JsonPrinter();
 
     public static void assertEquals(Object expected, Object actual)
-            throws JsonProcessingException {
+            throws JacksonException {
         String expectedJson = printer.writeAsString(expected);
         String actualJson = printer.writeAsString(actual);
         try {
@@ -32,7 +31,7 @@ public final class JsonAssertions {
 
     private static String enhanceErrorMessage(String originalMessage,
             String expectedJson, String actualJson)
-            throws JsonProcessingException {
+            throws JacksonException {
         StringBuilder enhanced = new StringBuilder();
         enhanced.append("JSON comparison failed:\n");
         enhanced.append(originalMessage);

--- a/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
+++ b/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
@@ -13,10 +13,9 @@ public final class JsonAssertions {
 
     public static void assertEquals(Object expected, Object actual)
             throws JsonProcessingException {
+        String expectedJson = printer.writeAsString(expected);
+        String actualJson = printer.writeAsString(actual);
         try {
-            String expectedJson = printer.writeAsString(expected);
-            String actualJson = printer.writeAsString(actual);
-
             // Use JSONAssert for comparison - ignores whitespace and provides
             // precise diffs
             JSONAssert.assertEquals(expectedJson, actualJson,
@@ -26,22 +25,23 @@ public final class JsonAssertions {
             // field
             String originalMessage = e.getMessage();
             String enhancedMessage = enhanceErrorMessage(originalMessage,
-                    expected, actual);
+                    expectedJson, actualJson);
             throw new AssertionError(enhancedMessage, e);
         }
     }
 
     private static String enhanceErrorMessage(String originalMessage,
-            Object expected, Object actual) throws JsonProcessingException {
+            String expectedJson, String actualJson)
+            throws JsonProcessingException {
         StringBuilder enhanced = new StringBuilder();
         enhanced.append("JSON comparison failed:\n");
         enhanced.append(originalMessage);
         enhanced.append(
                 "\n\nFor better context, here are the complete JSON structures:\n\n");
         enhanced.append("Expected:\n");
-        enhanced.append(printer.pretty().writeAsString(expected));
+        enhanced.append(expectedJson);
         enhanced.append("\n\nActual:\n");
-        enhanced.append(printer.pretty().writeAsString(actual));
+        enhanced.append(actualJson);
         return enhanced.toString();
     }
 }

--- a/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
+++ b/packages/java/parser-jvm-test-utils/src/main/java/com/vaadin/hilla/parser/testutils/JsonAssertions.java
@@ -30,8 +30,7 @@ public final class JsonAssertions {
     }
 
     private static String enhanceErrorMessage(String originalMessage,
-            String expectedJson, String actualJson)
-            throws JacksonException {
+            String expectedJson, String actualJson) throws JacksonException {
         StringBuilder enhanced = new StringBuilder();
         enhanced.append("JSON comparison failed:\n");
         enhanced.append(originalMessage);

--- a/packages/java/parser-jvm-test-utils/src/main/java/module-info.java
+++ b/packages/java/parser-jvm-test-utils/src/main/java/module-info.java
@@ -1,10 +1,11 @@
-module com.vaadin.hilla.parser.testutils {
+open module com.vaadin.hilla.parser.testutils {
     requires com.fasterxml.jackson.databind;
     requires com.vaadin.hilla.parser.utils;
     requires org.jspecify;
     requires io.swagger.v3.oas.models;
     requires io.swagger.v3.core;
     requires org.junit.jupiter.api;
+    // JSONAssert dependencies will be resolved as unnamed/automatic modules at runtime
 
     exports com.vaadin.hilla.parser.testutils;
 }


### PR DESCRIPTION
Replace string-based JSON comparison with JSONAssert library to avoid test failures caused by formatting changes like whitespace, indentation, or property ordering. Enhanced error messages now provide both precise field-level diffs and complete JSON context for easier debugging.

Changes:
- Add JSONAssert dependency to parser-jvm-test-utils
- Replace string comparison with structural JSON comparison
- Configure module system to allow JSONAssert automatic modules
- Add enhanced error messages showing full JSON context
- Configure compiler and javadoc plugins for module compatibility
