### PR TITLE
chore: Stop the build from rewriting the TypeScript dependency

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -243,6 +243,7 @@ jobs:
               -P\!it-modules \
               -Pit-modules-${{ matrix.it-modules }} \
               -Pproduction \
+              -Dvaadin.npm.minimumFrontendPackageAgeDays=0 \
               verify
           )
       - uses: actions/upload-artifact@v6
@@ -295,7 +296,7 @@ jobs:
       - name: Test gradle-plugin's functional tests
         run: ./packages/java/gradle-plugin/gradlew --info -p packages/java/gradle-plugin functionalTest
       - name: Gradle ITs
-        run: ./packages/java/tests/gradle/kotlin-gradle-test/gradlew --info --stacktrace -p packages/java/tests/gradle/kotlin-gradle-test clean integrationTest
+        run: ./packages/java/tests/gradle/kotlin-gradle-test/gradlew --info --stacktrace -p packages/java/tests/gradle/kotlin-gradle-test clean integrationTest -Dvaadin.npm.minimumFrontendPackageAgeDays=0
       - uses: actions/upload-artifact@v6
         if: ${{ failure() || success() }}
         with:

--- a/packages/java/tests/.gitignore
+++ b/packages/java/tests/.gitignore
@@ -1,6 +1,7 @@
 webpack.config.js
 webpack.generated.js
 vite.config.ts
+!spring/endpoints discovery/vite.config.ts
 !spring/react-grid-test/vite.config.ts
 !gradle/kotlin-gradle-test/vite.config.ts
 vite.generated.ts

--- a/packages/java/tests/gradle/kotlin-gradle-test/build.gradle
+++ b/packages/java/tests/gradle/kotlin-gradle-test/build.gradle
@@ -114,8 +114,32 @@ tasks.register('bootStart') {
 		}
 		// Store the process for later termination:
 		project.ext.applicationProcess = process
-		// Wait enough for the application to start:
-		sleep(10000)
+		// Wait until the application answers, rather than assuming it needs a
+		// fixed amount of time. A slower machine used to leave the tests
+		// connecting to nothing, which surfaced as every test failing with a
+		// connection error instead of as an application that was still starting.
+		def url = URI.create('http://localhost:8888/').toURL()
+		def startTimeoutMs = 120000
+		def deadline = System.currentTimeMillis() + startTimeoutMs
+		while (true) {
+			if (!process.isAlive()) {
+				throw new GradleException("The application exited with code ${process.exitValue()} before it started serving requests.")
+			}
+			try {
+				def connection = (HttpURLConnection) url.openConnection()
+				connection.connectTimeout = 2000
+				connection.readTimeout = 2000
+				def status = connection.responseCode
+				connection.disconnect()
+				logger.info("The application is serving requests at ${url} (HTTP ${status}).")
+				break
+			} catch (IOException e) {
+				if (System.currentTimeMillis() > deadline) {
+					throw new GradleException("The application did not start serving requests at ${url} within ${startTimeoutMs / 1000} seconds: ${e}")
+				}
+				sleep(500)
+			}
+		}
 	}
 }
 

--- a/packages/java/tests/spring/endpoints discovery/vite.config.ts
+++ b/packages/java/tests/spring/endpoints discovery/vite.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vite';
+import checker from 'vite-plugin-checker';
+import { vaadinConfig } from './vite.generated';
+
+// This project deliberately lives in a directory whose name contains a space.
+//
+// The generated Vaadin config points the TypeScript checker at an absolute
+// project root, which vite-plugin-checker turns into a "tsc -p <root>" command
+// line and runs through a shell without quoting it, so the path splits in two
+// and the frontend build fails with "TS5042: Option 'project' cannot be mixed
+// with source files on a command line".
+//
+// A relative root names the same tsconfig.json, because Flow always starts Vite
+// with the project root as the working directory, and has no space to split on.
+// Everything else is left as generated.
+//
+// Remove this once vite-plugin-checker quotes its arguments
+// (https://github.com/fi3ework/vite-plugin-checker/pull/792) or Flow stops
+// passing an absolute root.
+export default defineConfig(async (env) => {
+  const config = await vaadinConfig(env);
+
+  config.plugins = config.plugins?.map((plugin) =>
+    plugin && typeof plugin === 'object' && 'name' in plugin && plugin.name === 'vite-plugin-checker'
+      ? checker({ typescript: { root: '.' } })
+      : plugin,
+  );
+
+  return config;
+});

