### PR TITLE
chore: Revert the 25.3.0-alpha11 version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22631,14 +22631,14 @@
     },
     "packages/ts/file-router": {
       "name": "@vaadin/hilla-file-router",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
         "@ungap/with-resolvers": "0.1.0",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
-        "@vaadin/hilla-react-auth": "25.3.0-alpha11",
-        "@vaadin/hilla-react-signals": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
+        "@vaadin/hilla-react-auth": "25.3.0-beta1",
+        "@vaadin/hilla-react-signals": "25.3.0-beta1"
       },
       "peerDependencies": {
         "react": "18 || 19",
@@ -22648,7 +22648,7 @@
     },
     "packages/ts/frontend": {
       "name": "@vaadin/hilla-frontend",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
         "atmosphere.js": "3.1.3",
@@ -22660,11 +22660,11 @@
     },
     "packages/ts/generator-cli": {
       "name": "@vaadin/hilla-generator-cli",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1"
       },
       "bin": {
         "tsgen": "bin/index.js"
@@ -22675,12 +22675,12 @@
     },
     "packages/ts/generator-core": {
       "name": "@vaadin/hilla-generator-core",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.1.1",
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "meow": "13.2.0",
         "openapi-types": "12.1.3"
       },
@@ -22690,13 +22690,13 @@
     },
     "packages/ts/generator-plugin-backbone": {
       "name": "@vaadin/hilla-generator-plugin-backbone",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       },
@@ -22706,13 +22706,13 @@
     },
     "packages/ts/generator-plugin-barrel": {
       "name": "@vaadin/hilla-generator-plugin-barrel",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1"
       },
       "engines": {
         "node": ">= 16.13"
@@ -22720,12 +22720,12 @@
     },
     "packages/ts/generator-plugin-client": {
       "name": "@vaadin/hilla-generator-plugin-client",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1"
       },
       "engines": {
         "node": ">= 16.13"
@@ -22733,14 +22733,14 @@
     },
     "packages/ts/generator-plugin-model": {
       "name": "@vaadin/hilla-generator-plugin-model",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
-        "@vaadin/hilla-lit-form": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
+        "@vaadin/hilla-lit-form": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       },
@@ -22750,13 +22750,13 @@
     },
     "packages/ts/generator-plugin-push": {
       "name": "@vaadin/hilla-generator-plugin-push",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       },
@@ -22766,20 +22766,20 @@
     },
     "packages/ts/generator-plugin-signals": {
       "name": "@vaadin/hilla-generator-plugin-signals",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "iterator-helpers-polyfill": "3.0.1",
         "openapi-types": "12.1.3"
       },
       "devDependencies": {
-        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-transfertypes": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-transfertypes": "25.3.0-beta1"
       },
       "engines": {
         "node": ">= 16.13"
@@ -22787,14 +22787,14 @@
     },
     "packages/ts/generator-plugin-subtypes": {
       "name": "@vaadin/hilla-generator-plugin-subtypes",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-model": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-model": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3"
       },
@@ -22804,14 +22804,14 @@
     },
     "packages/ts/generator-plugin-transfertypes": {
       "name": "@vaadin/hilla-generator-plugin-transfertypes",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-model": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-model": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       },
