### PR TITLE
Remove Jackson #5319 workaround and update to 3.0.0-rc11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <swagger.parser.v3.version>2.1.15</swagger.parser.v3.version>
     <jackson2.version>2.20.0</jackson2.version>
     <jackson-annotations.version>2.20</jackson-annotations.version>
-    <jackson.version>3.0.0-rc9</jackson.version>
+    <jackson.version>3.0.0-rc11</jackson.version>
     <junit.version>5.10.1</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>25.0.0-alpha15</flow.version>


### PR DESCRIPTION
- Remove float-to-int coercion workaround methods from EndpointInvoker
- Remove TreeTraversingParser limitation comments and logic
- Update Jackson version from 3.0.0-rc9 to 3.0.0-rc11
- Issue https://github.com/FasterXML/jackson-databind/issues/5319 is fixed in Jackson 3.0.0-rc11
