### PR TITLE
chore: use managed flow-build-tools version (#4566) (CP: 25.0)

### DIFF
--- a/packages/java/engine-core/pom.xml
+++ b/packages/java/engine-core/pom.xml
@@ -47,7 +47,6 @@
       <artifactId>flow-build-tools</artifactId>
       <classifier>shaded</classifier>
       <scope>provided</scope>
-      <version>${flow.version}</version>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>

--- a/packages/java/engine-runtime/pom.xml
+++ b/packages/java/engine-runtime/pom.xml
@@ -41,7 +41,8 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>flow-build-tools</artifactId>
-      <version>${flow.version}</version>
+      <classifier>shaded</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.vaadin</groupId>


### PR DESCRIPTION
The flow-build-tools module has been added to the Flow BOM so there is no need to pin the version anymore.