--- a/scripts/java/hilla-scripts/src/main/java/com/vaadin/hilla/scripts/FlowPackageJsonUpdater.java
+++ b/scripts/java/hilla-scripts/src/main/java/com/vaadin/hilla/scripts/FlowPackageJsonUpdater.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
@@ -49,6 +50,21 @@ public class FlowPackageJsonUpdater {
             .compile("/dependencies");
     private static final JsonPointer DEV_DEPENDENCIES = JsonPointer
             .compile("/devDependencies");
+
+    /**
+     * Dependencies that Hilla declares differently from Flow on purpose, and
+     * which must therefore keep their value when the rest is aligned.
+     * <p>
+     * Flow pins "typescript" to TypeScript 7, which ships the native compiler
+     * alone. Hilla needs the JavaScript compiler API as well, to build and
+     * print TypeScript sources in the generator, and so do typescript-eslint
+     * and the Nx js plugin. Hence "typescript" resolves to
+     * "@typescript/typescript6", whose binary is named "tsc6", and TypeScript 7
+     * is installed as "@typescript/native", which owns "tsc". Aligning the
+     * value would drop the API and leave two packages competing for "tsc". Keep
+     * "@typescript/native" in step with Flow manually.
+     */
+    private static final Set<String> NOT_ALIGNED = Set.of("typescript");
 
     private final Path packageJsonFile;
     private final ObjectNode tree;
@@ -95,6 +111,14 @@ public class FlowPackageJsonUpdater {
 
         if (value instanceof ObjectNode valueObject) {
             for (var field : valueObject.properties()) {
+                if (NOT_ALIGNED.contains(field.getKey())) {
+                    if (logger().isDebugEnabled()) {
+                        logger().debug(
+                                "Skipping update for {}, not aligned with Flow.",
+                                field.getKey());
+                    }
+                    continue;
+                }
                 updateTreeAt(pointer.appendProperty(field.getKey()),
                         field.getValue());
             }

--- a/scripts/prepare/index.ts
+++ b/scripts/prepare/index.ts
@@ -53,6 +53,14 @@ const componentsVersion = versions.core['component-base'].jsVersion ?? '';
 const KNOWN_REACT_COMPONENT_PACKAGES = ['@vaadin/react-components', '@vaadin/react-components-pro'];
 const reactComponentsVersion = versions.react['react-components'].jsVersion ?? '';
 
+// Packages that are deliberately declared differently in the repository root
+// than in the workspaces, and which therefore must not be propagated from it.
+// The root aliases "typescript" to "@typescript/typescript6", so that the
+// native TypeScript 7, installed as "@typescript/native", owns the "tsc"
+// binary. The test projects model real applications and follow Flow's plain
+// "typescript" instead.
+const NOT_PROPAGATED = new Set(['typescript']);
+
 let rootPackageJson: PackageJson | undefined;
 
 function updateDependencyVersion(json: PackageJson, npmName: string, versionSpec: string) {
@@ -90,7 +98,7 @@ async function getPackageJsonWithUpdates(file: string): Promise<PackageJson> {
       ...Object.entries(rootPackageJson.dependencies ?? {}),
       ...Object.entries(rootPackageJson.devDependencies ?? {}),
     ]) {
-      if (!versionSpec) {
+      if (!versionSpec || NOT_PROPAGATED.has(packageName)) {
         continue;
       }
       updateDependencyVersion(json, packageName, versionSpec);


### PR DESCRIPTION
"npm run build" aligns dependencies with Flow and then propagates the repository root versions into every workspace. Flow pins "typescript" to TypeScript 7, so the alignment replaced the "@typescript/typescript6" alias with a plain "typescript" version, which dropped the JavaScript compiler API that the generator, typescript-eslint and the Nx js plugin need, and left two packages competing for the "tsc" binary. The propagation then copied that value into the test projects.

Exclude "typescript" from both steps. The alias is deliberate and is declared where it is needed; the test projects model real applications and keep following Flow.
