### PR TITLE
Replace AbstractSignal with Signal interface in endpoint package

### DIFF
--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/internal/InternalSignal.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/internal/InternalSignal.java
@@ -27,7 +27,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ObjectNode;
 
-import com.vaadin.signals.AbstractSignal;
+import com.vaadin.signals.Signal;
 import com.vaadin.signals.Id;
 import com.vaadin.signals.SignalCommand;
 import com.vaadin.signals.SignalUtils;
@@ -46,7 +46,7 @@ public class InternalSignal {
     // ClientSignalId -> Subscriber's sink
     private final Map<String, Sinks.Many<JsonNode>> subscribers = new HashMap<>();
 
-    private final AbstractSignal<?> signal;
+    private final Signal<?> signal;
     private final SignalTree tree;
     private CleanupCallback treeSubscriptionCanceler;
 
@@ -56,7 +56,7 @@ public class InternalSignal {
     private final Map<Id, String> commandsOfSubscribers = new HashMap<>();
     private final ObjectMapper objectMapper;
 
-    public InternalSignal(AbstractSignal<?> signal, ObjectMapper objectMapper) {
+    public InternalSignal(Signal<?> signal, ObjectMapper objectMapper) {
         this.signal = signal;
         this.tree = SignalUtils.treeOf(signal);
         this.objectMapper = objectMapper;

--- a/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/internal/SecureSignalsRegistry.java
+++ b/packages/java/endpoint/src/main/java/com/vaadin/hilla/signals/internal/SecureSignalsRegistry.java
@@ -31,7 +31,7 @@ import com.vaadin.hilla.AuthenticationUtil;
 import com.vaadin.hilla.EndpointInvocationException;
 import com.vaadin.hilla.EndpointInvoker;
 import com.vaadin.hilla.EndpointRegistry;
-import com.vaadin.signals.AbstractSignal;
+import com.vaadin.signals.Signal;
 
 /**
  * Proxy for the accessing the SignalRegistry.
@@ -63,7 +63,7 @@ public class SecureSignalsRegistry {
                 .getSecurityHolderRoleChecker();
         checkAccess(endpointName, methodName, principal, isInRole);
 
-        AbstractSignal<?> signal = (AbstractSignal<?>) invoker
+        Signal<?> signal = (Signal<?>) invoker
                 .invoke(endpointName, methodName, body, principal, isInRole);
         endpointMethods.put(clientSignalId,
                 new EndpointMethod(endpointName, methodName));

--- a/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/internal/SecureSignalsRegistryTest.java
+++ b/packages/java/endpoint/src/test/java/com/vaadin/hilla/signals/internal/SecureSignalsRegistryTest.java
@@ -37,14 +37,14 @@ import com.vaadin.hilla.AuthenticationUtil;
 import com.vaadin.hilla.EndpointInvocationException;
 import com.vaadin.hilla.EndpointInvoker;
 import com.vaadin.hilla.EndpointRegistry;
-import com.vaadin.signals.AbstractSignal;
+import com.vaadin.signals.Signal;
 
 public class SecureSignalsRegistryTest {
 
     @Test
     public void when_accessToEndpointIsAllowed_signalInstanceIsRegistered()
             throws Exception {
-        AbstractSignal<?> signal = Mockito.mock(AbstractSignal.class);
+        Signal<?> signal = Mockito.mock(Signal.class);
         InternalSignal internalSignal = new InternalSignal(signal,
                 new ObjectMapper());
         EndpointInvoker invoker = mockEndpointInvokerThatGrantsAccess(signal);
@@ -68,7 +68,7 @@ public class SecureSignalsRegistryTest {
     @Test
     public void when_unsubscribedIsCalled_underlyingRegistryRemovesClientSignalToSignalMapping()
             throws Exception {
-        AbstractSignal<?> signal = Mockito.mock(AbstractSignal.class);
+        Signal<?> signal = Mockito.mock(Signal.class);
         InternalSignal internalSignal = new InternalSignal(signal,
                 new ObjectMapper());
         EndpointInvoker invoker = mockEndpointInvokerThatGrantsAccess(signal);
@@ -104,7 +104,7 @@ public class SecureSignalsRegistryTest {
     @Test
     public void when_accessToEndpointIsAllowed_get_returnsSignal()
             throws Exception {
-        AbstractSignal<?> signal = Mockito.mock(AbstractSignal.class);
+        Signal<?> signal = Mockito.mock(Signal.class);
         InternalSignal internalSignal = new InternalSignal(signal,
                 new ObjectMapper());
         EndpointInvoker invoker = mockEndpointInvokerThatGrantsAccess(signal);
@@ -163,7 +163,7 @@ public class SecureSignalsRegistryTest {
     }
 
     private EndpointInvoker mockEndpointInvokerThatGrantsAccess(
-            AbstractSignal<?> signal) throws Exception {
+            Signal<?> signal) throws Exception {
         EndpointInvoker invoker = Mockito.mock(EndpointInvoker.class);
         when(invoker.invoke(Mockito.anyString(), Mockito.anyString(),
                 Mockito.any(), Mockito.any(), Mockito.any()))


### PR DESCRIPTION
## Summary
This PR updates the Hilla signals endpoint package to use the `Signal` interface instead of the `AbstractSignal` class. This change promotes better abstraction and decoupling by depending on the interface rather than a concrete implementation.

## Changes
- **InternalSignal.java**: Updated import and all references from `AbstractSignal<?>` to `Signal<?>` in:
  - Import statement
  - Field declaration
  - Constructor parameter type
  
- **SecureSignalsRegistry.java**: Updated import and cast operation from `AbstractSignal<?>` to `Signal<?>` in the `register()` method

- **SecureSignalsRegistryTest.java**: Updated all test mock declarations and method signatures from `AbstractSignal<?>` to `Signal<?>` across three test methods and one helper method

## Implementation Details
- All changes are straightforward type replacements with no logic modifications
- The `Signal` interface provides the same contract needed by these classes
- This improves code maintainability by reducing coupling to concrete implementations
- All test coverage remains intact with updated type declarations

https://claude.ai/code/session_017QUYhuvDfZqqfFr49n9GQQ