### PR TITLE
fix: do not trigger the production frontend build from hillaGenerate

### DIFF
--- a/packages/java/gradle-plugin/src/functionalTest/kotlin/com/vaadin/hilla/gradle/plugin/SingleModuleTest.kt
+++ b/packages/java/gradle-plugin/src/functionalTest/kotlin/com/vaadin/hilla/gradle/plugin/SingleModuleTest.kt
@@ -63,6 +63,28 @@ class SingleModuleTest : AbstractGradleTest() {
     }
 
     @Test
+    fun `hillaGenerate does not trigger the production frontend build`() {
+        createProject(productionMode = true, disableAllTasksToSimulateDryRun = true)
+
+        addHelloReactEndpoint()
+        addMainClass()
+
+        val buildResult: BuildResult = testProject.build("hillaGenerate", checkTasksSuccessful = false)
+
+        expect(true, "hillaGenerate should depend on the compiled classes") {
+            buildResult.task(":compileJava") != null
+        }
+        // The production frontend bundle is registered as an extra output
+        // directory of the source set, which makes the `classes` lifecycle task
+        // depend on vaadinBuildFrontend. hillaGenerate must not be affected by
+        // that: the bundle would then be built before the endpoints exist, and
+        // the frontend files generated for the bundle are cleaned up afterwards.
+        expect(null, "hillaGenerate should not depend on vaadinBuildFrontend") {
+            buildResult.task(":vaadinBuildFrontend")
+        }
+    }
+
+    @Test
     fun `flow filterClasspath configuration is applied to vaadinPrepareFrontend and vaadinBuildFrontend`() {
         createProject(productionMode = true, filterClasspath = true)
 

--- a/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineGenerateTask.kt
+++ b/packages/java/gradle-plugin/src/main/kotlin/com/vaadin/hilla/gradle/plugin/EngineGenerateTask.kt
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.Jar
 
@@ -49,9 +50,6 @@ public abstract class EngineGenerateTask : DefaultTask() {
         group = "Vaadin"
         description = "Hilla Generate Task"
 
-        // we need the compiled classes:
-        dependsOn("classes")
-
         // Make sure to run this task before the `war`/`jar` tasks, so that
         // generated endpoints and models will end up packaged in the war/jar archive.
         // The inclusion rule itself is configured in the HillaPlugin class.
@@ -61,6 +59,21 @@ public abstract class EngineGenerateTask : DefaultTask() {
     }
 
     internal fun configure(project: Project) {
+        val vaadinExtension = VaadinFlowPluginExtension.get(project)
+
+        // We need the compiled classes and the processed resources, but not the
+        // `classes` lifecycle task itself: the production frontend bundle is
+        // registered as an extra output directory of the source set, which makes
+        // `classes` depend on `vaadinBuildFrontend`. Generating TypeScript must
+        // not trigger a frontend build, which would in addition run before the
+        // endpoints are generated.
+        val sourceSet = project.extensions.getByType(SourceSetContainer::class.java)
+            .getByName(vaadinExtension.sourceSetName.get())
+        dependsOn(sourceSet.compileJavaTaskName, sourceSet.processResourcesTaskName)
+        project.plugins.withId("org.jetbrains.kotlin.jvm") {
+            dependsOn(sourceSet.getCompileTaskName("kotlin"))
+        }
+
         groupId.set(project.group.toString())
         artifactId.set(project.name)
         mainClass.set(project.findProperty("com.vaadin.hilla.mainClass") as String?
@@ -69,7 +82,7 @@ public abstract class EngineGenerateTask : DefaultTask() {
             ?: emptyList())
         val engineConfig = HillaPlugin.createEngineConfiguration(
             project,
-            VaadinFlowPluginExtension.get(project)
+            vaadinExtension
         )
         engineConfigurationSettings.set(engineConfig.toInputs())
         effectiveConfig.set(PluginEffectiveConfiguration.get(project))


### PR DESCRIPTION
Flow 25.3 registers the production frontend bundle as an extra output directory of the main source set (vaadin/flow#25024), which makes the `classes` lifecycle task depend on `vaadinBuildFrontend`. Since hillaGenerate depended on `classes`, running it started a full production frontend build first: the bundle got built before the endpoints were generated, and the frontend files Flow generates for the bundle - node_modules included - were cleaned up afterwards, so the generator could no longer resolve @vaadin/hilla-generator-cli and the task failed with

    GeneratorException: Unable to resolve npm package "@vaadin/hilla-generator-cli"

Depend on the source set compile tasks and processResources instead of the `classes` lifecycle task, and add a functional test asserting that hillaGenerate keeps the compile tasks but does not pull in vaadinBuildFrontend.