@@ -22821,7 +22821,7 @@
     },
     "packages/ts/generator-utils": {
       "name": "@vaadin/hilla-generator-utils",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript/typescript6": "6.0.2",
@@ -22834,11 +22834,11 @@
     },
     "packages/ts/lit-form": {
       "name": "@vaadin/hilla-lit-form",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
-        "@vaadin/hilla-models": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
+        "@vaadin/hilla-models": "25.3.0-beta1",
         "validator": "13.15.22"
       },
       "peerDependencies": {
@@ -22847,7 +22847,7 @@
     },
     "packages/ts/models": {
       "name": "@vaadin/hilla-models",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "18 || 19",
@@ -22856,10 +22856,10 @@
     },
     "packages/ts/react-auth": {
       "name": "@vaadin/hilla-react-auth",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11"
+        "@vaadin/hilla-frontend": "25.3.0-beta1"
       },
       "peerDependencies": {
         "react": "18 || 19",
@@ -22869,12 +22869,12 @@
     },
     "packages/ts/react-crud": {
       "name": "@vaadin/hilla-react-crud",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
-        "@vaadin/hilla-lit-form": "25.3.0-alpha11",
-        "@vaadin/hilla-react-form": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
+        "@vaadin/hilla-lit-form": "25.3.0-beta1",
+        "@vaadin/hilla-react-form": "25.3.0-beta1",
         "@vaadin/react-components": "25.3.0-beta1",
         "@vaadin/vaadin-lumo-styles": "25.3.0-beta1",
         "type-fest": "4.35.0"
@@ -22886,10 +22886,10 @@
     },
     "packages/ts/react-form": {
       "name": "@vaadin/hilla-react-form",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/hilla-lit-form": "25.3.0-alpha11"
+        "@vaadin/hilla-lit-form": "25.3.0-beta1"
       },
       "peerDependencies": {
         "react": "18 || 19",
@@ -22898,11 +22898,11 @@
     },
     "packages/ts/react-i18n": {
       "name": "@vaadin/hilla-react-i18n",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
-        "@vaadin/hilla-react-signals": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
+        "@vaadin/hilla-react-signals": "25.3.0-beta1",
         "intl-messageformat": "10.7.11"
       },
       "peerDependencies": {
@@ -22912,11 +22912,11 @@
     },
     "packages/ts/react-signals": {
       "name": "@vaadin/hilla-react-signals",
-      "version": "25.3.0-alpha11",
+      "version": "25.3.0-beta1",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-react": "3.0.1",
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
         "nanoid": "5.0.9"
       },
       "peerDependencies": {
@@ -27366,9 +27366,9 @@
       "requires": {
         "@typescript/typescript6": "6.0.2",
         "@ungap/with-resolvers": "0.1.0",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
-        "@vaadin/hilla-react-auth": "25.3.0-alpha11",
-        "@vaadin/hilla-react-signals": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
+        "@vaadin/hilla-react-auth": "25.3.0-beta1",
+        "@vaadin/hilla-react-signals": "25.3.0-beta1"
       }
     },
     "@vaadin/hilla-frontend": {
@@ -27381,8 +27381,8 @@
     "@vaadin/hilla-generator-cli": {
       "version": "file:packages/ts/generator-cli",
       "requires": {
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1"
       }
     },
     "@vaadin/hilla-generator-core": {
@@ -27390,7 +27390,7 @@
       "requires": {
         "@apidevtools/swagger-parser": "10.1.1",
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "meow": "13.2.0",
         "openapi-types": "12.1.3"
       }
@@ -27399,9 +27399,9 @@
       "version": "file:packages/ts/generator-plugin-backbone",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       }
@@ -27410,27 +27410,27 @@
       "version": "file:packages/ts/generator-plugin-barrel",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1"
       }
     },
     "@vaadin/hilla-generator-plugin-client": {
       "version": "file:packages/ts/generator-plugin-client",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1"
       }
     },
     "@vaadin/hilla-generator-plugin-model": {
       "version": "file:packages/ts/generator-plugin-model",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
-        "@vaadin/hilla-lit-form": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
+        "@vaadin/hilla-lit-form": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       }
@@ -27439,9 +27439,9 @@
       "version": "file:packages/ts/generator-plugin-push",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       }
@@ -27450,11 +27450,11 @@
       "version": "file:packages/ts/generator-plugin-signals",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-transfertypes": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-transfertypes": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "iterator-helpers-polyfill": "3.0.1",
         "openapi-types": "12.1.3"
@@ -27464,10 +27464,10 @@
       "version": "file:packages/ts/generator-plugin-subtypes",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-model": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-model": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "^3.1.3",
         "openapi-types": "^12.1.3"
       }
