### PR TITLE
chore: upgrade springboot to 3.5.15 (24.10) (#5571) (CP:24.9)

### DIFF
--- a/packages/java/tests/spring/pom.xml
+++ b/packages/java/tests/spring/pom.xml
@@ -50,6 +50,14 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>${nimbus-jose-jwt.version}</version>
             </dependency>
+
+            <!-- Resolve antlr4-runtime convergence: hibernate-core pulls 4.13.2,
+                 spring-data-jpa pulls 4.13.0 -->
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>4.13.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,13 @@
     <swagger.core.version>2.2.32</swagger.core.version>
     <swagger.models.version>2.2.32</swagger.models.version>
     <swagger.parser.v3.version>2.1.15</swagger.parser.v3.version>
-    <jackson.version>2.21.2</jackson.version>
+    <jackson.version>2.21.4</jackson.version>
     <jackson.annotation.version>2.21</jackson.annotation.version>
     <junit.version>5.10.1</junit.version>
     <mockito.version>4.5.0</mockito.version>
     <flow.version>24.9-SNAPSHOT</flow.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <spring.boot.version>3.5.14</spring.boot.version>
+    <spring.boot.version>3.5.15</spring.boot.version>
     <testbench.version>9.5.6</testbench.version>
     <jakarta.validation.version>3.0.2</jakarta.validation.version>
     <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>


### PR DESCRIPTION
* chore: upgrade springboot to 3.5.15 (24.10)

* align jackson version

* fix: pin antlr4-runtime to resolve dependency convergence

Spring Boot 3.5.15 pulls antlr4-runtime 4.13.2 via hibernate-core and 4.13.0 via spring-data-jpa, which fails the enforcer DependencyConvergence rule in the spring-security test modules. Pin it to 4.13.2 in the shared tests-spring dependencyManagement.
