### PR TITLE
test: retry the TestKit Gradle distribution download in gradle-plugin tests

### DIFF
--- a/packages/java/gradle-plugin/src/functionalTest/kotlin/com/vaadin/hilla/gradle/plugin/TestUtils.kt
+++ b/packages/java/gradle-plugin/src/functionalTest/kotlin/com/vaadin/hilla/gradle/plugin/TestUtils.kt
@@ -220,6 +220,9 @@ fun addConfigurationsToSettingsForUsingPluginFromLocalRepo(testProject: TestProj
     )
 }
 
+private const val DISTRIBUTION_DOWNLOAD_ATTEMPTS = 3
+private const val DISTRIBUTION_DOWNLOAD_RETRY_DELAY_MILLIS = 5_000L
+
 /**
  * A testing Gradle project, created in a temporary directory.
  *
@@ -305,9 +308,11 @@ class TestProject(val gradleVersion: String = "8.14") {
         expect(true, "$buildFile doesn't exist, can't run build") { buildFile.exists() }
 
         println("$dir/./gradlew ${args.joinToString(" ")}")
-        val result: BuildResult = createGradleRunner(debug)
-            .withArguments(args.toList() + "--stacktrace" + "--info")
-            .build()
+        val result: BuildResult = retryingDistributionDownload {
+            createGradleRunner(debug)
+                .withArguments(args.toList() + "--stacktrace" + "--info")
+                .build()
+        }
 
         if (checkTasksSuccessful) {
             for (arg: String in args) {
@@ -325,10 +330,48 @@ class TestProject(val gradleVersion: String = "8.14") {
      */
     fun buildAndFail(vararg args: String, debug: Boolean = true): BuildResult {
         println("$dir/./gradlew ${args.joinToString(" ")}")
-        return createGradleRunner(debug)
+        return retryingDistributionDownload {
+            createGradleRunner(debug)
                 .withArguments(args.toList() + "--stacktrace" + "--info")
                 .buildAndFail()
+        }
     }
+
+    /**
+     * TestKit runs the build with the [gradleVersion] distribution, which it
+     * downloads from `services.gradle.org` into its own working directory. The
+     * download is not shared with the Gradle distribution used to build this
+     * project, so it happens on every CI run and a hiccup in the network fails
+     * the test before the build is even started. Retry those, so a failed
+     * download doesn't fail an otherwise healthy build.
+     */
+    private fun <T> retryingDistributionDownload(runBuild: () -> T): T {
+        repeat(DISTRIBUTION_DOWNLOAD_ATTEMPTS - 1) { attempt ->
+            try {
+                return runBuild()
+            } catch (e: Exception) {
+                if (!e.isDistributionDownloadFailure()) {
+                    throw e
+                }
+                println("Downloading the Gradle $gradleVersion distribution failed " +
+                        "(attempt ${attempt + 1} of $DISTRIBUTION_DOWNLOAD_ATTEMPTS), retrying in " +
+                        "$DISTRIBUTION_DOWNLOAD_RETRY_DELAY_MILLIS ms: ${e.message}")
+                Thread.sleep(DISTRIBUTION_DOWNLOAD_RETRY_DELAY_MILLIS)
+            }
+        }
+        return runBuild()
+    }
+
+    /**
+     * Matches the failures reported while installing the distribution and while
+     * connecting to it, e.g. `Could not install Gradle distribution from '...'`
+     * and `Could not fetch model of type 'BuildEnvironment' using connection to
+     * Gradle distribution '...'`. A failing build under test never reports
+     * those.
+     */
+    private fun Throwable.isDistributionDownloadFailure(): Boolean =
+        generateSequence(this, Throwable::cause)
+            .any { it.message?.contains("Gradle distribution") == true }
 
     /**
      * Creates a file in the temporary test project.


### PR DESCRIPTION
The functional tests run the build under test with a pinned Gradle version, which TestKit downloads from services.gradle.org. A network hiccup during that download fails the test before the build even starts, which took out four tests on the Windows runner with "Could not install Gradle distribution from ... Unexpected end of file from server".

Retry the build up to three times when it fails while installing or connecting to the distribution. Failures of the build under test are rethrown as before.