@@ -27476,10 +27476,10 @@
       "version": "file:packages/ts/generator-plugin-transfertypes",
       "requires": {
         "@typescript/typescript6": "6.0.2",
-        "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-plugin-model": "25.3.0-alpha11",
-        "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+        "@vaadin/hilla-generator-core": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+        "@vaadin/hilla-generator-plugin-model": "25.3.0-beta1",
+        "@vaadin/hilla-generator-utils": "25.3.0-beta1",
         "fast-deep-equal": "3.1.3",
         "openapi-types": "12.1.3"
       }
@@ -27495,8 +27495,8 @@
     "@vaadin/hilla-lit-form": {
       "version": "file:packages/ts/lit-form",
       "requires": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
-        "@vaadin/hilla-models": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
+        "@vaadin/hilla-models": "25.3.0-beta1",
         "validator": "13.15.22"
       }
     },
@@ -27506,15 +27506,15 @@
     "@vaadin/hilla-react-auth": {
       "version": "file:packages/ts/react-auth",
       "requires": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11"
+        "@vaadin/hilla-frontend": "25.3.0-beta1"
       }
     },
     "@vaadin/hilla-react-crud": {
       "version": "file:packages/ts/react-crud",
       "requires": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
-        "@vaadin/hilla-lit-form": "25.3.0-alpha11",
-        "@vaadin/hilla-react-form": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
+        "@vaadin/hilla-lit-form": "25.3.0-beta1",
+        "@vaadin/hilla-react-form": "25.3.0-beta1",
         "@vaadin/react-components": "25.3.0-beta1",
         "@vaadin/vaadin-lumo-styles": "25.3.0-beta1",
         "type-fest": "4.35.0"
@@ -27523,14 +27523,14 @@
     "@vaadin/hilla-react-form": {
       "version": "file:packages/ts/react-form",
       "requires": {
-        "@vaadin/hilla-lit-form": "25.3.0-alpha11"
+        "@vaadin/hilla-lit-form": "25.3.0-beta1"
       }
     },
     "@vaadin/hilla-react-i18n": {
       "version": "file:packages/ts/react-i18n",
       "requires": {
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
-        "@vaadin/hilla-react-signals": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
+        "@vaadin/hilla-react-signals": "25.3.0-beta1",
         "intl-messageformat": "10.7.11"
       }
     },
@@ -27538,7 +27538,7 @@
       "version": "file:packages/ts/react-signals",
       "requires": {
         "@preact/signals-react": "3.0.1",
-        "@vaadin/hilla-frontend": "25.3.0-alpha11",
+        "@vaadin/hilla-frontend": "25.3.0-beta1",
         "nanoid": "5.0.9"
       },
       "dependencies": {

--- a/packages/ts/file-router/package.json
+++ b/packages/ts/file-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-file-router",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla file-based router",
   "main": "index.js",
   "module": "index.js",
@@ -63,8 +63,8 @@
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
     "@ungap/with-resolvers": "0.1.0",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
-    "@vaadin/hilla-react-auth": "25.3.0-alpha11",
-    "@vaadin/hilla-react-signals": "25.3.0-alpha11"
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
+    "@vaadin/hilla-react-auth": "25.3.0-beta1",
+    "@vaadin/hilla-react-signals": "25.3.0-beta1"
   }
 }

--- a/packages/ts/frontend/package.json
+++ b/packages/ts/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-frontend",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla core frontend utils",
   "main": "index.js",
   "module": "index.js",

--- a/packages/ts/generator-cli/package.json
+++ b/packages/ts/generator-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-cli",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla tool to generate TypeScript code from the OpenAPI document",
   "main": "index.js",
   "type": "module",
@@ -43,7 +43,7 @@
     "tsgen": "bin/index.js"
   },
   "dependencies": {
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1"
   }
 }

--- a/packages/ts/generator-core/package.json
+++ b/packages/ts/generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-core",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla tool to generate TypeScript code from the OpenAPI document",
   "main": "index.js",
   "type": "module",
