### PR TITLE
test: disable signal tests due to unstable implementation

### DIFF
--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/BasicSignalIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/BasicSignalIT.java
@@ -4,10 +4,14 @@ import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentInElement;
 
+// Tests are disabled due to unstable signal implementation.
+// Re-enable when there is a new signal implementation.
+@Ignore
 public class BasicSignalIT extends ChromeBrowserTest {
     @Override
     @Before

--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/NumberSignalIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/NumberSignalIT.java
@@ -6,12 +6,16 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.parallel.Browser;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WindowType;
 
+// Tests are disabled due to unstable signal implementation.
+// Re-enable when there is a new signal implementation.
+@Ignore
 @RunWith(BlockJUnit4ClassRunner.class)
 public class NumberSignalIT extends ChromeBrowserTest {
 

--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/ParamsIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/ParamsIT.java
@@ -5,11 +5,15 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.parallel.Browser;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.openqa.selenium.By;
 
+// Tests are disabled due to unstable signal implementation.
+// Re-enable when there is a new signal implementation.
+@Ignore
 @RunWith(BlockJUnit4ClassRunner.class)
 public class ParamsIT extends ChromeBrowserTest {
 

--- a/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/SignalBasicSecurityIT.java
+++ b/packages/java/tests/spring/react-signals/src/test/java/com/vaadin/hilla/test/SignalBasicSecurityIT.java
@@ -7,11 +7,15 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.parallel.Browser;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.openqa.selenium.By;
 
+// Tests are disabled due to unstable signal implementation.
+// Re-enable when there is a new signal implementation.
+@Ignore
 @RunWith(BlockJUnit4ClassRunner.class)
 public class SignalBasicSecurityIT extends ChromeBrowserTest {
 


### PR DESCRIPTION
Signal tests are temporarily disabled with @Ignore annotation until a new stable signal implementation is available. The tests can be re-enabled by removing the @Ignore annotation.
