### PR TITLE
chore: add Claude Code and code review workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Chrome
         id: setup-chrome
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@48ad923757ca74d66703209fe939badbdf80f2f4 # v2.2.0
 
       # Node.js, JDK 21, Maven and node_modules caches, `npm ci`. Nothing is
       # built up front; Claude builds what a task needs (see the instructions
@@ -56,17 +56,24 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install TestBench license
-        if: env.TB_LICENSE != ''
         env:
           TB_LICENSE: ${{ secrets.TB_LICENSE }}
         run: |
+          # The guard cannot live in `if`: neither the secrets context nor the
+          # step's own env is available to a step condition.
+          if [ -z "$TB_LICENSE" ]; then
+            echo 'TB_LICENSE is not set, skipping'
+            exit 0
+          fi
           mkdir -p ~/.vaadin
           user="${TB_LICENSE%%/*}"
           key="${TB_LICENSE#*/}"
           echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
 
       - name: Run Claude Code
-        uses: vaadin/github-actions/claude-code@main
+        # Pinned to a commit of the shared action's main branch; bump the pin to
+        # pick up changes there.
+        uses: vaadin/github-actions/claude-code@2a6fabc668c09424c29ca789789e9bf0720de8ee # main
         env:
           CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,108 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Skip workflow if the comment does not tag claude or the author is not a
