### PR TITLE
fix: enable Fast Refresh for views exporting `config` (#5159)

### DIFF
--- a/packages/ts/file-router/src/vite-plugin.ts
+++ b/packages/ts/file-router/src/vite-plugin.ts
@@ -4,8 +4,8 @@ import type { TransformResult } from 'rollup';
 import type { EnvironmentModuleNode, HotUpdateOptions, Logger, Plugin } from 'vite';
 import { generateRuntimeFiles, type RuntimeFileUrls } from './vite-plugin/generateRuntimeFiles.js';
 
-const INJECTION =
-  "if (Object.keys(nextExports).length === 2 && 'default' in nextExports && 'config' in nextExports) {nextExports = { ...nextExports, config: currentExports.config };}";
+const REFRESH_IGNORE_VIRTUAL_ID = 'virtual:hilla-fs-router-refresh-ignore';
+const RESOLVED_REFRESH_IGNORE_VIRTUAL_ID = `\0${REFRESH_IGNORE_VIRTUAL_ID}`;
 
 /**
  * The options for the Vite file-based router plugin.
@@ -99,6 +99,32 @@ export default function vitePluginFileSystemRouter({
     async buildStart() {
       await _generateRuntimeFiles();
     },
+    resolveId(source) {
+      if (source === REFRESH_IGNORE_VIRTUAL_ID) {
+        return RESOLVED_REFRESH_IGNORE_VIRTUAL_ID;
+      }
+      return undefined;
+    },
+    load(id) {
+      if (id !== RESOLVED_REFRESH_IGNORE_VIRTUAL_ID) {
+        return undefined;
+      }
+      return `
+const VIEWS_DIR = ${JSON.stringify(_viewsDirPosix)};
+const IGNORED = ['config'];
+if (typeof window !== 'undefined') {
+  const prev = window.__getReactRefreshIgnoredExports;
+  window.__getReactRefreshIgnoredExports = (ctx) => {
+    const inherited = prev ? prev(ctx) : [];
+    const id = typeof ctx?.id === 'string' ? ctx.id.split('?', 1)[0] : '';
+    if (id.startsWith(VIEWS_DIR)) {
+      return inherited.length ? [...inherited, ...IGNORED] : IGNORED;
+    }
+    return inherited;
+  };
+}
+`;
+    },
     async hotUpdate({ file, modules }: HotUpdateOptions): Promise<void | EnvironmentModuleNode[]> {
       const fileUrlString = String(pathToFileURL(file));
 
@@ -159,42 +185,30 @@ export default function vitePluginFileSystemRouter({
       return undefined;
     },
     transform(code, id): Promise<TransformResult> | TransformResult {
-      let modifiedCode = code;
-      if (id.startsWith(_viewsDirPosix) && !basename(id).startsWith('_')) {
-        if (isDevMode) {
-          // To enable HMR for route files with exported configurations, we need
-          // to address a limitation in `react-refresh`. This library requires
-          // strict equality (`===`) for non-component exports. However, the
-          // dynamic nature of HMR makes maintaining this equality between object
-          // literals challenging.
-          //
-          // To work around this, we implement a strategy that preserves the
-          // reference to the original configuration object (`currentExports.config`),
-          // replacing any newly created configuration objects (`nextExports.config`)
-          // with it. This ensures that the HMR mechanism perceives the
-          // configuration as unchanged.
-          const injectionPattern = /import\.meta\.hot\.accept[\s\S]+if\s\(!nextExports\)\s+return;/gu;
-          if (injectionPattern.test(modifiedCode)) {
-            modifiedCode = `${modifiedCode.substring(0, injectionPattern.lastIndex)}${INJECTION}${modifiedCode.substring(
-              injectionPattern.lastIndex,
-            )}`;
-          }
-        } else {
-          // In production mode, the function name is assigned as name to the function itself to avoid minification
-          const functionNames = /export\s+default\s+(?:function\s+)?(\w+)/u.exec(modifiedCode);
-
-          if (functionNames?.length) {
-            const [, functionName] = functionNames;
-            modifiedCode += `Object.defineProperty(${functionName}, 'name', { value: '${functionName}' });\n`;
-          }
-        }
-
+      if (!id.startsWith(_viewsDirPosix) || basename(id).startsWith('_')) {
+        return undefined;
+      }
+      if (isDevMode) {
+        // Side-effect import installs window.__getReactRefreshIgnoredExports
+        // so vite-plugin-react v6 ignores the `config` export when validating
+        // the Fast Refresh boundary. Without this, editing a view that exports
+        // `config` falls back to a full page reload.
         return {
-          code: modifiedCode,
+          code: `import ${JSON.stringify(REFRESH_IGNORE_VIRTUAL_ID)};\n${code}`,
+          map: null,
         };
       }
-
-      return undefined;
+      // In production mode, the function name is assigned as name to the
+      // function itself to avoid minification.
+      const match = /export\s+default\s+(?:function\s+)?(\w+)/u.exec(code);
+      if (!match || match[1] === 'function') {
+        return undefined;
+      }
+      const [, functionName] = match;
+      return {
+        code: `${code}\nObject.defineProperty(${functionName}, 'name', { value: ${JSON.stringify(functionName)} });\n`,
+        map: null,
+      };
     },
   };
 }

--- a/packages/ts/file-router/test/vite-plugin/vite-plugin.spec.ts
+++ b/packages/ts/file-router/test/vite-plugin/vite-plugin.spec.ts
@@ -1,13 +1,19 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { existsSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { runInNewContext } from 'node:vm';
 import chaiAsPromised from 'chai-as-promised';
+import type { TransformResult } from 'rollup';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import type { EnvironmentModuleNode, FetchModuleOptions, FetchResult, HotPayload, HotUpdateOptions } from 'vite';
 import { afterAll, beforeAll, beforeEach, chai, describe, expect, it } from 'vitest';
 import vitePluginFileSystemRouter from '../../src/vite-plugin';
 import { createTestingRouteFiles, createTmpDir } from '../utils';
+
+function runInstaller(installerCode: string, fakeWindow: object): void {
+  runInNewContext(installerCode, { window: fakeWindow });
+}
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -235,6 +241,135 @@ describe('@vaadin/hilla-file-router', () => {
       expect(mockEnvironment.fetchModule).to.not.be.called;
       expect(modulesToUpdate).to.equal(undefined);
       expect(existsSync(fileRoutesJsonModule.file!)).to.be.false;
+    });
+
+    describe('react-refresh ignore virtual module (dev mode)', () => {
+      const VIRTUAL_ID = 'virtual:hilla-fs-router-refresh-ignore';
+      const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`;
+
+      function callTransform(code: string, id: string): TransformResult {
+        return (plugin.transform as (this: unknown, code: string, id: string) => TransformResult).call({}, code, id);
+      }
+
+      function callResolveId(source: string): string | undefined {
+        return (plugin.resolveId as (this: unknown, source: string) => string | undefined).call({}, source);
+      }
+
+      function callLoad(id: string): string | undefined {
+        return (plugin.load as (this: unknown, id: string) => string | undefined).call({}, id);
+      }
+
+      it('prepends a side-effect import for view modules', () => {
+        const viewFile = fileURLToPath(new URL('login.tsx', viewsDir)).replaceAll('\\', '/');
+        const result = callTransform('export const config = {};\nexport default function Login() {}', viewFile);
+        expect(result).to.be.an('object');
+        expect((result as { code: string }).code).to.match(/^import "virtual:hilla-fs-router-refresh-ignore";\n/u);
+      });
+
+      it('does not transform underscored view files', () => {
+        const ignoredFile = fileURLToPath(new URL('test/_ignored.tsx', viewsDir)).replaceAll('\\', '/');
+        const result = callTransform('export default function Ignored() {}', ignoredFile);
+        expect(result).to.equal(undefined);
+      });
+
+      it('does not transform files outside the views directory', () => {
+        const outsideFile = `${fileURLToPath(generatedDir).replaceAll('\\', '/')}elsewhere.tsx`;
+        const result = callTransform('export default function X() {}', outsideFile);
+        expect(result).to.equal(undefined);
+      });
+
+      it('resolveId maps the virtual id to its resolved (\\0-prefixed) form', () => {
+        expect(callResolveId(VIRTUAL_ID)).to.equal(RESOLVED_VIRTUAL_ID);
+        expect(callResolveId('something-else')).to.equal(undefined);
+      });
+
+      it('load returns code that installs window.__getReactRefreshIgnoredExports', () => {
+        const code = callLoad(RESOLVED_VIRTUAL_ID);
+        expect(code).to.be.a('string');
+        const viewsDirPosix = fileURLToPath(viewsDir).replaceAll('\\', '/');
+        expect(code).to.include('window.__getReactRefreshIgnoredExports');
+        expect(code).to.include("'config'");
+        expect(code).to.include(JSON.stringify(viewsDirPosix));
+      });
+
+      it('load returns undefined for unrelated ids', () => {
+        expect(callLoad('/some/other/id')).to.equal(undefined);
+      });
+
+      it('the installed hook returns ["config"] for view ids and inherits otherwise', () => {
+        const viewsDirPosix = fileURLToPath(viewsDir).replaceAll('\\', '/');
+        const fakeWindow: { __getReactRefreshIgnoredExports?(ctx: { id: string }): string[] } = {};
+        runInstaller(callLoad(RESOLVED_VIRTUAL_ID)!, fakeWindow);
+
+        const hook = fakeWindow.__getReactRefreshIgnoredExports!;
+        expect(hook).to.be.a('function');
+        expect(hook({ id: `${viewsDirPosix}login.tsx` })).to.deep.equal(['config']);
+        expect(hook({ id: `${viewsDirPosix}login.tsx?t=12345` })).to.deep.equal(['config']);
+        expect(hook({ id: '/elsewhere/file.tsx' })).to.deep.equal([]);
+      });
+
+      it('the installed hook chains with a pre-existing implementation', () => {
+        const viewsDirPosix = fileURLToPath(viewsDir).replaceAll('\\', '/');
+        const fakeWindow: {
+          __getReactRefreshIgnoredExports?(ctx: { id: string }): string[];
+        } = {
+          __getReactRefreshIgnoredExports: () => ['preExisting'],
+        };
+        runInstaller(callLoad(RESOLVED_VIRTUAL_ID)!, fakeWindow);
+
+        const hook = fakeWindow.__getReactRefreshIgnoredExports!;
+        expect(hook({ id: `${viewsDirPosix}login.tsx` })).to.deep.equal(['preExisting', 'config']);
+        expect(hook({ id: '/elsewhere/file.tsx' })).to.deep.equal(['preExisting']);
+      });
+    });
+
+    describe('production-mode transform', () => {
+      let prodPlugin: ReturnType<typeof vitePluginFileSystemRouter>;
+      let prodViewsDir: URL;
+
+      beforeAll(async () => {
+        const prodRootDir = await createTmpDir();
+        const prodOutDir = new URL('dist/', prodRootDir);
+        prodViewsDir = new URL('frontend/views/', prodRootDir);
+        await createTestingRouteFiles(prodViewsDir);
+        prodPlugin = vitePluginFileSystemRouter({ isDevMode: false });
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error: the configResolved method could be either a function or an object.
+        prodPlugin.configResolved({
+          logger: { info: sinon.spy(), warn: sinon.spy(), error: sinon.spy() },
+          root: fileURLToPath(prodRootDir),
+          build: { outDir: fileURLToPath(prodOutDir) },
+        });
+      });
+
+      function callTransform(code: string, id: string): TransformResult {
+        return (prodPlugin.transform as (this: unknown, code: string, id: string) => TransformResult).call(
+          {},
+          code,
+          id,
+        );
+      }
+
+      it('does not prepend the virtual import in production mode', () => {
+        const viewFile = fileURLToPath(new URL('login.tsx', prodViewsDir)).replaceAll('\\', '/');
+        const result = callTransform('export default function Login() {}', viewFile);
+        expect(result).to.be.an('object');
+        expect((result as { code: string }).code).to.not.include('virtual:hilla-fs-router-refresh-ignore');
+      });
+
+      it('appends Object.defineProperty(name, ...) for named default exports', () => {
+        const viewFile = fileURLToPath(new URL('login.tsx', prodViewsDir)).replaceAll('\\', '/');
+        const result = callTransform('export default function Login() {}', viewFile);
+        expect((result as { code: string }).code).to.include(
+          'Object.defineProperty(Login, \'name\', { value: "Login" });',
+        );
+      });
+
+      it('returns undefined when default export has no inferable name', () => {
+        const viewFile = fileURLToPath(new URL('anonymous.tsx', prodViewsDir)).replaceAll('\\', '/');
+        const result = callTransform('export default function () {}', viewFile);
+        expect(result).to.equal(undefined);
+      });
     });
   });
 });


### PR DESCRIPTION
vite-plugin-react v6's Fast Refresh runtime invalidates the HMR boundary whenever a non-component export changes by reference. After each edit, the `export const config` in a Hilla view file becomes a fresh object, so the boundary fails validation and Vite falls back to a full page reload.

The previous workaround tried to regex-rewrite the react-refresh wrapper from a `transform` hook running with `enforce: 'pre'`, but the wrapper was never present at that point and the rewrite ran against unmodified source — dead code in practice.

Replace it with a virtual module that installs
`window.__getReactRefreshIgnoredExports`, the documented escape hatch in vite-plugin-react v6. The hook returns `['config']` for any module under `viewsDir`, telling the runtime to skip the export during boundary validation. The Hilla plugin injects a single side-effect import of the virtual module into every view file in dev mode; Vite dedupes the install to once per app boot. Production behavior (function-name preservation) is unchanged.

Fixes #5159 