@@ -68,7 +68,7 @@
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
     "@apidevtools/swagger-parser": "10.1.1",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
     "meow": "13.2.0",
     "openapi-types": "12.1.3"
   }

--- a/packages/ts/generator-plugin-backbone/package.json
+++ b/packages/ts/generator-plugin-backbone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-backbone",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to generate basic code",
   "main": "index.js",
   "type": "module",
@@ -50,9 +50,9 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
     "fast-deep-equal": "3.1.3",
     "openapi-types": "12.1.3"
   }

--- a/packages/ts/generator-plugin-barrel/package.json
+++ b/packages/ts/generator-plugin-barrel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-barrel",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to generate barrel file",
   "main": "index.js",
   "type": "module",
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1"
   }
 }

--- a/packages/ts/generator-plugin-client/package.json
+++ b/packages/ts/generator-plugin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-client",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to generate default client implementation",
   "main": "index.js",
   "type": "module",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11"
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1"
   }
 }

--- a/packages/ts/generator-plugin-model/package.json
+++ b/packages/ts/generator-plugin-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-model",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to generate form models",
   "main": "index.js",
   "type": "module",
@@ -50,10 +50,10 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
-    "@vaadin/hilla-lit-form": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
+    "@vaadin/hilla-lit-form": "25.3.0-beta1",
     "fast-deep-equal": "3.1.3",
     "openapi-types": "12.1.3"
   }

--- a/packages/ts/generator-plugin-push/package.json
+++ b/packages/ts/generator-plugin-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-push",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to add push support",
   "main": "index.js",
   "type": "module",
@@ -50,9 +50,9 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
     "fast-deep-equal": "3.1.3",
     "openapi-types": "12.1.3"
   }

--- a/packages/ts/generator-plugin-signals/package.json
+++ b/packages/ts/generator-plugin-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-signals",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to add Shared Signals support",
   "main": "index.js",
   "type": "module",
@@ -50,15 +50,15 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
     "fast-deep-equal": "3.1.3",
     "iterator-helpers-polyfill": "3.0.1",
     "openapi-types": "12.1.3"
   },
   "devDependencies": {
-    "@vaadin/hilla-generator-plugin-backbone": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-transfertypes": "25.3.0-alpha11"
+    "@vaadin/hilla-generator-plugin-backbone": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-transfertypes": "25.3.0-beta1"
   }
 }

--- a/packages/ts/generator-plugin-subtypes/package.json
+++ b/packages/ts/generator-plugin-subtypes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-subtypes",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A Hilla TypeScript Generator plugin to support JsonSubTypes",
   "main": "index.js",
   "type": "module",
@@ -50,10 +50,10 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-model": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-model": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
     "fast-deep-equal": "^3.1.3",
     "openapi-types": "^12.1.3"
   }

--- a/packages/ts/generator-plugin-transfertypes/package.json
+++ b/packages/ts/generator-plugin-transfertypes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-plugin-transfertypes",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A plugin to replace types in the generated code",
   "main": "index.js",
   "type": "module",
@@ -50,10 +50,10 @@
   },
   "dependencies": {
     "@typescript/typescript6": "6.0.2",
-    "@vaadin/hilla-generator-core": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-client": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-plugin-model": "25.3.0-alpha11",
-    "@vaadin/hilla-generator-utils": "25.3.0-alpha11",
+    "@vaadin/hilla-generator-core": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-client": "25.3.0-beta1",
+    "@vaadin/hilla-generator-plugin-model": "25.3.0-beta1",
+    "@vaadin/hilla-generator-utils": "25.3.0-beta1",
     "fast-deep-equal": "3.1.3",
     "openapi-types": "12.1.3"
   }

--- a/packages/ts/generator-utils/package.json
+++ b/packages/ts/generator-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-generator-utils",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "A set of utils for developing Hilla generator plugins",
   "main": "index.js",
   "type": "module",

--- a/packages/ts/lit-form/package.json
+++ b/packages/ts/lit-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-lit-form",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla form utils",
   "main": "index.js",
   "module": "index.js",