+    # maintainer. Having this check here ensures that this scenario does not
+    # even start a runner.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
+    runs-on: ubuntu-latest
+    permissions:
+      # Required by actions/checkout
+      contents: read
+      # Required by anthropics/claude-code-action to generate a short-lived
+      # app token (contents/pull_requests/issues: write) that is revoked at the
+      # end of the run. Thus, there should be no need to grant additional write
+      # permissions to the workflow itself.
+      id-token: write
+      # Required by github_ci MCP server, which uses the workflow token instead
+      # of the short-lived app token
+      actions: read
+    env:
+      # Same as in validation.yml: the browser-based Vitest tests drive the
+      # runner's Chrome (CHROME_BIN, set below) instead of a Playwright-managed
+      # browser, so no browser download is needed on `npm install`.
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+
+      # Node.js, JDK 21, Maven and node_modules caches, `npm ci`. Nothing is
+      # built up front; Claude builds what a task needs (see the instructions
+      # passed to the action below).
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install TestBench license
+        if: env.TB_LICENSE != ''
+        env:
+          TB_LICENSE: ${{ secrets.TB_LICENSE }}
+        run: |
+          mkdir -p ~/.vaadin
+          user="${TB_LICENSE%%/*}"
+          key="${TB_LICENSE#*/}"
+          echo "{\"username\":\"${user}\",\"proKey\":\"${key}\"}" > ~/.vaadin/proKey
+
+      - name: Run Claude Code
+        uses: vaadin/github-actions/claude-code@main
+        env:
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          reference-repos: |
+            vaadin/flow | the Vaadin Flow framework (Java). Consult it to understand the server-side APIs that Hilla's endpoint layer, dev mode and build plugins integrate with (VaadinService, frontend build tooling, dev server, and so on).
+          extra-allowed-tools: |
+            Bash(mvn:*)
+            Bash(npm ci)
+            Bash(npm install)
+            Bash(npm run:*)
+            Bash(npm test:*)
+            Bash(npx nx:*)
+            Bash(npx vitest:*)
+            Bash(npx tsc:*)
+            Bash(npx eslint:*)
+            Bash(npx prettier:*)
+            Bash(./gradlew:*)
+            Bash(./packages/java/gradle-plugin/gradlew:*)
+            Bash(./packages/java/tests/gradle/kotlin-gradle-test/gradlew:*)
+          extra-instructions: |
+            # Notes for running in CI
+
+            - npm dependencies are installed, but nothing is built. The
+              TypeScript packages import each other through their built output,
+              so run `npm run build` before testing a package that depends on
+              other `@vaadin/hilla-*` packages. Likewise, run
+              `mvn install -DskipTests` before testing a Java module that
+              depends on other modules of this repository.
+            - Chrome is available through `CHROME_BIN` for the browser-based
+              Vitest tests; the Node-based ones need nothing extra.
+            - Prefer targeted runs over the full suites: `npm test` inside a
+              single package under `packages/ts`, or `mvn test -pl :<artifactId>
+              -Dtest=<Class>` for a Java module. Do not run the integration
+              tests under `packages/java/tests` wholesale; they are split across
+              several CI jobs and take about 25 minutes each.
+            - Before committing, format Java with `mvn spotless:apply` and
+              TypeScript with `npm run lint:fix`.
+          upload-execution-log: ${{ vars.CLAUDE_DEBUG }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,122 @@
+name: Code Review
+
+# Reviews a pull request, triggered automatically when a PR is opened or marked
+# ready for review (eligibility rules on the job condition), or on request by a
+# "/code-review" PR comment or a review request for vaadin-review-bot.
+# The review itself lives in the shared vaadin/github-actions/code-review
+# action (prepared review inputs, the Claude review, posting the findings as
+# one review); this workflow owns the triggers, eligibility rules, and the
+# reaction to the trigger.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, ready_for_review, review_requested]
+    branches: [main]
+
+env:
+  PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+
+jobs:
+  check:
+    # Eligibility is a cheap `if` pre-filter plus an authoritative org-membership
+    # check in the job. Requested reviews (comment, review request) only check
+    # who asked. Auto triggers (opened, ready for review) additionally skip
+    # drafts, chore PRs, and known bots. The pre-filter allows CONTRIBUTOR
+    # because on pull_request events the author_association of a private org
+    # member is reported as CONTRIBUTOR; the org-membership API call in the job
+    # is what actually confirms access. PRs opened by the totally-not-ai app
+    # (agent-created PRs) are reviewed too: the app is not an org member, so the
+    # job allows it explicitly.
+    if: |
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.body == '/code-review' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'review_requested' &&
+       github.event.requested_reviewer.login == 'vaadin-review-bot') ||
+      (github.event_name == 'pull_request' &&
+       contains(fromJSON('["opened", "ready_for_review"]'), github.event.action) &&
+       github.event.pull_request.draft == false &&
+       !contains(fromJSON('["dependabot[bot]", "vaadin-bot"]'), github.event.pull_request.user.login) &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) &&
+       !startsWith(github.event.pull_request.title, 'chore:') &&
+       !startsWith(github.event.pull_request.title, 'chore('))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      eligible: ${{ steps.access.outputs.eligible }}
+    steps:
+      - name: Check org membership
+        id: access
+        env:
+          GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
+          REQUESTER: ${{ github.event.sender.login }}
+        run: |
+          if [ "$REQUESTER" = "totally-not-ai[bot]" ] ||
+             gh api "orgs/${{ github.repository_owner }}/members/$REQUESTER" --silent; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  review:
+    needs: check
+    if: needs.check.outputs.eligible == 'true'
+    # One review per PR at a time; a re-trigger queues instead of aborting a run
+    # that may be mid-posting. Group is enforced on the job level instead of the
+    # workflow: newer workflow runs in the same group cancel previous ones that
+    # haven't started yet. This can lead to a scenario where opening a PR and
+    # assigning reviewers at the same time can cause workflows that would pass
+    # the check pre-condition to get canceled by workflows whose condition would
+    # not pass.
+    concurrency:
+      group: code-review-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      # Required by actions/checkout
+      contents: read
+      # Required to react to the trigger comment
+      issues: write
+      # Required to post the review
+      pull-requests: write
+    steps:
+      - name: React to trigger
+        env:
+          GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            target="issues/comments/${{ github.event.comment.id }}"
+          else
+            target="issues/$PR_NUMBER"
+          fi
+          gh api "repos/${{ github.repository }}/$target/reactions" \
+            -f content=eyes
+
+      # The review session is read-only and never builds or runs anything, so
+      # only Node is needed (for the action's own scripts and the Claude Code
+      # CLI); no JDK, Maven, or npm dependencies.
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Run code review
+        uses: vaadin/github-actions/code-review@main
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          pr-number: ${{ env.PR_NUMBER }}
+          github-token: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
+          reference-repos: |
+            vaadin/flow | the Vaadin Flow framework (Java). Consult it to understand the server-side APIs that Hilla's endpoint layer, dev mode and build plugins integrate with (VaadinService, frontend build tooling, dev server, and so on).
+          upload-execution-log: ${{ vars.CLAUDE_DEBUG }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -105,6 +105,10 @@ jobs:
         with:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
           fetch-depth: 1
+          # The checked out tree is untrusted PR code, and the job token can
+          # write issues and pull requests; the review action gets its token
+          # through `github-token` instead.
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -112,7 +116,9 @@ jobs:
           node-version: '24'
 
       - name: Run code review
-        uses: vaadin/github-actions/code-review@main
+        # Pinned to a commit of the shared action's main branch; bump the pin to
+        # pick up changes there.
+        uses: vaadin/github-actions/code-review@2a6fabc668c09424c29ca789789e9bf0720de8ee # main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           pr-number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
## Description

Adds the Claude Code (`@claude`) and code review workflows, using the shared actions from [vaadin/github-actions](https://github.com/vaadin/github-actions) with the same triggers and eligibility rules as in `flow-components` and `web-components`.

Repo-specific parts:

- `claude.yml` reuses `.github/actions/setup` for the toolchain, provides Chrome for the browser-based Vitest tests (`CHROME_BIN`, as in `validation.yml`), and installs the TestBench license. Allowed tools on top of the base list: `mvn`, `npm ci` / `npm install`, `npm run` / `npm test`, `npx nx|vitest|tsc|eslint|prettier`, and the Gradle wrappers. Nothing is prebuilt; the injected instructions tell Claude that cross-package TypeScript tests need `npm run build` first and to avoid running the integration test suites wholesale.
- `code-review.yml` also reviews PRs opened by the `totally-not-ai` app. The app is not an org member, so the check job allows it explicitly.
- Both clone `vaadin/flow` as a read-only reference checkout.
- The review job drops `id-token: write`, which the code-review action does not use.

Requires the `ANTHROPIC_API_KEY` secret and the org secret `VAADIN_REVIEW_BOT` to be shared with this repository.

## Type of change

- Chore