### PR TITLE
fix(react-auth): deduplicate initial auth

### DIFF
--- a/packages/ts/react-auth/src/useAuth.tsx
+++ b/packages/ts/react-auth/src/useAuth.tsx
@@ -6,7 +6,7 @@ import {
   type LogoutOptions,
   UnauthorizedResponseError,
 } from '@vaadin/hilla-frontend';
-import { type Context, createContext, type Dispatch, useContext, useEffect, useReducer } from 'react';
+import { type Context, createContext, type Dispatch, useContext, useEffect, useReducer, useRef } from 'react';
 
 type LoginFunction = (username: string, password: string, options?: LoginOptions) => Promise<LoginResult>;
 type LogoutFunction = () => Promise<void>;
@@ -184,6 +184,7 @@ const getDefaultRoles = (user: unknown) => {
 
 function AuthProvider<TUser>({ children, getAuthenticatedUser, config }: AuthProviderProps<TUser>) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const initialAuthentication = useRef<Promise<void> | undefined>(undefined);
   const authenticate = createAuthenticateThunk(dispatch, getAuthenticatedUser);
   const unauthenticate = createUnauthenticateThunk(dispatch);
 
@@ -221,7 +222,7 @@ function AuthProvider<TUser>({ children, getAuthenticatedUser, config }: AuthPro
   }
 
   useEffect(() => {
-    authenticate().catch(() => {
+    initialAuthentication.current ??= authenticate().catch(() => {
       // Do nothing
     });
   }, []);

--- a/packages/ts/react-auth/test/useAuth.spec.tsx
+++ b/packages/ts/react-auth/test/useAuth.spec.tsx
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 import { UnauthorizedResponseError } from '@vaadin/hilla-frontend';
-import { describe, expect, it } from 'vitest';
+import { StrictMode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 import { configureAuth } from '../src/index.js';
 
 describe('@vaadin/react-auth', () => {
@@ -11,6 +12,39 @@ describe('@vaadin/react-auth', () => {
       const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
 
       await waitFor(() => expect(result.current.state.user).to.equal(user));
+    });
+
+    it('should fetch the authenticated user once per mount in Strict Mode', async () => {
+      const user = { customRoles: ['admin'] };
+      const getAuthenticatedUser = vi.fn(async () => {
+        await Promise.resolve();
+        return user;
+      });
+      const { AuthProvider, useAuth } = configureAuth(getAuthenticatedUser);
+      const AuthState = () => <span>{useAuth().state.user ? 'authenticated' : 'unauthenticated'}</span>;
+
+      const { container, unmount } = render(
+        <StrictMode>
+          <AuthProvider>
+            <AuthState />
+          </AuthProvider>
+        </StrictMode>,
+      );
+
+      expect(getAuthenticatedUser).toHaveBeenCalledOnce();
+      await waitFor(() => expect(container.textContent).to.equal('authenticated'));
+
+      unmount();
+      const { container: remountedContainer } = render(
+        <StrictMode>
+          <AuthProvider>
+            <AuthState />
+          </AuthProvider>
+        </StrictMode>,
+      );
+
+      expect(getAuthenticatedUser).toHaveBeenCalledTimes(2);
+      await waitFor(() => expect(remountedContainer.textContent).to.equal('authenticated'));
     });
 
     it('should handle 401 from UserInfo endpoint', async () => {


### PR DESCRIPTION
Coalesce development Strict Mode effect replays within one provider lifetime while preserving authentication on real remounts.

Add regression coverage for request count and eventual authentication state.

Fixes #5812
