### PR TITLE
fix: Set required Java and Maven versions in flow-maven-plugin

### DIFF
--- a/packages/java/maven-plugin/pom.xml
+++ b/packages/java/maven-plugin/pom.xml
@@ -107,9 +107,11 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.15.0</version>
+          <version>3.15.2</version>
           <configuration>
             <goalPrefix>vaadin</goalPrefix>
+            <requiredMavenVersion>3.8</requiredMavenVersion>
+            <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
Prevents potential issues with Maven versions >= 3.9.12 if a Java version newer than the supported one is used to package the Maven plugin.
