### PR TITLE
fix(react-auth): deduplicate initial auth

### DIFF
--- a/packages/ts/react-auth/src/useAuth.tsx
+++ b/packages/ts/react-auth/src/useAuth.tsx
@@ -6,7 +6,7 @@ import {
   type LogoutOptions,
   UnauthorizedResponseError,
 } from '@vaadin/hilla-frontend';
-import { type Context, createContext, type Dispatch, useContext, useEffect, useReducer } from 'react';
+import { type Context, createContext, type Dispatch, useContext, useEffect, useReducer, useRef } from 'react';
 
 type LoginFunction = (username: string, password: string, options?: LoginOptions) => Promise<LoginResult>;
 type LogoutFunction = () => Promise<void>;
@@ -184,6 +184,7 @@ const getDefaultRoles = (user: unknown) => {
 
 function AuthProvider<TUser>({ children, getAuthenticatedUser, config }: AuthProviderProps<TUser>) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const initialAuthentication = useRef<Promise<void> | undefined>(undefined);
   const authenticate = createAuthenticateThunk(dispatch, getAuthenticatedUser);
   const unauthenticate = createUnauthenticateThunk(dispatch);
 
@@ -221,7 +222,7 @@ function AuthProvider<TUser>({ children, getAuthenticatedUser, config }: AuthPro
   }
 
   useEffect(() => {
-    authenticate().catch(() => {
+    initialAuthentication.current ??= authenticate().catch(() => {
       // Do nothing
     });
   }, []);

--- a/packages/ts/react-auth/test/useAuth.spec.tsx
+++ b/packages/ts/react-auth/test/useAuth.spec.tsx
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { UnauthorizedResponseError } from '@vaadin/hilla-frontend';
-import { describe, expect, it } from 'vitest';
+import { StrictMode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 import { configureAuth } from '../src/index.js';
 
 describe('@vaadin/react-auth', () => {
@@ -11,6 +12,39 @@ describe('@vaadin/react-auth', () => {
       const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
 
       await waitFor(() => expect(result.current.state.user).to.equal(user));
+    });
+
+    it('should fetch the authenticated user once per mount in Strict Mode', async () => {
+      const user = { customRoles: ['admin'] };
+      const getAuthenticatedUser = vi.fn(async () => {
+        await Promise.resolve();
+        return user;
+      });
+      const { AuthProvider, useAuth } = configureAuth(getAuthenticatedUser);
+      const AuthState = () => <span>{useAuth().state.user ? 'authenticated' : 'unauthenticated'}</span>;
+
+      const { container, unmount } = render(
+        <StrictMode>
+          <AuthProvider>
+            <AuthState />
+          </AuthProvider>
+        </StrictMode>,
+      );
+
+      expect(getAuthenticatedUser).toHaveBeenCalledOnce();
+      await waitFor(() => expect(container.textContent).to.equal('authenticated'));
+
+      unmount();
+      const { container: remountedContainer } = render(
+        <StrictMode>
+          <AuthProvider>
+            <AuthState />
+          </AuthProvider>
+        </StrictMode>,
+      );
+
+      expect(getAuthenticatedUser).toHaveBeenCalledTimes(2);
+      await waitFor(() => expect(remountedContainer.textContent).to.equal('authenticated'));
     });
 
     it('should handle 401 from UserInfo endpoint', async () => {


### PR DESCRIPTION
## Problem

`AuthProvider` starts its initial user lookup in an Effect. In development, root-level React Strict Mode runs an extra setup/cleanup/setup cycle, which currently triggers two concurrent `getAuthenticatedUser` calls for one provider lifetime. Production is unaffected.

## Solution

Store the initial authentication promise in a provider-local ref. The Strict Mode Effect replay reuses that promise, while a real unmount and remount creates a new provider and authenticates again. Login-triggered authentication remains independent. This is not a general request cache or cancellation mechanism.

## Verification

- Added a root-level Strict Mode regression test
- Verified one request and successful auth state for the initial provider lifetime
- Verified a real unmount/remount performs a second request and reaches the authenticated state
- `npm run test:coverage` — 11 tests passed in Chromium
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Documentation follow-up

The issue proposes clarifying the current [React introduction](https://vaadin.com/docs/latest/hilla/guides/from-java-to-react), which describes an empty-dependency Effect as running once, against the development behavior documented by [React StrictMode](https://react.dev/reference/react/StrictMode). A release note is likely sufficient for this transparent fix; any permanent docs clarification should be handled separately in the documentation repository.

Fixes #5812