### PR TITLE
chore: remove unnecessary InputEvent cast for TS 6

### DIFF
--- a/packages/ts/react-crud/src/header-filter.tsx
+++ b/packages/ts/react-crud/src/header-filter.tsx
@@ -197,7 +197,7 @@ export function NumberHeaderFilter(): ReactElement {
         theme="small"
         placeholder={filterPlaceholder ?? 'Filter...'}
         onInput={(e) => {
-          const fieldValue = ((e as InputEvent).target as TextFieldElement).value;
+          const fieldValue = (e.target as TextFieldElement).value;
           setInputValue(fieldValue);
         }}
       />


### PR DESCRIPTION
TS 6 infers the NumberField onInput handler parameter as InputEvent, so the explicit 'as InputEvent' cast is flagged as unnecessary by the no-unnecessary-type-assertion ESLint rule.
