### PR TITLE
chore: Make project TypeScript 6 compatible

### DIFF
--- a/packages/java/tests/spring/endpoints/src/main/frontend/sw.ts
+++ b/packages/java/tests/spring/endpoints/src/main/frontend/sw.ts
@@ -19,7 +19,18 @@ self.skipWaiting();
 clientsClaim();
 
 declare var OFFLINE_PATH: string; // defined by Webpack/Vite
-declare var VITE_ENABLED: boolean; // defined by Webpack/Vite
+
+declare global {
+  interface ImportMeta {
+    readonly env: {
+      readonly MODE: string;
+      readonly BASE_URL: string;
+      readonly PROD: boolean;
+      readonly DEV: boolean;
+      readonly SSR: boolean;
+    } & Readonly<Record<string, string>>;
+  }
+}
 
 // Combine manifest entries injected at compile-time by Webpack/Vite
 // with ones that Flow injects at runtime through `sw-runtime-resources-precache.js`.
@@ -80,7 +91,7 @@ const networkFirst = new NetworkFirst({
   plugins: [checkConnectionPlugin()]
 });
 
-if (process.env.NODE_ENV === 'development' && VITE_ENABLED) {
+if (import.meta.env.DEV) {
   self.addEventListener('activate', (event) => {
     event.waitUntil(caches.delete(cacheNames.runtime));
   });

--- a/packages/ts/react-crud/src/header-filter.tsx
+++ b/packages/ts/react-crud/src/header-filter.tsx
@@ -197,7 +197,7 @@ export function NumberHeaderFilter(): ReactElement {
         theme="small"
         placeholder={filterPlaceholder ?? 'Filter...'}
         onInput={(e) => {
-          const fieldValue = ((e as InputEvent).target as TextFieldElement).value;
+          const fieldValue = (e.target as TextFieldElement).value;
           setInputValue(fieldValue);
         }}
       />


### PR DESCRIPTION
TypeScript 6 no longer provides a global 'process' type by default. Replace 'process.env.NODE_ENV === development' with 'import.meta.env.DEV' to match Flow's canonical sw.ts.

TS 6 infers the NumberField onInput handler parameter as InputEvent,
so the explicit 'as InputEvent' cast is flagged as unnecessary by the
no-unnecessary-type-assertion ESLint rule.