@@ -69,8 +69,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@vaadin/hilla-frontend": "25.3.0-alpha11",
-    "@vaadin/hilla-models": "25.3.0-alpha11",
+    "@vaadin/hilla-frontend": "25.3.0-beta1",
+    "@vaadin/hilla-models": "25.3.0-beta1",
     "validator": "13.15.22"
   },
   "peerDependencies": {

--- a/packages/ts/models/package.json
+++ b/packages/ts/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-models",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Generative form models for Hilla",
   "main": "index.js",
   "module": "index.js",

--- a/packages/ts/react-auth/package.json
+++ b/packages/ts/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-react-auth",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla auth utils for React",
   "main": "index.js",
   "module": "index.js",
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@vaadin/hilla-frontend": "25.3.0-alpha11"
+    "@vaadin/hilla-frontend": "25.3.0-beta1"
   },
   "peerDependencies": {
     "react": "18 || 19",

--- a/packages/ts/react-crud/package.json
+++ b/packages/ts/react-crud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-react-crud",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla CRUD utils for React",
   "main": "index.js",
   "module": "index.js",
@@ -54,9 +54,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@vaadin/hilla-frontend": "25.3.0-alpha11",
-    "@vaadin/hilla-lit-form": "25.3.0-alpha11",
-    "@vaadin/hilla-react-form": "25.3.0-alpha11",
+    "@vaadin/hilla-frontend": "25.3.0-beta1",
+    "@vaadin/hilla-lit-form": "25.3.0-beta1",
+    "@vaadin/hilla-react-form": "25.3.0-beta1",
     "@vaadin/vaadin-lumo-styles": "25.3.0-beta1",
     "@vaadin/react-components": "25.3.0-beta1",
     "type-fest": "4.35.0"

--- a/packages/ts/react-form/package.json
+++ b/packages/ts/react-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-react-form",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla form utils for React",
   "main": "index.js",
   "module": "index.js",
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@vaadin/hilla-lit-form": "25.3.0-alpha11"
+    "@vaadin/hilla-lit-form": "25.3.0-beta1"
   },
   "peerDependencies": {
     "react": "18 || 19",

--- a/packages/ts/react-i18n/package.json
+++ b/packages/ts/react-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-react-i18n",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Hilla I18n utils for React",
   "main": "index.js",
   "module": "index.js",
@@ -44,8 +44,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@vaadin/hilla-frontend": "25.3.0-alpha11",
-    "@vaadin/hilla-react-signals": "25.3.0-alpha11",
+    "@vaadin/hilla-frontend": "25.3.0-beta1",
+    "@vaadin/hilla-react-signals": "25.3.0-beta1",
     "intl-messageformat": "10.7.11"
   },
   "peerDependencies": {

--- a/packages/ts/react-signals/package.json
+++ b/packages/ts/react-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/hilla-react-signals",
-  "version": "25.3.0-alpha11",
+  "version": "25.3.0-beta1",
   "description": "Signals for Hilla React",
   "main": "index.js",
   "module": "index.js",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@preact/signals-react": "3.0.1",
-    "@vaadin/hilla-frontend": "25.3.0-alpha11",
+    "@vaadin/hilla-frontend": "25.3.0-beta1",
     "nanoid": "5.0.9"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- Put the workspace versions back to 25.3.0-beta1, which is the highest version published on npm

## Context

The 25.3.0-alpha11 release was meant to publish only its Java half, so that the Java artifacts would point at the TypeScript packages of 25.3.0-beta1. It ran with `skip.npm.release=false`, so it also published the TypeScript packages and committed this version bump.

The bump is what leaks further: the snapshot build bakes these versions into the `package.json` embedded in the `hilla` jar, and the platform snapshot build then asks npm for `@vaadin/hilla-*@25.3.0-alpha11`, which npm rejects for a day under `--min-release-age=1`.

The npm `next` dist-tag has already been moved back to 25.3.0-beta1.
