### PR TITLE
chore: update workflow cache strategy

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Java version
     required: true
     default: '21'
+  cache-version:
+    description: Cache version prefix — increment to bust all stale caches
+    required: false
+    default: 'v1'
 
 runs:
   using: composite
@@ -24,7 +28,13 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'
-        cache: maven
+    - name: Cache Maven repository
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ inputs.cache-version }}-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ inputs.cache-version }}-${{ runner.os }}-maven-
     - name: Cache node_modules
       uses: actions/cache@v4
       id: cache-node_modules
@@ -32,7 +42,7 @@ runs:
         path: |
           node_modules
           packages/ts/*/node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}
+        key: ${{ inputs.cache-version }}-${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}
     - name: Install npm dependencies
       if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}
       shell: bash

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -279,6 +279,8 @@ jobs:
           set -x
           tar xf workspace.tar
           tar cf - .m2 | (cd ~ && tar xf -)
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set TB License
         run: |
           TB_LICENSE=${{secrets.TB_LICENSE}}


### PR DESCRIPTION
It seems the old cache policy here is causing random failures on gradle windows validations across different branches.
so this fix is trying to targeting that issue. 

```
 .github/actions/setup/action.yml:                                                                                                                                                                                                
  - Removed cache: maven from setup-java@v4 — the built-in cache uses an implicit restore-keys fallback (setup-java-$RUNNER_OS-maven-) which restores any old cache when there's no exact match, causing stale SNAPSHOT artifacts  
  to persist across builds                                                                                                                                                                                                         
  - Added explicit Maven cache via actions/cache@v4 with a versioned key: ${{ inputs.cache-version }}-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}. The restore-keys fallback is now scoped to the same cache-version   
  prefix                                                                                                                                                                                                                           
  - Added cache-version input (default: v1) — when the cache goes stale, bump this to v2 in one place instead of needing gh cache delete --all
  - Added version prefix to node_modules cache key for consistency

  .github/workflows/validation.yml:
  - Added gradle/actions/setup-gradle@v4 step to the test-gradle job. This provides proper Gradle caching (~/.gradle/caches, ~/.gradle/wrapper) with smart defaults: saves cache only on the default branch, restores on all
  branches, and handles cache cleanup automatically

  How this fixes the issue

  The root cause was that setup-java's cache: maven would restore stale SNAPSHOT artifacts from a previous build into ~/.m2/repository. Even though the workspace tar overwrites the project's own artifacts, stale transitive
  SNAPSHOT dependencies could remain. On Windows specifically, Gradle resolves from both mavenLocal() and its own cache, amplifying the staleness problem.

  Now:
  - Bumping cache-version from v1 to v2 (one-line change) busts all Maven and node_modules caches — no more gh cache delete --all
  - Gradle caching is explicitly managed, preventing inconsistent Gradle wrapper/dependency state across runs
```